### PR TITLE
feat: deck breadcrumb in global header

### DIFF
--- a/docs/superpowers/plans/2026-05-03-deck-breadcrumbs.md
+++ b/docs/superpowers/plans/2026-05-03-deck-breadcrumbs.md
@@ -1,0 +1,715 @@
+# Deck Breadcrumbs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the global header's static "Decks" nav link with a breadcrumb (`Decks › <deckName>`) that resolves the current deck from the URL on all `/deck/$deckId/...` routes.
+
+**Architecture:** A new `DeckBreadcrumb` component reads the current pathname via TanStack Router's `useLocation`, parses out `deckId`, and uses the existing `useDeck` query to fetch the name. On the deck root the name renders as plain text with `aria-current="page"`; on the editor and print routes it renders as a link back to the deck. The component is mounted from `Root.tsx` in the existing nav slot.
+
+**Tech Stack:** React 18 + TypeScript, TanStack Router (`useLocation`), TanStack Query (`useDeck`), CSS Modules. Tests with Vitest + RTL + MSW; the router is mocked the same way `HomeView.test.tsx` and `DeckView.test.tsx` mock it.
+
+**Spec:** `docs/superpowers/specs/2026-05-03-deck-breadcrumbs-design.md`
+
+---
+
+## File Structure
+
+- **Create:** `src/app/DeckBreadcrumb.tsx` — the component, all render branches.
+- **Create:** `src/app/DeckBreadcrumb.test.tsx` — covers no-deck, deck-root, editor, print, loading, not-found, long-name states.
+- **Modify:** `src/app/Root.tsx` — replace the static `<Link to="/">Decks</Link>` with `<DeckBreadcrumb />`.
+- **Modify:** `src/app/root.module.css` — add `.breadcrumb`, `.crumbList`, `.separator`, `.crumbCurrent`, `.crumbName` styles.
+
+No new factories, no shared primitive in `src/lib/ui/` (it's a one-off header element).
+
+---
+
+### Task 1: Failing test — "no deck context renders a single Decks link"
+
+**Files:**
+- Create: `src/app/DeckBreadcrumb.test.tsx`
+- (Will create) `src/app/DeckBreadcrumb.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/app/DeckBreadcrumb.test.tsx`:
+
+```tsx
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { DeckBreadcrumb } from "./DeckBreadcrumb";
+
+let mockPathname = "/";
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual =
+    await vi.importActual<typeof import("@tanstack/react-router")>("@tanstack/react-router");
+  return {
+    ...actual,
+    useLocation: () => ({ pathname: mockPathname }),
+    Link: ({
+      children,
+      to,
+      params: _params,
+      ...rest
+    }: {
+      children: ReactNode;
+      to?: string;
+      params?: Record<string, string>;
+    } & Record<string, unknown>) => (
+      <a href={to} {...rest}>
+        {children}
+      </a>
+    ),
+  };
+});
+
+function wrap(ui: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{ui}</QueryClientProvider>;
+}
+
+describe("DeckBreadcrumb", () => {
+  it("renders just a Decks link when not under a deck route", () => {
+    mockPathname = "/";
+    render(wrap(<DeckBreadcrumb />));
+    const nav = screen.getByRole("navigation", { name: /breadcrumb/i });
+    const links = screen.getAllByRole("link", { name: /decks/i });
+    expect(nav).toContainElement(links[0]);
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveAttribute("href", "/");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+Run: `npm test -- --run src/app/DeckBreadcrumb.test.tsx`
+Expected: FAIL — module `./DeckBreadcrumb` not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/app/DeckBreadcrumb.tsx`:
+
+```tsx
+import { Link, useLocation } from "@tanstack/react-router";
+import styles from "./root.module.css";
+
+export function DeckBreadcrumb() {
+  const { pathname } = useLocation();
+  const deckId = parseDeckId(pathname);
+
+  return (
+    <nav aria-label="Breadcrumb" className={styles.breadcrumb}>
+      <ol className={styles.crumbList}>
+        <li>
+          <Link to="/" className={styles.link}>
+            Decks
+          </Link>
+        </li>
+        {deckId && (
+          <>
+            <li aria-hidden="true" className={styles.separator}>
+              ›
+            </li>
+            <li>…</li>
+          </>
+        )}
+      </ol>
+    </nav>
+  );
+}
+
+function parseDeckId(pathname: string): string | undefined {
+  const m = pathname.match(/^\/deck\/([^/]+)/);
+  return m?.[1];
+}
+```
+
+(The `…` placeholder will be replaced in Task 2.)
+
+- [ ] **Step 4: Run test to confirm it passes**
+
+Run: `npm test -- --run src/app/DeckBreadcrumb.test.tsx`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/DeckBreadcrumb.tsx src/app/DeckBreadcrumb.test.tsx
+git commit -m "Add DeckBreadcrumb skeleton with no-deck state"
+```
+
+---
+
+### Task 2: Deck-root state — name rendered as current page
+
+**Files:**
+- Modify: `src/app/DeckBreadcrumb.test.tsx`
+- Modify: `src/app/DeckBreadcrumb.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `DeckBreadcrumb.test.tsx`:
+
+```tsx
+import { HttpResponse, http } from "msw";
+import { makeDeckRow } from "../test/factories";
+import { server } from "../test/msw";
+
+const SB = "http://localhost:54321";
+```
+
+(Add those imports near the existing imports — preserve alphabetical order Biome may enforce.)
+
+Then add inside `describe("DeckBreadcrumb", ...)`:
+
+```tsx
+it("renders the deck name as current page on /deck/$id", async () => {
+  const deck = makeDeckRow.build();
+  mockPathname = `/deck/${deck.id}`;
+  server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([deck])));
+  render(wrap(<DeckBreadcrumb />));
+
+  expect(screen.getByRole("link", { name: "Decks" })).toHaveAttribute("href", "/");
+  const current = await screen.findByText(deck.name);
+  expect(current).toHaveAttribute("aria-current", "page");
+  expect(current.tagName).not.toBe("A");
+});
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+Run: `npm test -- --run src/app/DeckBreadcrumb.test.tsx`
+Expected: 1 PASS, 1 FAIL — the new test fails because the component renders `…` instead of the deck name.
+
+- [ ] **Step 3: Implement deck-root branch**
+
+Replace the body of `DeckBreadcrumb.tsx`:
+
+```tsx
+import { Link, useLocation } from "@tanstack/react-router";
+import { useDeck } from "../decks/queries";
+import styles from "./root.module.css";
+
+export function DeckBreadcrumb() {
+  const { pathname } = useLocation();
+  const { deckId, isAtDeckRoot } = parsePathname(pathname);
+  const deckQuery = useDeck(deckId);
+
+  return (
+    <nav aria-label="Breadcrumb" className={styles.breadcrumb}>
+      <ol className={styles.crumbList}>
+        <li>
+          <Link to="/" className={styles.link}>
+            Decks
+          </Link>
+        </li>
+        {deckId && (
+          <>
+            <li aria-hidden="true" className={styles.separator}>
+              ›
+            </li>
+            <li>{renderDeckCrumb(deckQuery.data?.name, isAtDeckRoot)}</li>
+          </>
+        )}
+      </ol>
+    </nav>
+  );
+}
+
+function renderDeckCrumb(name: string | undefined, isAtDeckRoot: boolean) {
+  if (!name) return "…";
+  if (isAtDeckRoot) {
+    return (
+      <span aria-current="page" className={styles.crumbCurrent}>
+        {name}
+      </span>
+    );
+  }
+  // Editor / print — link back to the deck. Wired up in Task 3.
+  return name;
+}
+
+function parsePathname(pathname: string): { deckId: string | undefined; isAtDeckRoot: boolean } {
+  const m = pathname.match(/^\/deck\/([^/]+)(\/.*)?$/);
+  if (!m) return { deckId: undefined, isAtDeckRoot: false };
+  return { deckId: m[1], isAtDeckRoot: !m[2] };
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+Run: `npm test -- --run src/app/DeckBreadcrumb.test.tsx`
+Expected: 2 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/DeckBreadcrumb.tsx src/app/DeckBreadcrumb.test.tsx
+git commit -m "Render deck name as current page on /deck/\$id"
+```
+
+---
+
+### Task 3: Editor + print states — deck name as link
+
+**Files:**
+- Modify: `src/app/DeckBreadcrumb.test.tsx`
+- Modify: `src/app/DeckBreadcrumb.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append two tests inside `describe("DeckBreadcrumb", ...)`:
+
+```tsx
+it("renders the deck name as a link on the editor route", async () => {
+  const deck = makeDeckRow.build();
+  mockPathname = `/deck/${deck.id}/edit/new`;
+  server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([deck])));
+  render(wrap(<DeckBreadcrumb />));
+
+  const deckLink = await screen.findByRole("link", { name: deck.name });
+  expect(deckLink).toHaveAttribute("href", "/deck/$deckId");
+  expect(deckLink).not.toHaveAttribute("aria-current");
+});
+
+it("renders the deck name as a link on the print route", async () => {
+  const deck = makeDeckRow.build();
+  mockPathname = `/deck/${deck.id}/print`;
+  server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([deck])));
+  render(wrap(<DeckBreadcrumb />));
+
+  const deckLink = await screen.findByRole("link", { name: deck.name });
+  expect(deckLink).toHaveAttribute("href", "/deck/$deckId");
+});
+```
+
+(Note: the test mock replaces `Link` with `<a href={to}>`, so the `href` is the literal `to` prop, not a resolved URL — same convention as `DeckView.test.tsx`.)
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `npm test -- --run src/app/DeckBreadcrumb.test.tsx`
+Expected: 2 PASS, 2 FAIL — the deck name renders as plain text on these routes, not as a link.
+
+- [ ] **Step 3: Update `renderDeckCrumb` to emit a Link when not at root**
+
+In `DeckBreadcrumb.tsx`, replace `renderDeckCrumb`:
+
+```tsx
+function renderDeckCrumb(
+  name: string | undefined,
+  isAtDeckRoot: boolean,
+  deckId: string,
+) {
+  if (!name) return "…";
+  if (isAtDeckRoot) {
+    return (
+      <span aria-current="page" className={styles.crumbCurrent}>
+        {name}
+      </span>
+    );
+  }
+  return (
+    <Link
+      to="/deck/$deckId"
+      params={{ deckId }}
+      className={styles.link}
+      title={name}
+    >
+      {name}
+    </Link>
+  );
+}
+```
+
+And update the call site (now passes `deckId` since it's required):
+
+```tsx
+<li>{renderDeckCrumb(deckQuery.data?.name, isAtDeckRoot, deckId)}</li>
+```
+
+(The `deckId &&` outer guard ensures this branch only runs when `deckId` is a string.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm test -- --run src/app/DeckBreadcrumb.test.tsx`
+Expected: 4 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/DeckBreadcrumb.tsx src/app/DeckBreadcrumb.test.tsx
+git commit -m "Make deck crumb a link on editor and print routes"
+```
+
+---
+
+### Task 4: Loading state — show ellipsis while query is pending
+
+**Files:**
+- Modify: `src/app/DeckBreadcrumb.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```tsx
+it("shows an ellipsis while the deck query is pending", async () => {
+  const deck = makeDeckRow.build();
+  mockPathname = `/deck/${deck.id}`;
+  let resolve: ((res: Response) => void) | undefined;
+  server.use(
+    http.get(
+      `${SB}/rest/v1/decks`,
+      () => new Promise<Response>((r) => { resolve = r; }),
+    ),
+  );
+  render(wrap(<DeckBreadcrumb />));
+
+  expect(await screen.findByText("…")).toBeInTheDocument();
+  expect(screen.queryByText(deck.name)).not.toBeInTheDocument();
+
+  resolve?.(HttpResponse.json([deck]));
+  await screen.findByText(deck.name);
+});
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `npm test -- --run src/app/DeckBreadcrumb.test.tsx`
+Expected: 5 PASS — this should already work because Task 2's `renderDeckCrumb` returns `"…"` when `name` is undefined.
+
+If it does pass: skip step 3 and go to step 4.
+
+- [ ] **Step 3 (only if test failed):** Investigate. The `useDeck` query starts in `pending` state, so `deckQuery.data` should be `undefined`. If the test fails, check that the `…` is rendered inside the `<li>` — adjust the assertion to `getByRole("listitem")` if needed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/DeckBreadcrumb.test.tsx
+git commit -m "Pin loading state behavior"
+```
+
+---
+
+### Task 5: Not-found state — collapse to just "Decks"
+
+**Files:**
+- Modify: `src/app/DeckBreadcrumb.test.tsx`
+- Modify: `src/app/DeckBreadcrumb.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```tsx
+it("collapses to just Decks when the deck is not found", async () => {
+  mockPathname = "/deck/missing";
+  server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([])));
+  render(wrap(<DeckBreadcrumb />));
+
+  // Wait until the query resolves (the ellipsis disappears).
+  await screen.findByRole("link", { name: "Decks" });
+  // Give React Query a tick to settle, then assert the trail is collapsed.
+  await new Promise((r) => setTimeout(r, 0));
+  expect(screen.queryByText("›")).not.toBeInTheDocument();
+  expect(screen.queryByText("…")).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `npm test -- --run src/app/DeckBreadcrumb.test.tsx`
+Expected: FAIL — separator and ellipsis are still rendered.
+
+- [ ] **Step 3: Distinguish "loading" from "loaded but empty"**
+
+In `DeckBreadcrumb.tsx`, change the gating around the separator + deck crumb so that once the query is no longer pending and returned no deck, we collapse:
+
+```tsx
+{deckId && (deckQuery.isPending || deckQuery.data) && (
+  <>
+    <li aria-hidden="true" className={styles.separator}>
+      ›
+    </li>
+    <li>{renderDeckCrumb(deckQuery.data?.name, isAtDeckRoot, deckId)}</li>
+  </>
+)}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm test -- --run src/app/DeckBreadcrumb.test.tsx`
+Expected: 6 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/DeckBreadcrumb.tsx src/app/DeckBreadcrumb.test.tsx
+git commit -m "Collapse breadcrumb to 'Decks' when deck not found"
+```
+
+---
+
+### Task 6: Long deck name — title attribute carries full name
+
+**Files:**
+- Modify: `src/app/DeckBreadcrumb.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```tsx
+it("sets the full deck name on title for a truncated link", async () => {
+  const longName = "A Very Long Deck Name That Will Overflow Twenty Four Characters";
+  const deck = makeDeckRow.build({ name: longName });
+  mockPathname = `/deck/${deck.id}/edit/new`;
+  server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([deck])));
+  render(wrap(<DeckBreadcrumb />));
+
+  const link = await screen.findByRole("link", { name: longName });
+  expect(link).toHaveAttribute("title", longName);
+});
+```
+
+(This is one of the rare cases where overriding the factory `name` is justified — the test specifically exercises the long-name code path.)
+
+- [ ] **Step 2: Run test**
+
+Run: `npm test -- --run src/app/DeckBreadcrumb.test.tsx`
+Expected: PASS — the link branch already sets `title={name}` in Task 3.
+
+If it fails (e.g., title not yet wired): add `title={name}` to the editor/print Link.
+
+- [ ] **Step 3: Add the same title to the current-page span**
+
+For consistency on the deck root (where the name is plain text):
+
+```tsx
+return (
+  <span aria-current="page" className={styles.crumbCurrent} title={name}>
+    {name}
+  </span>
+);
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm test -- --run src/app/DeckBreadcrumb.test.tsx`
+Expected: 7 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/DeckBreadcrumb.tsx src/app/DeckBreadcrumb.test.tsx
+git commit -m "Set title attr on deck crumb for truncation hover"
+```
+
+---
+
+### Task 7: Wire the breadcrumb into Root, remove the static link
+
+**Files:**
+- Modify: `src/app/Root.tsx`
+
+- [ ] **Step 1: Replace the `<nav>` block with `<DeckBreadcrumb />`**
+
+Open `src/app/Root.tsx`. Current:
+
+```tsx
+import { Link, Outlet } from "@tanstack/react-router";
+import { UserMenu } from "../lib/ui/UserMenu";
+import styles from "./root.module.css";
+
+export function Root() {
+  return (
+    <div className={styles.shell}>
+      <header className={styles.header}>
+        <Link to="/" className={styles.brand}>
+          D&amp;D Cards
+        </Link>
+        <nav aria-label="Primary" className={styles.nav}>
+          <Link to="/" className={styles.link} activeProps={{ className: styles.active }}>
+            Decks
+          </Link>
+        </nav>
+        <UserMenu />
+      </header>
+      <main className={styles.main}>
+        <Outlet />
+      </main>
+    </div>
+  );
+}
+```
+
+Replace with:
+
+```tsx
+import { Link, Outlet } from "@tanstack/react-router";
+import { UserMenu } from "../lib/ui/UserMenu";
+import { DeckBreadcrumb } from "./DeckBreadcrumb";
+import styles from "./root.module.css";
+
+export function Root() {
+  return (
+    <div className={styles.shell}>
+      <header className={styles.header}>
+        <Link to="/" className={styles.brand}>
+          D&amp;D Cards
+        </Link>
+        <DeckBreadcrumb />
+        <UserMenu />
+      </header>
+      <main className={styles.main}>
+        <Outlet />
+      </main>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `npm test -- --run`
+Expected: all 226 tests pass (225 baseline + 7 new − 6 since some count toward existing files… actually new test file adds 7 tests, total ≈ 232). Confirm 0 failures.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/Root.tsx
+git commit -m "Use DeckBreadcrumb in global header"
+```
+
+---
+
+### Task 8: CSS — separator, current crumb, truncation
+
+**Files:**
+- Modify: `src/app/root.module.css`
+
+- [ ] **Step 1: Add new rules**
+
+Append to `src/app/root.module.css` (after `.active`, before `.main`):
+
+```css
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+}
+
+.crumbList {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+}
+
+.crumbList li {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.separator {
+  color: var(--color-text-muted, var(--color-text));
+  opacity: 0.5;
+}
+
+.crumbCurrent {
+  font-weight: 600;
+  max-width: 24ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.crumbList .link {
+  max-width: 24ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+```
+
+Also remove the now-unused `.nav` and `.active` rules (the static nav is gone). Check first whether anything else references them — `grep -rn "styles.nav\|styles.active" src` — and only delete if no remaining users.
+
+- [ ] **Step 2: Verify nothing else references the deleted classes**
+
+Run: `grep -rn "styles\\.nav\\|styles\\.active" src`
+Expected: no matches (or only matches that are inside `Root.tsx` which we just edited — there should be none).
+
+- [ ] **Step 3: Delete `.nav` and `.active` from `root.module.css`** (only if grep was clean).
+
+- [ ] **Step 4: Re-run tests**
+
+Run: `npm test -- --run`
+Expected: still all green. CSS changes don't affect test assertions (they assert on roles/text/attrs).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/root.module.css
+git commit -m "Style breadcrumb separator, current crumb, and truncation"
+```
+
+---
+
+### Task 9: Final verification — biome, build, manual visual check
+
+- [ ] **Step 1: Biome check**
+
+Run: `npx biome check src/app/DeckBreadcrumb.tsx src/app/DeckBreadcrumb.test.tsx src/app/Root.tsx src/app/root.module.css`
+Expected: no errors. If Biome reformats anything, accept the reformat (`npx biome check --write` on the same files), then re-run.
+
+- [ ] **Step 2: Type check + build**
+
+Run: `npm run build`
+Expected: succeeds with no TS errors.
+
+- [ ] **Step 3: Full test run**
+
+Run: `npm test -- --run`
+Expected: all tests pass.
+
+- [ ] **Step 4: Manual visual check**
+
+Run: `npm run dev` (in background or new shell). Open the browser and verify:
+1. On `/` (Decks list) — header shows `Decks` only, as a link.
+2. Click into a deck — header shows `Decks › <DeckName>`, with `Decks` clickable, name as plain bold text.
+3. Click "Edit" on a card — header shows `Decks › <DeckName>` with both clickable. Click `<DeckName>` — should navigate back to the deck.
+4. Click "Print" — same two-link breadcrumb. Click `<DeckName>` — back to deck.
+5. Hard-refresh `/deck/<id>/edit/<cardId>` — verify the `…` placeholder appears briefly (or not at all if cache is warm), then the deck name resolves.
+6. Visit `/deck/missing-id` — header collapses to just `Decks`.
+7. Verify the UserMenu is still visible at far right; resize narrower until truncation kicks in.
+
+- [ ] **Step 5: Commit only if any changes were needed**
+
+(Steps 1–3 should require no code changes. Step 4 is verification only.)
+
+---
+
+## Self-review checklist
+
+(Run after writing the plan, before handoff.)
+
+- **Spec coverage:**
+  - Render rules per route → Task 1 (no-deck), 2 (deck root), 3 (editor + print) ✓
+  - Loading state → Task 4 ✓
+  - Error / not-found state → Task 5 ✓
+  - Long deck names → Task 6 + Task 8 (CSS truncation) ✓
+  - Component placement (Root.tsx) → Task 7 ✓
+  - Accessibility (`<nav aria-label="Breadcrumb">`, `<ol>`/`<li>`, `aria-current="page"`, `aria-hidden` separator) → Task 1 (nav+ol), Task 2 (aria-current), Task 5 (separator aria-hidden) ✓
+  - Tests cover each state → Tasks 1–6 ✓
+
+- **Placeholder scan:** No "TBD"/"TODO"/"add appropriate" in steps. Code blocks present where steps change code. ✓
+
+- **Type consistency:** `parsePathname` defined in Task 2, used in Tasks 2–5; signature unchanged. `renderDeckCrumb` signature evolves (Task 2: 2 args; Task 3: 3 args) — Task 3 explicitly updates the call site. ✓

--- a/docs/superpowers/specs/2026-05-03-deck-breadcrumbs-design.md
+++ b/docs/superpowers/specs/2026-05-03-deck-breadcrumbs-design.md
@@ -1,0 +1,116 @@
+# Deck breadcrumbs in the global header
+
+## Problem
+
+When a user is editing a card or viewing the print sheet, the global header gives no signal of which deck they're inside. Today the header is just `[D&D Cards] [Decks]` plus the user menu. `DeckView` shows the deck name as an H2, but `EditorView` and `PrintView` do not — so context is lost as soon as you click into a card.
+
+## Solution
+
+Replace the existing `Decks` nav link in the global header with a breadcrumb that resolves the current deck (when the URL has a `deckId`) and renders `Decks › <deckName>`. The breadcrumb derives its state from the URL, fetches via React Query, and reuses cached data when present.
+
+## Scope
+
+In scope:
+- New `DeckBreadcrumb` component, rendered from `Root.tsx` in the existing nav slot.
+- Reads `deckId` from the matched route via TanStack Router's `useMatch` (with `shouldThrow: false`).
+- Uses `useDeck(deckId)` (already exists in `src/decks/queries.ts`) to fetch the deck name.
+- Loading, error, and "no deck context" states.
+- Light styling additions to `root.module.css` for the separator, current-page crumb, and truncation.
+- Tests in `Root.test.tsx` (new) covering each render state.
+
+Out of scope:
+- 3-level breadcrumbs (e.g. `Decks › Deckname › "Card name"` on the editor). Page content already conveys what you're editing.
+- Touching `DeckView`'s in-page H2 title.
+- Any change to print output (`@media print` already hides the header).
+- Other navigation surfaces (sidebar, footer, mobile menu — none exist today).
+
+## Behavior
+
+### Render rules per route
+
+| Route | Breadcrumb |
+|---|---|
+| `/` (home), `/login`, `/auth/callback`, `/debug/icons` | `Decks` (link to `/`, current behavior) |
+| `/deck/$deckId` | `Decks` › `<deckName>` — `Decks` is a link, `<deckName>` is plain text with `aria-current="page"` |
+| `/deck/$deckId/edit/$cardId` | `Decks` › `<deckName>` — both clickable links |
+| `/deck/$deckId/print` | `Decks` › `<deckName>` — both clickable links |
+
+The "current page" crumb is the deck name *only* on the deck-root route. On editor/print, neither crumb is `aria-current` because the leaf (the card or the print sheet) isn't represented in the trail.
+
+### Loading state
+
+While `useDeck(deckId)` is `pending`, render `Decks › …` (literal ellipsis as plain text). In practice this only flashes on a hard refresh or deep-link, because navigating from `DeckView` populates the React Query cache.
+
+### Error / not-found state
+
+If the deck query errors or returns nothing, render just `Decks` (collapse the trail). The view itself surfaces the error message — the breadcrumb stays out of the way.
+
+### Long deck names
+
+Cap the deck-name crumb at `max-width: 24ch` with `text-overflow: ellipsis` and `white-space: nowrap`. Set `title={deck.name}` for the full name on hover.
+
+## Architecture
+
+### Files
+
+```
+src/app/
+  Root.tsx                  ← swap nav slot to render <DeckBreadcrumb />
+  Root.test.tsx             ← NEW — covers each breadcrumb state
+  root.module.css           ← add .breadcrumb, .separator, .crumbCurrent, .crumbName styles
+  DeckBreadcrumb.tsx        ← NEW — the component
+```
+
+`DeckBreadcrumb` lives next to `Root.tsx` because it's only used there and is tightly coupled to the header's layout slot. No `src/lib/ui/` entry — it's not a reusable primitive.
+
+### Component shape
+
+```tsx
+export function DeckBreadcrumb() {
+  const deckId = useDeckIdFromUrl();          // undefined when not under /deck/$deckId
+  const deckQuery = useDeck(deckId);           // useDeck already no-ops when deckId is undefined
+  // … render branches per behavior table above
+}
+```
+
+`useDeck` (in `src/decks/queries.ts`) already accepts `string | undefined` and is disabled internally when undefined — no extra options needed.
+
+`useDeckIdFromUrl` is a small local helper that wraps the router lookup. Exact invocation (`useMatch({ from: ..., shouldThrow: false })` vs `useMatches().find(...)`) settled at implementation time against the installed router version. Contract: returns `string` when the URL matches `/deck/$deckId/...`, else `undefined`.
+
+The `Decks` link points at `/` (the home/decks-list route).
+
+### Data flow
+
+1. `Root` always mounts `DeckBreadcrumb` in the header.
+2. `DeckBreadcrumb` reads the matched route. No `deckId` → render the static `Decks` link.
+3. With `deckId` → call `useDeck(deckId)`. Loading / error / success branches as defined above.
+4. React Query caches the deck across routes, so transitions inside a deck are instant.
+
+### Accessibility
+
+- Wrapper: `<nav aria-label="Breadcrumb">` containing `<ol>`.
+- Each crumb is an `<li>`. Links use the existing `.link` class; the current crumb is plain text inside the `<li>` with `aria-current="page"`.
+- The `›` separator is a sibling `<span aria-hidden="true">` between list items (or implemented via a CSS `::after` pseudo with `content: "›"` and not announced — either is fine; tests pin behavior, not implementation).
+
+## Testing
+
+A single new `src/app/Root.test.tsx` covers all states. Each test mounts the router at a specific URL with appropriate MSW handlers, then asserts on the `nav[aria-label="Breadcrumb"]` region.
+
+| Test | Setup | Assertion |
+|---|---|---|
+| Home shows just "Decks" link | Navigate to `/` | Only one crumb, role=link, name "Decks" |
+| Deck route shows deck name as current | `/deck/<id>`, deck factory returns name "X" | `Decks` is a link; `X` rendered as text with `aria-current="page"` |
+| Editor route — both crumbs are links | `/deck/<id>/edit/new` | `Decks` and `X` both have role=link |
+| Print route — both crumbs are links | `/deck/<id>/print` | `Decks` and `X` both have role=link |
+| Loading state | `/deck/<id>`, MSW handler delays response | Renders `Decks › …` while pending |
+| Deck not found | `/deck/<id>`, MSW handler returns no rows | Only `Decks` link rendered |
+| Long deck name truncates | `/deck/<id>` with very long name | Crumb has the full name in `title` attr |
+
+Existing tests for `DeckView`, `EditorView`, `PrintView`, `HomeView` are unaffected — none assert on the global header today.
+
+## Risks & non-risks
+
+- **Cache miss flicker:** mitigated by the loading state. Acceptable — only visible on hard refresh.
+- **TanStack Router API shape:** `useMatch` vs `useMatches` syntax may need a small adjustment at implementation time. Low risk — the contract is trivial.
+- **Print output:** the header is already hidden under `@media print`, so no risk to the printed sheet.
+- **Layout collision on narrow viewports:** truncation at 24ch keeps the UserMenu visible.

--- a/e2e/breadcrumb.spec.ts
+++ b/e2e/breadcrumb.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+import { seedDeck, TEST_DECK_ID } from "./fixtures";
+
+const card = {
+  id: "00000000-0000-4000-8000-200000000001",
+  name: "Sword of Testing",
+  body: "A simple test weapon.",
+};
+
+test.describe("deck breadcrumb", () => {
+  test("shows deck name on the deck route, with Decks linking home", async ({ page }) => {
+    await seedDeck(page, [card]);
+    await page.goto(`/deck/${TEST_DECK_ID}`);
+
+    const breadcrumb = page.getByRole("navigation", { name: "Breadcrumb" });
+    await expect(breadcrumb.getByRole("link", { name: "Decks" })).toHaveAttribute("href", "/");
+    await expect(breadcrumb.getByText("E2E Test Deck")).toHaveAttribute("aria-current", "page");
+  });
+
+  test("shows deck name as a back-link on the editor route", async ({ page }) => {
+    await seedDeck(page, [card]);
+    await page.goto(`/deck/${TEST_DECK_ID}/edit/${card.id}`);
+
+    const breadcrumb = page.getByRole("navigation", { name: "Breadcrumb" });
+    const deckLink = breadcrumb.getByRole("link", { name: "E2E Test Deck" });
+    await expect(deckLink).toBeVisible();
+
+    await deckLink.click();
+    await expect(page).toHaveURL(`/deck/${TEST_DECK_ID}`);
+  });
+
+  test("shows deck name as a back-link on the print route", async ({ page }) => {
+    await seedDeck(page, [card]);
+    await page.goto(`/deck/${TEST_DECK_ID}/print`);
+
+    const breadcrumb = page.getByRole("navigation", { name: "Breadcrumb" });
+    await expect(breadcrumb.getByRole("link", { name: "E2E Test Deck" })).toBeVisible();
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const port = Number(process.env.PLAYWRIGHT_PORT ?? 5173);
+const baseURL = `http://localhost:${port}`;
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
@@ -7,12 +10,12 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? "github" : "list",
   use: {
-    baseURL: "http://localhost:5173",
+    baseURL,
     trace: "retain-on-failure",
   },
   webServer: {
-    command: "npm run dev",
-    url: "http://localhost:5173",
+    command: `npm run dev -- --port ${port}`,
+    url: baseURL,
     reuseExistingServer: !process.env.CI,
     stdout: "ignore",
     stderr: "pipe",

--- a/src/app/DeckBreadcrumb.test.tsx
+++ b/src/app/DeckBreadcrumb.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
@@ -111,8 +111,7 @@ describe("DeckBreadcrumb", () => {
     render(wrap(<DeckBreadcrumb />));
 
     await screen.findByRole("link", { name: "Decks" });
-    await new Promise((r) => setTimeout(r, 0));
-    expect(screen.queryByText("›")).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText("›")).not.toBeInTheDocument());
     expect(screen.queryByText("…")).not.toBeInTheDocument();
   });
 

--- a/src/app/DeckBreadcrumb.test.tsx
+++ b/src/app/DeckBreadcrumb.test.tsx
@@ -1,8 +1,13 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
+import { makeDeckRow } from "../test/factories";
+import { server } from "../test/msw";
 import { DeckBreadcrumb } from "./DeckBreadcrumb";
+
+const SB = "http://localhost:54321";
 
 let mockPathname = "/";
 
@@ -43,5 +48,17 @@ describe("DeckBreadcrumb", () => {
     expect(nav).toContainElement(links[0]);
     expect(links).toHaveLength(1);
     expect(links[0]).toHaveAttribute("href", "/");
+  });
+
+  it("renders the deck name as current page on /deck/$id", async () => {
+    const deck = makeDeckRow.build();
+    mockPathname = `/deck/${deck.id}`;
+    server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([deck])));
+    render(wrap(<DeckBreadcrumb />));
+
+    expect(screen.getByRole("link", { name: "Decks" })).toHaveAttribute("href", "/");
+    const current = await screen.findByText(deck.name);
+    expect(current).toHaveAttribute("aria-current", "page");
+    expect(current.tagName).not.toBe("A");
   });
 });

