### PR TITLE
fix: render fallback icon when imageUrl is empty string

### DIFF
--- a/src/cards/Card.test.tsx
+++ b/src/cards/Card.test.tsx
@@ -47,6 +47,13 @@ describe("<Card>", () => {
     expect(screen.getByTestId("card-fallback-icon")).toBeInTheDocument();
   });
 
+  test("treats an empty-string imageUrl as no image and shows the fallback icon", () => {
+    const card = itemCardFactory.build({ imageUrl: "" });
+    render(<Card card={card} layout="4-up" />);
+    expect(screen.queryByTestId("card-image")).not.toBeInTheDocument();
+    expect(screen.getByTestId("card-fallback-icon")).toBeInTheDocument();
+  });
+
   test("shows a fallback icon when the card has no imageUrl", () => {
     const card = itemCardFactory.build({ imageUrl: undefined });
     render(<Card card={card} layout="4-up" />);

--- a/src/cards/Card.tsx
+++ b/src/cards/Card.tsx
@@ -21,7 +21,10 @@ export function Card({ card, layout }: Props) {
   const layoutClass = layout === "4-up" ? styles["four-up"] : styles["two-up"];
   const [brokenUrl, setBrokenUrl] = useState<string | null>(null);
 
-  const showImage = card.imageUrl !== undefined && brokenUrl !== card.imageUrl;
+  // Treat empty string the same as undefined: rendering <img src=""> makes the
+  // browser refetch the document URL, which doesn't fire onError reliably and
+  // leaves the styled-but-empty image element visible instead of falling back.
+  const showImage = !!card.imageUrl && brokenUrl !== card.imageUrl;
   const iconKey = card.iconKey ?? pickIconKey(card);
 
   return (


### PR DESCRIPTION
### What are the relevant tickets?

N/A — surfaced while testing the pagination branch (#16) against a card whose `imageUrl` had been written as `""` rather than `undefined`. Independent fix; lands as its own PR so it can ship without the pagination work.

### Description (What does it do?)

When `card.imageUrl === ""`, the previous check `card.imageUrl !== undefined && ...` evaluated true and rendered `<img src="">`. Browsers treat that as "fetch the current document URL as an image," which:

- Doesn't fire `onError` reliably (Chrome surfaces a console warning: "An empty string was passed to the src attribute…").
- Leaves the styled-but-blank `<img>` element visible — it has the card's image background/border, so users see a small gray rectangle instead of the auto-picked fallback icon.

This commit changes the gate to a truthy check (`!!card.imageUrl`), so an empty string is treated the same as undefined and the fallback icon path runs immediately. A short comment in the source explains the WHY since the condition's relationship to the browser bug isn't obvious from the code alone.

### How can this be tested?

**Manual:**
1. Edit any card. In the **Image URL (optional)** field, leave the input empty (or paste a URL and then clear it). The card preview should show the auto-picked icon (e.g., the wizard staff for a wand-typed item) rather than a blank gray box.
2. Save → reopen the card → preview still shows the icon.
3. Type a real URL → preview switches to that image.
4. Type a *broken* URL (e.g., `https://example.com/missing.png`) → preview falls back to the icon after `onError` fires (existing behavior, unchanged).

**Test coverage:**
- `src/cards/Card.test.tsx` — new test: `treats an empty-string imageUrl as no image and shows the fallback icon`. Verifies `card-image` is not in the document and `card-fallback-icon` is. Existing tests for set, broken, and undefined `imageUrl` paths continue to pass.

### Additional Context

There's a related but separate UX issue: when a card has a *truthy but dead* `imageUrl` (e.g., a stale `https://www.dnd5eapi.co/api/images/magic-items/wand-of-wonder.png` that now returns 403), the fallback path relies on `onError` firing. Some browser/cache configurations don't fire it reliably, leaving the same styled-empty-`<img>` artifact. That's a deeper change — likely involves inverting precedence so an explicit `iconKey` wins over `imageUrl`, or sniffing URLs at import time — and is worth its own PR after this one. Filing it as a follow-up.