### PR TITLE
ItemEditor: put Name and Icon on the same form row

### DIFF
--- a/src/cards/ItemEditor.module.css
+++ b/src/cards/ItemEditor.module.css
@@ -27,3 +27,14 @@
   color: var(--color-text-muted);
   margin-top: var(--space-1);
 }
+
+.row {
+  display: flex;
+  gap: var(--space-4);
+  align-items: flex-start;
+}
+
+.row > .field:first-child {
+  flex: 1;
+  min-width: 0;
+}

--- a/src/cards/ItemEditor.test.tsx
+++ b/src/cards/ItemEditor.test.tsx
@@ -118,4 +118,19 @@ describe("<ItemEditor>", () => {
     render(<Harness initial={card} />);
     expect(screen.queryByText(/auto-picking/i)).not.toBeInTheDocument();
   });
+
+  test("Name and Icon controls share a row container", () => {
+    const card = itemCardFactory.build();
+    render(<Harness initial={card} />);
+
+    const nameField = screen.getByLabelText(/name/i).closest("label");
+    const iconField = screen
+      .getByRole("button", { name: /pick icon/i })
+      .closest("label");
+
+    expect(nameField).not.toBeNull();
+    expect(iconField).not.toBeNull();
+    expect(nameField?.parentElement).toBe(iconField?.parentElement);
+    expect(nameField?.parentElement?.tagName).toBe("DIV");
+  });
 });

--- a/src/cards/ItemEditor.test.tsx
+++ b/src/cards/ItemEditor.test.tsx
@@ -124,9 +124,7 @@ describe("<ItemEditor>", () => {
     render(<Harness initial={card} />);
 
     const nameField = screen.getByLabelText(/name/i).closest("label");
-    const iconField = screen
-      .getByRole("button", { name: /pick icon/i })
-      .closest("label");
+    const iconField = screen.getByRole("button", { name: /pick icon/i }).closest("label");
 
     expect(nameField).not.toBeNull();
     expect(iconField).not.toBeNull();

--- a/src/cards/ItemEditor.tsx
+++ b/src/cards/ItemEditor.tsx
@@ -40,10 +40,20 @@ export function ItemEditor({ card, onChange }: Props) {
 
   return (
     <form className={styles.form} onSubmit={(e) => e.preventDefault()}>
-      <label className={styles.field} htmlFor={ids.name}>
-        <span className={styles.label}>Name</span>
-        <Input id={ids.name} value={card.name} onChange={handle("name")} />
-      </label>
+      <div className={styles.row}>
+        <label className={styles.field} htmlFor={ids.name}>
+          <span className={styles.label}>Name</span>
+          <Input id={ids.name} value={card.name} onChange={handle("name")} />
+        </label>
+        <label className={styles.field} htmlFor={ids.icon}>
+          <span className={styles.label}>Icon (optional)</span>
+          <div className={styles.iconRow}>
+            <IconPreview iconKey={resolvedKey} label={resolvedKey} size="md" />
+            <IconPickerDialog id={ids.icon} value={card.iconKey} onChange={handleIconChange} />
+          </div>
+          {showHint && <div className={styles.iconHint}>Currently auto-picking: {resolvedKey}</div>}
+        </label>
+      </div>
       <label className={styles.field} htmlFor={ids.typeLine}>
         <span className={styles.label}>Type line</span>
         <Input
@@ -52,14 +62,6 @@ export function ItemEditor({ card, onChange }: Props) {
           onChange={handle("typeLine")}
           placeholder="Wondrous item, uncommon"
         />
-      </label>
-      <label className={styles.field} htmlFor={ids.icon}>
-        <span className={styles.label}>Icon (optional)</span>
-        <div className={styles.iconRow}>
-          <IconPreview iconKey={resolvedKey} label={resolvedKey} size="md" />
-          <IconPickerDialog id={ids.icon} value={card.iconKey} onChange={handleIconChange} />
-        </div>
-        {showHint && <div className={styles.iconHint}>Currently auto-picking: {resolvedKey}</div>}
       </label>
       <label className={styles.field} htmlFor={ids.body}>
         <span className={styles.label}>Body</span>


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/ChristopherChudzicki/dnd-cards/issues/20

### Description (What does it do?)

In the rendered card, the icon floats top-right of the title — they read as a single header unit. The editor form, however, separated them onto distinct vertical rows (Name → Type line → Icon), so the editor's structure didn't mirror the card it was editing.

This change wraps the Name and Icon `<label>` elements in a single horizontal flex row so they sit side by side, matching the card header. Type line moves down one position; everything else (Body, Cost / weight, Image URL) is untouched.

The "Currently auto-picking: <key>" hint stays inside the Icon `<label>` so it sits directly under the icon control — visually paired with the affordance it describes, matching the standard form convention that help text belongs to a specific field.

### Screenshots (if appropriate):
- [ ] Desktop screenshot — editor form showing Name + Icon on the same row
- [ ] Desktop screenshot — auto-pick hint visible under the icon control

### How can this be tested?

**Manual:**
1. `npm run dev`, open the editor for any item.
2. Confirm Name input and Icon control (preview + "Auto ▾" button) sit on a single row, with Name filling the remaining width on the left and Icon compact on the right.
3. Type a name like "Trident of Fish Command" on a card with no explicit icon (or click "Auto" in the picker) — confirm the "Currently auto-picking: trident" hint appears under the icon control specifically (right column, not full-width).
4. Pick an icon explicitly — hint disappears.
5. Resize the editor pane narrow — Name + Icon stay inline; Name input shrinks rather than overflowing.

**Test coverage:**
- Existing `ItemEditor.test.tsx` tests (label wiring, picker behavior, hint show/hide) all still pass against the new layout — no test changes needed for those.
- One new test, "Name and Icon controls share a row container", asserts that the two `<label>` elements share a parent `<div>` (the row wrapper) rather than being direct children of the form. The assertion checks both shared parentage and `tagName === "DIV"`, so it would fail if a future change moved the Icon label back out of the row.

### Additional Context

**Layout choice.** Plain horizontal flex (`display: flex; gap: var(--space-4); align-items: flex-start`) on a wrapper `div`, with `flex: 1; min-width: 0` on the Name field. `min-width: 0` overrides the flex default of `min-width: auto` so the Name input shrinks rather than refusing to go below its intrinsic content width. `align-items: flex-start` keeps the two label texts top-aligned even when the auto-pick hint adds height to the right column.

**Narrow viewports.** No new breakpoint. The editor view already collapses to a single column at `max-width: 900px`, and the icon control itself is compact (small preview + short "Auto ▾" button), so Name + Icon stay inline at all widths.

**Out of scope (intentional):** no changes to `Card.tsx` or print CSS, no new shared `FormRow` primitive, no order/styling changes to the other form fields.

**Note for reviewers:** I (Claude Code) was unable to visually verify the rendered output in a browser — the change is pure JSX restructuring (no logic change) plus three CSS rules, and all 226 tests + the typecheck/build pass. A quick `npm run dev` glance from a human is recommended, particularly to confirm the auto-pick hint placement reads as intended.