--- a/src/app/DeckBreadcrumb.test.tsx
+++ b/src/app/DeckBreadcrumb.test.tsx
@@ -44,10 +44,10 @@ describe("DeckBreadcrumb", () => {
     mockPathname = "/";
     render(wrap(<DeckBreadcrumb />));
     const nav = screen.getByRole("navigation", { name: /breadcrumb/i });
-    const links = screen.getAllByRole("link", { name: /decks/i });
-    expect(nav).toContainElement(links[0]);
-    expect(links).toHaveLength(1);
-    expect(links[0]).toHaveAttribute("href", "/");
+    const link = screen.getByRole("link", { name: /decks/i });
+    expect(nav).toContainElement(link);
+    expect(link).toHaveAttribute("href", "/");
+    expect(screen.queryByText("›")).not.toBeInTheDocument();
   });
 
   it("renders the deck name as current page on /deck/$id", async () => {

--- a/src/app/DeckBreadcrumb.test.tsx
+++ b/src/app/DeckBreadcrumb.test.tsx
@@ -104,4 +104,15 @@ describe("DeckBreadcrumb", () => {
     resolve?.(HttpResponse.json([deck]));
     await screen.findByText(deck.name);
   });
+
+  it("collapses to just Decks when the deck is not found", async () => {
+    mockPathname = "/deck/missing";
+    server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([])));
+    render(wrap(<DeckBreadcrumb />));
+
+    await screen.findByRole("link", { name: "Decks" });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.queryByText("›")).not.toBeInTheDocument();
+    expect(screen.queryByText("…")).not.toBeInTheDocument();
+  });
 });

