### PR TITLE
Auto-deploy Supabase migrations from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -37,3 +38,23 @@ jobs:
       - run: npm ci
       - run: npx supabase start
       - run: npx supabase test db
+
+  db-deploy:
+    name: db-deploy (push migrations to linked project)
+    needs: [frontend, db]
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+      - run: supabase link --project-ref "$SUPABASE_PROJECT_ID"
+      - run: supabase migration list --linked
+      # Remove --dry-run after the first manual workflow_dispatch verifies link + secrets work.
+      - run: supabase db push --linked --dry-run


### PR DESCRIPTION
## Summary

Adds a `db-deploy` job to `.github/workflows/ci.yml` that runs `supabase db push` against the linked production Supabase project on merges to `main` (or via `workflow_dispatch`). Gated behind the existing `frontend` and `db` jobs, scoped to the `production` GitHub environment so it picks up `SUPABASE_ACCESS_TOKEN`, `SUPABASE_DB_PASSWORD`, and `SUPABASE_PROJECT_ID` from environment secrets.

This replaces the manual `supabase db push` step that was previously needed after merging anything that touched `supabase/migrations/` (e.g. PR #5).

## Verification flow

The `db push` step is intentionally left as `--dry-run` in this PR so the first run is non-destructive:

1. Merge → push to `main` triggers `db-deploy`, or trigger manually with `gh workflow run CI --ref main`.
2. `supabase migration list --linked` should show every existing migration as already applied on remote (since they were pushed by hand).
3. `supabase db push --linked --dry-run` should report nothing to do.
4. Once green, open a follow-up to drop `--dry-run` (line 60) so the next real migration auto-deploys.

## Notes

- `workflow_dispatch` was added at the top of the file so the `db-deploy` job can be triggered on demand for verification or recovery, independent of a merge.
- The job uses `environment: production`, so if that environment has required reviewers configured, the run will pause for approval — that's expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)