### PR TITLE
Move db-deploy out of CI into its own workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
   push:
     branches: [main]
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -38,23 +37,3 @@ jobs:
       - run: npm ci
       - run: npx supabase start
       - run: npx supabase test db
-
-  db-deploy:
-    name: db-deploy (push migrations to linked project)
-    needs: [frontend, db]
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    runs-on: ubuntu-latest
-    environment: production
-    env:
-      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
-      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: supabase/setup-cli@v1
-        with:
-          version: latest
-      - run: supabase link --project-ref "$SUPABASE_PROJECT_ID"
-      - run: supabase migration list --linked
-      # Remove --dry-run after the first manual workflow_dispatch verifies link + secrets work.
-      - run: supabase db push --linked --dry-run

--- a/.github/workflows/deploy-db.yml
+++ b/.github/workflows/deploy-db.yml
@@ -1,0 +1,32 @@
+name: Deploy DB
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "supabase/migrations/**"
+      - ".github/workflows/deploy-db.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-db
+  cancel-in-progress: false
+
+jobs:
+  push-migrations:
+    name: push migrations to linked project
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+      - run: supabase link --project-ref "$SUPABASE_PROJECT_ID"
+      - run: supabase migration list --linked
+      # Remove --dry-run after the first manual workflow_dispatch verifies link + secrets work.
+      - run: supabase db push --linked --dry-run


### PR DESCRIPTION
## Summary

Follow-up to #12. Splits the Supabase migration push out of `ci.yml` into a dedicated `.github/workflows/deploy-db.yml`.

Why:
- A deploy step doesn't belong in the workflow named "CI" — bundling them meant `db-deploy` showed up as a permanently skipped job on every PR.
- A separate workflow gets its own entry in the Actions sidebar, making the deploy easier to find and trigger.
- Scoping with a `paths:` filter means the deploy only runs when `supabase/migrations/**` actually changes, instead of on every push to main.

`ci.yml` reverts to its pre-#12 state.

## Behavior

`deploy-db.yml` triggers on:
- `push: main` when files under `supabase/migrations/**` (or the workflow itself) change
- `workflow_dispatch` for manual runs

Concurrency group `deploy-db` with `cancel-in-progress: false` so a push during a deploy queues rather than aborts mid-migration.

The `supabase db push` step still has `--dry-run` — same plan as #12 (verify link + secrets on the first manual run, then drop the flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)