--- a/src/app/DeckBreadcrumb.test.tsx
+++ b/src/app/DeckBreadcrumb.test.tsx
@@ -1,0 +1,47 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { DeckBreadcrumb } from "./DeckBreadcrumb";
+
+let mockPathname = "/";
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual =
+    await vi.importActual<typeof import("@tanstack/react-router")>("@tanstack/react-router");
+  return {
+    ...actual,
+    useLocation: () => ({ pathname: mockPathname }),
+    Link: ({
+      children,
+      to,
+      params: _params,
+      ...rest
+    }: {
+      children: ReactNode;
+      to?: string;
+      params?: Record<string, string>;
+    } & Record<string, unknown>) => (
+      <a href={to} {...rest}>
+        {children}
+      </a>
+    ),
+  };
+});
+
+function wrap(ui: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{ui}</QueryClientProvider>;
+}
+
+describe("DeckBreadcrumb", () => {
+  it("renders just a Decks link when not under a deck route", () => {
+    mockPathname = "/";
+    render(wrap(<DeckBreadcrumb />));
+    const nav = screen.getByRole("navigation", { name: /breadcrumb/i });
+    const links = screen.getAllByRole("link", { name: /decks/i });
+    expect(nav).toContainElement(links[0]);
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveAttribute("href", "/");
+  });
+});

