### PR TITLE
UI follow-ups: docs, dev-login redirect, OAuth env gates

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -6,3 +6,11 @@
 
 VITE_SUPABASE_URL=http://localhost:54321
 VITE_SUPABASE_ANON_KEY=<publishable-key-from-supabase-status>
+
+# OAuth provider gates. Each provider's sign-in button is hidden
+# unless its flag is "true". Set in Vercel for prod; set in
+# .env.local to test locally. Supabase must also be configured
+# with the provider for sign-in to actually succeed.
+
+# VITE_AUTH_GOOGLE_ENABLED=true
+# VITE_AUTH_GITHUB_ENABLED=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# CLAUDE.md
+
+Project-specific guidance for AI coding sessions on this repo. Read alongside `README.md`.
+
+## Stack
+
+- React 18 + TypeScript + Vite, TanStack Router + TanStack Query.
+- `@supabase/supabase-js` for auth + persistence; no other backend code.
+- Biome for lint + format. CSS modules for styling.
+- Vitest + RTL + `@testing-library/user-event`. MSW for HTTP mocks. Fishery + faker for factories.
+
+## Design system
+
+See README's "Design system" section for the full picture. Short version:
+
+- Tokens are defined in `src/index.css`. Component CSS references tokens; no inline hexes/rems in scope.
+- Use `react-aria-components` for new interactive primitives. **No** emotion / styled-components / MUI / Tailwind / shadcn.
+- Shared UI primitives live in `src/lib/ui/`. Prefer reusing them over hand-rolling new patterns.
+- Cards (`src/cards/`) and `PrintView` are intentionally **not** token-driven — they target print dimensions in absolute units.
+
+## Tests
+
+- Prefer `getByRole(...)` over text/class selectors. React Aria primitives expose accurate ARIA roles.
+- Factories pass no values they don't assert on. Don't write `factory.build({ name: "Foo" })` unless the test reads `name`.
+- Tests sit next to the file they cover (`Foo.tsx` + `Foo.test.tsx`).
+
+## Code
+
+- Default to no comments. Add one only when the WHY is non-obvious (a hidden constraint, a workaround, behavior that would surprise a reader).
+- Don't add features, refactors, or abstractions beyond what the task requires.
+- Don't add error handling for cases that can't happen — trust internal code.
+- Biome's formatter is authoritative — if it reformats your output, accept the reformatting.
+
+## Working norms
+
+- Ask before running `npm install`, `npm test`, `npm run dev`, or `npm run build` (unless already approved in the current task).
+- Address review nits inline in the same task — don't accumulate a deferred cleanup pass.
+- Don't use `git -C <path>` — run git from the working directory.
+- Don't push or create PRs without explicit instruction.
+
+## Off-limits without asking
+
+- `src/cards/` — Card, AutoFitCard, ItemEditor (the in-card editor; distinct from the page-level `EditorView`).
+- `src/views/PrintView.tsx` and `@page` rules.
+- Database schema and RLS policies — changes go through `supabase/migrations`.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,26 @@ Then open http://localhost:5173.
 3. Choose 2 or 4 cards per page.
 4. Click **Print**. In the browser print dialog, set **Margins: None** and uncheck **Headers and footers** for a tight fit.
 
