### PR TITLE
ItemEditor: drop '(optional)' from Icon label

### DIFF
--- a/src/cards/ItemEditor.tsx
+++ b/src/cards/ItemEditor.tsx
@@ -57,7 +57,7 @@ export function ItemEditor({ card, onChange }: Props) {
           <Input id={ids.name} value={card.name} onChange={handle("name")} />
         </label>
         <label className={styles.field} htmlFor={ids.icon}>
-          <span className={styles.label}>Icon (optional)</span>
+          <span className={styles.label}>Icon</span>
           <div className={styles.iconRow}>
             <IconPreview iconKey={resolvedKey} label={resolvedKey} size="md" />
             <IconPickerDialog id={ids.icon} value={card.iconKey} onChange={handleIconChange} />


### PR DESCRIPTION
### What are the relevant tickets?

N/A — small follow-up surfaced while reviewing #23 in the dev server.

### Description (What does it do?)

The Icon field's label read \"Icon (optional)\", but every card always renders an icon: an explicitly picked one, a heuristic match from the name/type, or the fallback. There's no way to *not* have one, so \"optional\" misrepresents the field. Drop the parenthetical.

\"Cost / weight (optional)\" and \"Image URL (optional)\" stay — those are genuinely nullable.

### Screenshots (if appropriate):
- [ ] Editor form showing the Icon label without the \"(optional)\" suffix

### How can this be tested?

Open the editor for any item and confirm the label above the icon picker reads \"Icon\" rather than \"Icon (optional)\". No tests reference the literal label text, so no test changes are needed.