--- a/src/app/DeckBreadcrumb.test.tsx
+++ b/src/app/DeckBreadcrumb.test.tsx
@@ -61,4 +61,25 @@ describe("DeckBreadcrumb", () => {
     expect(current).toHaveAttribute("aria-current", "page");
     expect(current.tagName).not.toBe("A");
   });
+
+  it("renders the deck name as a link on the editor route", async () => {
+    const deck = makeDeckRow.build();
+    mockPathname = `/deck/${deck.id}/edit/new`;
+    server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([deck])));
+    render(wrap(<DeckBreadcrumb />));
+
+    const deckLink = await screen.findByRole("link", { name: deck.name });
+    expect(deckLink).toHaveAttribute("href", "/deck/$deckId");
+    expect(deckLink).not.toHaveAttribute("aria-current");
+  });
+
+  it("renders the deck name as a link on the print route", async () => {
+    const deck = makeDeckRow.build();
+    mockPathname = `/deck/${deck.id}/print`;
+    server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([deck])));
+    render(wrap(<DeckBreadcrumb />));
+
+    const deckLink = await screen.findByRole("link", { name: deck.name });
+    expect(deckLink).toHaveAttribute("href", "/deck/$deckId");
+  });
 });

--- a/src/app/DeckBreadcrumb.test.tsx
+++ b/src/app/DeckBreadcrumb.test.tsx
@@ -115,4 +115,15 @@ describe("DeckBreadcrumb", () => {
     expect(screen.queryByText("›")).not.toBeInTheDocument();
     expect(screen.queryByText("…")).not.toBeInTheDocument();
   });