+## Design system
+
+UI styling is driven by CSS custom-property tokens defined in [`src/index.css`](src/index.css). Components reference tokens via `var(--name)`; **no hardcoded colors, font sizes, or spacing values** in component CSS modules. The card visual and print view are intentionally exempt — they target physical print dimensions in absolute units.
+
+**Stack**
+
+- [`react-aria-components`](https://react-spectrum.adobe.com/react-aria/) for accessible interactive primitives (Dialog, Menu, ToggleButtonGroup, etc.).
+- CSS modules. No styled-components, emotion, MUI, Tailwind, or shadcn.
+- Self-hosted Inter (body) and Cinzel (display headings) via fontsource.
+
+**Shared primitives** live in `src/lib/ui/`: `<Button>`, `<IconButton>`, `<OAuthButton>`, `<UserMenu>`. Button variants are set via `data-variant`; React Aria exposes interaction state via `[data-hovered]`, `[data-pressed]`, `[data-focus-visible]`.
+
+**Conventions**
+
+- Reach for tokens first; if one is missing, add it to `src/index.css` rather than inlining a hex.
+- React Aria buttons use `onPress` (not `onClick`) and `isDisabled` (not `disabled`).
+- Tests use `getByRole(...)` queries — React Aria primitives expose accurate ARIA roles.
+
+For rationale, see the [UI refinement spec](docs/superpowers/specs/2026-04-29-ui-refinement-design.md).
+
 ## Project docs
 
 - Design: [`docs/superpowers/specs/2026-04-19-dnd-cards-design.md`](docs/superpowers/specs/2026-04-19-dnd-cards-design.md)

--- a/src/auth/LoginView.test.tsx
+++ b/src/auth/LoginView.test.tsx
@@ -11,6 +11,7 @@ vi.mock("@tanstack/react-router", () => ({
 
 describe("LoginView", () => {
   it("calls signInWithOAuth with google when the Google button is clicked", async () => {
+    vi.stubEnv("VITE_AUTH_GOOGLE_ENABLED", "true");
     const spy = vi
       .spyOn(supabase.auth, "signInWithOAuth")
       .mockResolvedValue({ data: { provider: "google", url: "https://x" }, error: null });
@@ -19,15 +20,24 @@ describe("LoginView", () => {
     expect(spy).toHaveBeenCalledWith(
       expect.objectContaining({ provider: "google", options: expect.any(Object) }),
     );
+    vi.unstubAllEnvs();
   });
 
   it("calls signInWithOAuth with github when the GitHub button is clicked", async () => {
+    vi.stubEnv("VITE_AUTH_GITHUB_ENABLED", "true");
     const spy = vi
       .spyOn(supabase.auth, "signInWithOAuth")
       .mockResolvedValue({ data: { provider: "github", url: "https://x" }, error: null });
     render(<LoginView />);
     await userEvent.click(screen.getByRole("button", { name: /sign in with github/i }));
     expect(spy).toHaveBeenCalledWith(expect.objectContaining({ provider: "github" }));
+    vi.unstubAllEnvs();
+  });
+
+  it("hides Google and GitHub buttons when their env vars are unset", () => {
+    render(<LoginView />);
+    expect(screen.queryByRole("button", { name: /sign in with google/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /sign in with github/i })).not.toBeInTheDocument();
   });
 
   it("shows a dev sign-in button in dev mode that signs in as the dev user and navigates", async () => {

--- a/src/auth/LoginView.test.tsx
+++ b/src/auth/LoginView.test.tsx
@@ -1,8 +1,13 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { supabase } from "../api/supabase";
 import { LoginView } from "./LoginView";
+
+const navigate = vi.fn();
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => navigate,
+}));
 
 describe("LoginView", () => {
   it("calls signInWithOAuth with google when the Google button is clicked", async () => {
@@ -25,14 +30,16 @@ describe("LoginView", () => {
     expect(spy).toHaveBeenCalledWith(expect.objectContaining({ provider: "github" }));
   });
 
-  it("shows a dev sign-in button in dev mode that signs in as the dev user", async () => {
+  it("shows a dev sign-in button in dev mode that signs in as the dev user and navigates", async () => {
     vi.stubEnv("DEV", true);
+    navigate.mockClear();
     const signInSpy = vi
       .spyOn(supabase.auth, "signInWithPassword")
       .mockResolvedValue({ data: { session: null, user: null }, error: null } as never);
     render(<LoginView />);
     await userEvent.click(screen.getByRole("button", { name: /sign in as dev user/i }));
     expect(signInSpy).toHaveBeenCalledWith({ email: "dev@local", password: "devpass" });
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: "/" }));
     vi.unstubAllEnvs();
   });
 

--- a/src/auth/LoginView.tsx
+++ b/src/auth/LoginView.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "@tanstack/react-router";
 import { supabase } from "../api/supabase";
 import { OAuthButton } from "../lib/ui/OAuthButton";
 import styles from "./LoginView.module.css";
@@ -6,6 +7,8 @@ const DEV_EMAIL = "dev@local";
 const DEV_PASSWORD = "devpass";
 
 export function LoginView() {
+  const navigate = useNavigate();
+
   const signIn = (provider: "google" | "github") => {
     const next = new URLSearchParams(window.location.search).get("next") ?? "/";
     supabase.auth.signInWithOAuth({
@@ -27,6 +30,10 @@ export function LoginView() {
       // signUp establishes a session immediately.
       await supabase.auth.signUp({ email: DEV_EMAIL, password: DEV_PASSWORD });
     }
+    // OAuth providers route back through /auth/callback which navigates;
+    // dev sign-in is direct, so navigate manually.
+    const next = new URLSearchParams(window.location.search).get("next") ?? "/";
+    navigate({ to: next });
   };
 
   return (

--- a/src/auth/LoginView.tsx
+++ b/src/auth/LoginView.tsx
@@ -44,12 +44,16 @@ export function LoginView() {
       </p>
       {/* biome-ignore lint/a11y/noRedundantRoles: required because list-style:none strips the implicit list role in WebKit */}
       <ul className={styles.providers} role="list">
-        <li>
-          <OAuthButton provider="google" onPress={() => signIn("google")} />
-        </li>
-        <li>
-          <OAuthButton provider="github" onPress={() => signIn("github")} />
-        </li>
+        {import.meta.env.VITE_AUTH_GOOGLE_ENABLED === "true" && (
+          <li>
+            <OAuthButton provider="google" onPress={() => signIn("google")} />
+          </li>
+        )}
+        {import.meta.env.VITE_AUTH_GITHUB_ENABLED === "true" && (
+          <li>
+            <OAuthButton provider="github" onPress={() => signIn("github")} />
+          </li>
+        )}
         {import.meta.env.DEV && (
           <li>
             <OAuthButton provider="dev" onPress={() => void devSignIn()} />

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -73,6 +73,8 @@ export function HomeView() {
     deleteDeck.mutate(deckId);
   };
 
+  if (decks.isLoading) return <p>Loading…</p>;
+
   if (!decks.data || decks.data.length === 0) {
     return (
       <section className={styles.empty}>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,8 @@
 interface ImportMetaEnv {
   readonly VITE_SUPABASE_URL: string;
   readonly VITE_SUPABASE_ANON_KEY: string;
+  readonly VITE_AUTH_GOOGLE_ENABLED?: string;
+  readonly VITE_AUTH_GITHUB_ENABLED?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Three follow-ups discovered after PR #3 merged.

## Summary

- **Document the design system** — add a "Design system" section to README and a new `CLAUDE.md` at repo root so future contributors (human or AI) pick up the conventions: tokens in `src/index.css`, `react-aria-components` for new primitives, no CSS-in-JS, role-based test selectors, and the cards/print "off-limits without asking" boundary.
- **Fix dev-login redirect and HomeView loading flash.** Dev sign-in resolved locally without going through `/auth/callback`, so it never navigated; `LoginView` now reads the same `next` param the OAuth flow uses and calls `useNavigate` after `signInWithPassword` resolves. `HomeView` was treating `useDecks`'s pending state as "no decks", flashing the empty-state UI for a beat — now shows a brief Loading state when `decks.isLoading`.
- **Gate OAuth providers by env var.** New `VITE_AUTH_GOOGLE_ENABLED` and `VITE_AUTH_GITHUB_ENABLED` control whether each provider button renders. Both default to off; flip the relevant flag in the deploy environment to enable. Dev sign-in continues to gate on `import.meta.env.DEV`.

## Required prod env change

⚠️ Before merging, set `VITE_AUTH_GOOGLE_ENABLED=true` in Vercel — otherwise the Google sign-in button will disappear from prod after deploy.

`VITE_AUTH_GITHUB_ENABLED` stays unset until you're ready to enable GitHub.

## Test plan

- [x] \`npm test\` — 137/137 pass
- [x] \`npm run lint\` — clean
- [ ] Manual: dev sign-in redirects to home after click
- [ ] Manual: home page shows brief Loading instead of "No decks yet" flash before deck data loads
- [ ] Manual: with no env vars set, Google/GitHub buttons hidden; dev button still shows in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)