### PR TITLE
Drop --dry-run from Deploy DB workflow

### DIFF
--- a/.github/workflows/deploy-db.yml
+++ b/.github/workflows/deploy-db.yml
@@ -28,5 +28,4 @@ jobs:
           version: latest
       - run: supabase link --project-ref "$SUPABASE_PROJECT_ID"
       - run: supabase migration list --linked
-      # Remove --dry-run after the first manual workflow_dispatch verifies link + secrets work.
-      - run: supabase db push --linked --dry-run
+      - run: supabase db push --linked


### PR DESCRIPTION
## Summary

Manual `workflow_dispatch` runs of the `Deploy DB` workflow confirmed `supabase link` + `migration list --linked` + `db push --linked --dry-run` all succeed end-to-end with the configured production environment secrets.

This PR drops `--dry-run` so future merges to `main` that touch `supabase/migrations/**` auto-apply against the linked Supabase project, and removes the now-stale comment.

## Behavior after merge

- Push to `main` with no migration changes → workflow doesn't trigger (paths filter).
- Push to `main` adding a migration → `Deploy DB` runs, `db push --linked` applies it.
- Manual `gh workflow run "Deploy DB" --ref main` → re-runs against current state (`db push` is idempotent — no-op if nothing pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)