+
+  it("sets the full deck name on title for a truncated link", async () => {
+    const longName = "A Very Long Deck Name That Will Overflow Twenty Four Characters";
+    const deck = makeDeckRow.build({ name: longName });
+    mockPathname = `/deck/${deck.id}/edit/new`;
+    server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([deck])));
+    render(wrap(<DeckBreadcrumb />));
+
+    const link = await screen.findByRole("link", { name: longName });
+    expect(link).toHaveAttribute("title", longName);
+  });
 });

--- a/src/app/DeckBreadcrumb.test.tsx
+++ b/src/app/DeckBreadcrumb.test.tsx
@@ -82,4 +82,26 @@ describe("DeckBreadcrumb", () => {
     const deckLink = await screen.findByRole("link", { name: deck.name });
     expect(deckLink).toHaveAttribute("href", "/deck/$deckId");
   });
+
+  it("shows an ellipsis while the deck query is pending", async () => {
+    const deck = makeDeckRow.build();
+    mockPathname = `/deck/${deck.id}`;
+    let resolve: ((res: Response) => void) | undefined;
+    server.use(
+      http.get(
+        `${SB}/rest/v1/decks`,
+        () =>
+          new Promise<Response>((r) => {
+            resolve = r;
+          }),
+      ),
+    );
+    render(wrap(<DeckBreadcrumb />));
+
+    expect(await screen.findByText("…")).toBeInTheDocument();
+    expect(screen.queryByText(deck.name)).not.toBeInTheDocument();
+
+    resolve?.(HttpResponse.json([deck]));
+    await screen.findByText(deck.name);
+  });
 });

--- a/src/app/DeckBreadcrumb.tsx
+++ b/src/app/DeckBreadcrumb.tsx
@@ -20,7 +20,7 @@ export function DeckBreadcrumb() {
             <li aria-hidden="true" className={styles.separator}>
               ›
             </li>
-            <li>{renderDeckCrumb(deckQuery.data?.name, isAtDeckRoot)}</li>
+            <li>{renderDeckCrumb(deckQuery.data?.name, isAtDeckRoot, deckId)}</li>
           </>
         )}
       </ol>
@@ -28,16 +28,20 @@ export function DeckBreadcrumb() {
   );
 }
 
-function renderDeckCrumb(name: string | undefined, isAtDeckRoot: boolean) {
+function renderDeckCrumb(name: string | undefined, isAtDeckRoot: boolean, deckId: string) {
   if (!name) return "…";
   if (isAtDeckRoot) {
     return (
-      <span aria-current="page" className={styles.crumbCurrent}>
+      <span aria-current="page" className={styles.crumbCurrent} title={name}>
         {name}
       </span>
     );
   }
-  return name;
+  return (
+    <Link to="/deck/$deckId" params={{ deckId }} className={styles.link} title={name}>
+      {name}
+    </Link>
+  );
 }
 
 function parsePathname(pathname: string): { deckId: string | undefined; isAtDeckRoot: boolean } {

--- a/src/app/DeckBreadcrumb.tsx
+++ b/src/app/DeckBreadcrumb.tsx
@@ -15,7 +15,7 @@ export function DeckBreadcrumb() {
             Decks
           </Link>
         </li>
-        {deckId && (
+        {deckId && (deckQuery.isPending || deckQuery.data) && (
           <>
             <li aria-hidden="true" className={styles.separator}>
               ›

--- a/src/app/DeckBreadcrumb.tsx
+++ b/src/app/DeckBreadcrumb.tsx
@@ -1,9 +1,11 @@
 import { Link, useLocation } from "@tanstack/react-router";
+import { useDeck } from "../decks/queries";
 import styles from "./root.module.css";
 
 export function DeckBreadcrumb() {
   const { pathname } = useLocation();
-  const deckId = parseDeckId(pathname);
+  const { deckId, isAtDeckRoot } = parsePathname(pathname);
+  const deckQuery = useDeck(deckId);
 
   return (
     <nav aria-label="Breadcrumb" className={styles.breadcrumb}>
@@ -18,7 +20,7 @@ export function DeckBreadcrumb() {
             <li aria-hidden="true" className={styles.separator}>
               ›
             </li>
-            <li>…</li>
+            <li>{renderDeckCrumb(deckQuery.data?.name, isAtDeckRoot)}</li>
           </>
         )}
       </ol>
@@ -26,7 +28,20 @@ export function DeckBreadcrumb() {
   );
 }
 
-function parseDeckId(pathname: string): string | undefined {
-  const m = pathname.match(/^\/deck\/([^/]+)/);
-  return m?.[1];
+function renderDeckCrumb(name: string | undefined, isAtDeckRoot: boolean) {
+  if (!name) return "…";
+  if (isAtDeckRoot) {
+    return (
+      <span aria-current="page" className={styles.crumbCurrent}>
+        {name}
+      </span>
+    );
+  }
+  return name;
+}
+
+function parsePathname(pathname: string): { deckId: string | undefined; isAtDeckRoot: boolean } {
+  const m = pathname.match(/^\/deck\/([^/]+)(\/.*)?$/);
+  if (!m) return { deckId: undefined, isAtDeckRoot: false };
+  return { deckId: m[1], isAtDeckRoot: !m[2] };
 }

--- a/src/app/DeckBreadcrumb.tsx
+++ b/src/app/DeckBreadcrumb.tsx
@@ -1,0 +1,32 @@
+import { Link, useLocation } from "@tanstack/react-router";
+import styles from "./root.module.css";
+
+export function DeckBreadcrumb() {
+  const { pathname } = useLocation();
+  const deckId = parseDeckId(pathname);
+
+  return (
+    <nav aria-label="Breadcrumb" className={styles.breadcrumb}>
+      <ol className={styles.crumbList}>
+        <li>
+          <Link to="/" className={styles.link}>
+            Decks
+          </Link>
+        </li>
+        {deckId && (
+          <>
+            <li aria-hidden="true" className={styles.separator}>
+              ›
+            </li>
+            <li>…</li>
+          </>
+        )}
+      </ol>
+    </nav>
+  );
+}
+
+function parseDeckId(pathname: string): string | undefined {
+  const m = pathname.match(/^\/deck\/([^/]+)/);
+  return m?.[1];
+}

--- a/src/app/Root.tsx
+++ b/src/app/Root.tsx
@@ -1,5 +1,6 @@
 import { Link, Outlet } from "@tanstack/react-router";
 import { UserMenu } from "../lib/ui/UserMenu";
+import { DeckBreadcrumb } from "./DeckBreadcrumb";
 import styles from "./root.module.css";
 
 export function Root() {
@@ -9,11 +10,7 @@ export function Root() {
         <Link to="/" className={styles.brand}>
           D&amp;D Cards
         </Link>
-        <nav aria-label="Primary" className={styles.nav}>
-          <Link to="/" className={styles.link} activeProps={{ className: styles.active }}>
-            Decks
-          </Link>
-        </nav>
+        <DeckBreadcrumb />
         <UserMenu />
       </header>
       <main className={styles.main}>

--- a/src/app/root.module.css
+++ b/src/app/root.module.css
@@ -62,13 +62,9 @@
 
 .crumbCurrent {
   font-weight: 600;
-  max-width: 24ch;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
-.crumbList .link {
+.crumbList :is(.crumbCurrent, .link) {
   max-width: 24ch;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/app/root.module.css
+++ b/src/app/root.module.css
@@ -22,11 +22,6 @@
   letter-spacing: 0.02em;
 }
 
-.nav {
-  display: flex;
-  gap: var(--space-3);
-}
-
 .link {
   color: var(--color-text);
   text-decoration: none;
@@ -38,9 +33,46 @@
   background: var(--color-surface-2);
 }
 
-.active {
-  background: var(--color-surface-2);
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+}
+
+.crumbList {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+}
+
+.crumbList li {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.separator {
+  color: var(--color-text-muted);
+}
+
+.crumbCurrent {
   font-weight: 600;
+  max-width: 24ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.crumbList .link {
+  max-width: 24ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .main {


### PR DESCRIPTION
### What are the relevant tickets?

N/A — work specced and planned in:

- `docs/superpowers/specs/2026-05-03-deck-breadcrumbs-design.md`
- `docs/superpowers/plans/2026-05-03-deck-breadcrumbs.md`

### Description (What does it do?)

When editing a card or viewing the print sheet, the global header currently gives no signal of which deck you're inside. `DeckView` shows the deck name as an H2, but `EditorView` and `PrintView` don't surface it at all — so context is lost as soon as you click into a card.

This PR replaces the static `Decks` nav link in the header with a breadcrumb that resolves the current deck from the URL on all `/deck/$deckId/...` routes:

| Route | Header |
|---|---|
| `/`, `/login`, `/auth/callback`, `/debug/icons` | `Decks` (link) |
| `/deck/$deckId` | `Decks` › `<deckName>` — `Decks` is a link, deck name is plain text with `aria-current="page"` |
| `/deck/$deckId/edit/$cardId` | `Decks` › `<deckName>` — both clickable, deck name links back to the deck |
| `/deck/$deckId/print` | `Decks` › `<deckName>` — both clickable |

The deck-name crumb is capped at `max-width: 24ch` with ellipsis and the full name in `title` so it can't push the UserMenu off-screen on narrow viewports. Loading shows `Decks › …`; deck-not-found collapses cleanly to just `Decks`.

#### Implementation notes

- New `src/app/DeckBreadcrumb.tsx` reads pathname via `useLocation()` and parses `deckId` with a small regex (`/^\/deck\/([^/]+)(\/.*)?$/`). Considered `useMatch({ from: ..., shouldThrow: false })`; chose pathname-parsing because it's contract-light against the route tree and the deck routes are stable.
- Uses the existing `useDeck(deckId)` query — already accepts `string | undefined` and disables itself internally. React Query cache means navigating from `DeckView` into the editor is instant (no flash of the loading ellipsis).
- The not-found gate uses `(deckQuery.isPending || deckQuery.data)`, which collapses correctly across all four query states (pending / success / error / not-found-empty).
- Removed the now-unused `.nav` and `.active` CSS classes from `root.module.css` (verified zero references in `src/`).
- Print output is unaffected — `@media print { .header { display: none } }` already hides the header.

### Screenshots (if appropriate):

- [ ] Desktop — `/deck/<id>` showing `Decks › <deckName>`
- [ ] Desktop — editor route showing both crumbs as clickable links
- [ ] Narrow viewport — long deck name truncating without colliding with UserMenu

### How can this be tested?

**Manual smoke (`npm run dev`):**

1. Open the home page — header still shows just `Decks` (link to `/`).
2. Click into a deck — header shows `Decks › <DeckName>`. `Decks` is clickable; deck name is bold text.
3. Click "Edit" on any card — header shows both crumbs as links. Click `<DeckName>` to confirm it navigates back to the deck.
4. Click "Print" — same two-link breadcrumb.
5. Hard-refresh `/deck/<id>/edit/<cardId>` — verify the brief `…` placeholder, then the deck name resolves.
6. Visit `/deck/missing-id` — header collapses to just `Decks`; the page itself shows the existing "This deck no longer exists." message.
7. Drag the window narrow until truncation kicks in — confirm UserMenu stays visible and the deck name's full text shows on hover (`title` attr).

**Automated:**

- `src/app/DeckBreadcrumb.test.tsx` — 7 unit tests covering each render branch (no-deck, deck root with `aria-current`, editor link, print link, loading ellipsis, not-found collapse, long-name `title`). Follows the project's convention of mocking `@tanstack/react-router` (parallels `DeckView.test.tsx`, `HomeView.test.tsx`).
- `e2e/breadcrumb.spec.ts` — 3 Playwright specs covering the deck root, editor, and print routes against a real router. Catches drift between the route paths in `router.tsx` and the regex in `DeckBreadcrumb.tsx` that unit tests can't see.

### Additional Context

**Spec ↔ plan ↔ implementation.** Both docs are committed under `docs/superpowers/{specs,plans}/`. The plan was reviewed by the `superpowers:code-reviewer` agent before merge; two minor nits (a `waitFor` cleanup + DRYing the duplicated `max-width: 24ch` rule) were addressed inline. Four other suggestions (add explanatory comments, extract the gate expression, etc.) were intentionally declined per the project's "default to no comments" / "no premature abstraction" conventions.

**Why pathname regex over `useMatch`.** The route tree is flat (`/deck/$deckId`, `/deck/$deckId/edit/$cardId`, `/deck/$deckId/print` are all siblings of root, not nested). Using `useMatch({ from: "/deck/$deckId", ... })` would only match the deck-root route exactly; matching all three would require chaining lookups or using `useMatches()` with route-id filters. The regex is simpler and the e2e tests pin the contract.

**`playwright.config.ts` is now port-flexible** via `PLAYWRIGHT_PORT` (defaults to 5173). Added so the worktree's e2e run wouldn't collide with a dev server on the default port. No-op for the existing CI flow; worth keeping for parallel local development.

**Pre-existing failure.** `e2e/editor-pagination.spec.ts` fails on this branch — the `preview-counts` label renders `"13 cards"` but the spec expects the pattern `/cards \(4 per page\) · /`. **Confirmed this also fails on a clean `main` checkout** (verified by reverting to main and re-running). Not introduced by this PR; flagging here so the failing CI signal isn't misattributed. Worth a separate fix branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)