### PR TITLE
Surface SRD import in the new-card editor

### DIFF
--- a/src/cards/ItemEditor.test.tsx
+++ b/src/cards/ItemEditor.test.tsx
@@ -36,7 +36,7 @@ describe("<ItemEditor>", () => {
   });
 
   test("name field shows 'Untitled item' as placeholder", () => {
-    const card = itemCardFactory.build({ name: "" });
+    const card = itemCardFactory.build();
     render(<Harness initial={card} />);
 
     expect(screen.getByPlaceholderText("Untitled item")).toBe(screen.getByLabelText(/name/i));

--- a/src/cards/ItemEditor.test.tsx
+++ b/src/cards/ItemEditor.test.tsx
@@ -35,6 +35,13 @@ describe("<ItemEditor>", () => {
     expect(nameInput.value).toBe("Vorpal");
   });
 
+  test("name field shows 'Untitled item' as placeholder", () => {
+    const card = itemCardFactory.build({ name: "" });
+    render(<Harness initial={card} />);
+
+    expect(screen.getByPlaceholderText("Untitled item")).toBe(screen.getByLabelText(/name/i));
+  });
+
   test("onChange is called with the updated card on body edits", async () => {
     const card = itemCardFactory.build({ body: "" });
     const seen: ItemCard[] = [];

--- a/src/cards/ItemEditor.tsx
+++ b/src/cards/ItemEditor.tsx
@@ -54,7 +54,12 @@ export function ItemEditor({ card, onChange }: Props) {
       <div className={styles.row}>
         <label className={styles.field} htmlFor={ids.name}>
           <span className={styles.label}>Name</span>
-          <Input id={ids.name} value={card.name} onChange={handle("name")} />
+          <Input
+            id={ids.name}
+            value={card.name}
+            onChange={handle("name")}
+            placeholder="Untitled item"
+          />
         </label>
         <label className={styles.field} htmlFor={ids.icon}>
           <span className={styles.label}>Icon (optional)</span>

--- a/src/index.css
+++ b/src/index.css
@@ -34,6 +34,8 @@ body,
   --color-danger-bg-hover: #fff0f0;
   --color-warning-bg: #fff8e1;
   --color-warning-fg: #4a3c10;
+  --color-info-bg: #e3e7ef;
+  --color-info-fg: #3a4a6b;
   --color-focus-ring: #7a3530;
   --color-overlay: rgba(26, 20, 16, 0.4);
 

--- a/src/index.css
+++ b/src/index.css
@@ -34,8 +34,10 @@ body,
   --color-danger-bg-hover: #fff0f0;
   --color-warning-bg: #fff8e1;
   --color-warning-fg: #4a3c10;
+  --color-warning-border: #d6c794;
   --color-info-bg: #e3e7ef;
   --color-info-fg: #3a4a6b;
+  --color-info-border: #b8c0d0;
   --color-focus-ring: #7a3530;
   --color-overlay: rgba(26, 20, 16, 0.4);
 

--- a/src/lib/ui/Link.module.css
+++ b/src/lib/ui/Link.module.css
@@ -1,0 +1,12 @@
+.link {
+  color: var(--color-accent);
+  text-decoration: underline;
+}
+
+.link:hover {
+  color: var(--color-accent-hover);
+}
+
+.link:visited {
+  color: var(--color-accent);
+}

--- a/src/lib/ui/Link.test.tsx
+++ b/src/lib/ui/Link.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Link } from "./Link";
+
+describe("<Link>", () => {
+  it("renders an anchor with the given href", () => {
+    render(<Link href="https://example.test/docs">Docs</Link>);
+    expect(screen.getByRole("link", { name: "Docs" })).toHaveAttribute(
+      "href",
+      "https://example.test/docs",
+    );
+  });
+
+  it("applies an extra className alongside the primitive class", () => {
+    render(
+      <Link href="https://example.test/" className="extra">
+        Home
+      </Link>,
+    );
+    expect(screen.getByRole("link", { name: "Home" }).className).toContain("extra");
+  });
+
+  it("forwards target and rel attributes", () => {
+    render(
+      <Link href="https://example.test/" target="_blank" rel="noopener noreferrer">
+        External
+      </Link>,
+    );
+    const link = screen.getByRole("link", { name: "External" });
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});

--- a/src/lib/ui/Link.tsx
+++ b/src/lib/ui/Link.tsx
@@ -1,0 +1,8 @@
+import type { AnchorHTMLAttributes } from "react";
+import styles from "./Link.module.css";
+
+export type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement>;
+
+export function Link({ className, ...rest }: LinkProps) {
+  return <a {...rest} className={[styles.link, className].filter(Boolean).join(" ")} />;
+}

--- a/src/lib/ui/README.md
+++ b/src/lib/ui/README.md
@@ -10,6 +10,7 @@ Thin wrappers around `react-aria-components` (and a couple of native elements) t
 | `IconButton` | An icon-only button. Pass an SVG component as children. |
 | `OAuthButton` | A sign-in button branded for an OAuth provider. |
 | `Input` | A single-line text field. |
+| `Link` | An `<a>` styled with the accent color and an underline. Use for inline external links; in-app navigation goes through TanStack Router's `<Link>`. |
 | `Textarea` | A multi-line text field. |
 | `TagInput` | A controlled chip-input field. Users type freeform text + Enter to commit chips; `×` per chip removes them. |
 | `Switch` | An on/off toggle with a track + thumb. Children are the label. |

--- a/src/views/DeckView.test.tsx
+++ b/src/views/DeckView.test.tsx
@@ -63,7 +63,7 @@ describe("DeckView (logged-out)", () => {
     expect(
       screen.queryByRole("button", { name: `Delete ${card.payload.name}` }),
     ).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /browse from api/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /browse items/i })).not.toBeInTheDocument();
     // Print is read-only and should be available to anyone viewing the deck.
     expect(screen.getByRole("link", { name: /print/i })).toBeInTheDocument();
   });
@@ -100,6 +100,6 @@ describe("DeckView (owner)", () => {
     await userEvent.click(del);
     await waitFor(() => expect(onDelete).toHaveBeenCalled());
     expect(screen.getByRole("link", { name: /new card/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /browse from api/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /browse items/i })).toBeInTheDocument();
   });
 });

--- a/src/views/DeckView.tsx
+++ b/src/views/DeckView.tsx
@@ -56,7 +56,7 @@ export function DeckView({ deckId }: Props) {
           {isOwner && (
             <>
               <Button variant="secondary" onPress={() => setBrowseOpen(true)}>
-                Browse from API
+                Browse Items
               </Button>
               <Link
                 to="/deck/$deckId/edit/$cardId"

--- a/src/views/EditorView.module.css
+++ b/src/views/EditorView.module.css
@@ -28,6 +28,21 @@
   line-height: var(--lh-body);
 }
 
+.importHint {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  background: var(--color-info-bg);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  padding: var(--space-3) var(--space-4);
+  margin-bottom: var(--space-4);
+  font-size: var(--fs-sm);
+  color: var(--color-info-fg);
+  line-height: var(--lh-body);
+}
+
 .preview {
   display: flex;
   flex-direction: column;

--- a/src/views/EditorView.module.css
+++ b/src/views/EditorView.module.css
@@ -19,7 +19,7 @@
 
 .templateNotice {
   background: var(--color-warning-bg);
-  border: 1px solid var(--color-border-strong);
+  border: 1px solid var(--color-warning-border);
   border-radius: var(--radius-md);
   padding: var(--space-3) var(--space-4);
   margin-bottom: var(--space-4);
@@ -34,7 +34,7 @@
   justify-content: space-between;
   gap: var(--space-3);
   background: var(--color-info-bg);
-  border: 1px solid var(--color-border-strong);
+  border: 1px solid var(--color-info-border);
   border-radius: var(--radius-md);
   padding: var(--space-3) var(--space-4);
   margin-bottom: var(--space-4);

--- a/src/views/EditorView.test.tsx
+++ b/src/views/EditorView.test.tsx
@@ -113,7 +113,7 @@ describe("EditorView", () => {
   it("opens BrowseApiModal when the hint button is pressed", async () => {
     render(wrap(<EditorView deckId="d1" cardId="new" />));
     const hint = await screen.findByTestId("import-hint");
-    await userEvent.click(within(hint).getByRole("button", { name: /browse from api/i }));
+    await userEvent.click(within(hint).getByRole("button", { name: /browse items/i }));
     expect(await screen.findByRole("dialog", { name: /browse magic items/i })).toBeInTheDocument();
   });
 
@@ -126,7 +126,7 @@ describe("EditorView", () => {
     );
     render(wrap(<EditorView deckId="d1" cardId="new" />));
     const hint = await screen.findByTestId("import-hint");
-    await userEvent.click(within(hint).getByRole("button", { name: /browse from api/i }));
+    await userEvent.click(within(hint).getByRole("button", { name: /browse items/i }));
     await userEvent.click(await screen.findByRole("button", { name: "Bag of Holding" }));
     await waitFor(() =>
       expect(navigate).toHaveBeenCalledWith({

--- a/src/views/EditorView.test.tsx
+++ b/src/views/EditorView.test.tsx
@@ -1,12 +1,13 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { magicItemDetail2024Factory, magicItemIndexEntryFactory } from "../api/factories";
 import * as paginateModule from "../cards/paginate";
 import { makeCardRow, makeItemPayload } from "../test/factories";
-import { SB_URL as SB, server } from "../test/msw";
+import { magicItemDetailHandler, magicItemIndexHandler, SB_URL as SB, server } from "../test/msw";
 import { EditorView } from "./EditorView";
 
 const navigate = vi.fn();
@@ -32,6 +33,21 @@ describe("EditorView", () => {
     await waitFor(() => expect(screen.getByText(/card not found/i)).toBeInTheDocument());
   });
 
+  it("opens a new card with an empty name field", async () => {
+    render(wrap(<EditorView deckId="d1" cardId="new" />));
+    const nameInput = (await screen.findByLabelText(/name/i)) as HTMLInputElement;
+    expect(nameInput.value).toBe("");
+  });
+
+  it("disables Save until the name is non-empty", async () => {
+    render(wrap(<EditorView deckId="d1" cardId="new" />));
+    const save = await screen.findByRole("button", { name: /save/i });
+    expect(save).toBeDisabled();
+
+    await userEvent.type(screen.getByLabelText(/name/i), "Vorpal");
+    expect(save).toBeEnabled();
+  });
+
   it("saves via POST when cardId='new'", async () => {
     const onPost = vi.fn();
     server.use(
@@ -41,7 +57,8 @@ describe("EditorView", () => {
       }),
     );
     render(wrap(<EditorView deckId="d1" cardId="new" />));
-    await userEvent.click(await screen.findByRole("button", { name: /save/i }));
+    await userEvent.type(await screen.findByLabelText(/name/i), "Vorpal");
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
     await waitFor(() => expect(onPost).toHaveBeenCalled());
     expect(navigate).toHaveBeenCalledWith({ to: "/deck/$deckId", params: { deckId: "d1" } });
   });
@@ -71,6 +88,52 @@ describe("EditorView", () => {
     server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json([card])));
     render(wrap(<EditorView deckId="d1" cardId="c1" />));
     expect(await screen.findByTestId("template-notice")).toBeInTheDocument();
+  });
+
+  it("shows the import-from-API hint on a fresh new card", async () => {
+    render(wrap(<EditorView deckId="d1" cardId="new" />));
+    expect(await screen.findByTestId("import-hint")).toBeInTheDocument();
+  });
+
+  it("hides the import hint once a name is typed", async () => {
+    render(wrap(<EditorView deckId="d1" cardId="new" />));
+    await screen.findByTestId("import-hint");
+    await userEvent.type(screen.getByLabelText(/name/i), "x");
+    expect(screen.queryByTestId("import-hint")).not.toBeInTheDocument();
+  });
+
+  it("does NOT show the import hint when editing an existing card", async () => {
+    const card = makeCardRow.build({ id: "c1", deck_id: "d1" });
+    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json([card])));
+    render(wrap(<EditorView deckId="d1" cardId="c1" />));
+    await screen.findByRole("button", { name: /save/i });
+    expect(screen.queryByTestId("import-hint")).not.toBeInTheDocument();
+  });
+
+  it("opens BrowseApiModal when the hint button is pressed", async () => {
+    render(wrap(<EditorView deckId="d1" cardId="new" />));
+    const hint = await screen.findByTestId("import-hint");
+    await userEvent.click(within(hint).getByRole("button", { name: /browse from api/i }));
+    expect(await screen.findByRole("dialog", { name: /browse magic items/i })).toBeInTheDocument();
+  });
+
+  it("navigates to the imported card's editor after picking from the modal", async () => {
+    const entry = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
+    const detail = magicItemDetail2024Factory.build({ index: entry.index, name: entry.name });
+    server.use(
+      magicItemIndexHandler("2024", { count: 1, results: [entry] }),
+      magicItemDetailHandler("2024", entry.index, detail),
+    );
+    render(wrap(<EditorView deckId="d1" cardId="new" />));
+    const hint = await screen.findByTestId("import-hint");
+    await userEvent.click(within(hint).getByRole("button", { name: /browse from api/i }));
+    await userEvent.click(await screen.findByRole("button", { name: "Bag of Holding" }));
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith({
+        to: "/deck/$deckId/edit/$cardId",
+        params: { deckId: "d1", cardId: expect.any(String) },
+      }),
+    );
   });
 
   it("does NOT show the template notice for custom items", async () => {

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -11,10 +11,11 @@ import { nowIso } from "../lib/time";
 import { Button } from "../lib/ui/Button";
 import { LoadingState } from "../lib/ui/LoadingState";
 import { useDebouncedValue } from "../lib/useDebouncedValue";
+import { BrowseApiModal } from "./BrowseApiModal";
 import styles from "./EditorView.module.css";
 
 const isPristineNewCard = (card: ItemCard): boolean =>
-  card.name === "Untitled item" &&
+  card.name === "" &&
   card.headerTags.length === 0 &&
   card.body === "" &&
   card.footerTags.length === 0 &&
@@ -54,7 +55,7 @@ export function EditorView({ deckId, cardId }: Props) {
     return {
       id: newId(),
       kind: "item",
-      name: "Untitled item",
+      name: "",
       headerTags: [],
       body: "",
       footerTags: [],
@@ -88,6 +89,7 @@ export function EditorView({ deckId, cardId }: Props) {
   const { physicalCards: chunks2Up } = useExpandedCards(measurementItems, 2);
 
   const [previewPage, setPreviewPage] = useState(0);
+  const [browseOpen, setBrowseOpen] = useState(false);
   const totalPages4 = Math.max(chunks4Up.length, 1);
   const clampedPage = Math.min(previewPage, totalPages4 - 1);
   const visibleChunk = chunks4Up[clampedPage];
@@ -116,6 +118,8 @@ export function EditorView({ deckId, cardId }: Props) {
 
   const showPaginator = totalPages4 > 1;
 
+  const showImportHint = isNew && draft.name === "";
+
   return (
     <section className={styles.editor}>
       <div className={styles.form}>
@@ -126,9 +130,21 @@ export function EditorView({ deckId, cardId }: Props) {
             weapon or armor.
           </div>
         )}
+        {showImportHint && (
+          <div className={styles.importHint} data-testid="import-hint">
+            <span>Importing from the SRD? Browse the catalog instead.</span>
+            <Button variant="secondary" size="sm" onPress={() => setBrowseOpen(true)}>
+              Browse from API
+            </Button>
+          </div>
+        )}
         <ItemEditor card={draft} onChange={setDraft} />
         <div className={styles.formActions}>
-          <Button variant="primary" onPress={handleSave} isDisabled={saveCard.isPending}>
+          <Button
+            variant="primary"
+            onPress={handleSave}
+            isDisabled={saveCard.isPending || draft.name === ""}
+          >
             Save
           </Button>
           <Button variant="secondary" onPress={handleCancel}>
@@ -171,6 +187,19 @@ export function EditorView({ deckId, cardId }: Props) {
           {label}
         </div>
       </div>
+      {browseOpen && (
+        <BrowseApiModal
+          deckId={deckId}
+          onClose={() => setBrowseOpen(false)}
+          onSelected={(importedCardId) => {
+            setBrowseOpen(false);
+            navigate({
+              to: "/deck/$deckId/edit/$cardId",
+              params: { deckId, cardId: importedCardId },
+            });
+          }}
+        />
+      )}
     </section>
   );
 }

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -145,7 +145,7 @@ export function EditorView({ deckId, cardId }: Props) {
               ? Browse the catalog instead.
             </span>
             <Button variant="secondary" onPress={() => setBrowseOpen(true)}>
-              Browse from API
+              Browse Items
             </Button>
           </div>
         )}

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -9,6 +9,7 @@ import { useDeckCards } from "../decks/queries";
 import { newId } from "../lib/id";
 import { nowIso } from "../lib/time";
 import { Button } from "../lib/ui/Button";
+import { Link } from "../lib/ui/Link";
 import { LoadingState } from "../lib/ui/LoadingState";
 import { useDebouncedValue } from "../lib/useDebouncedValue";
 import { BrowseApiModal } from "./BrowseApiModal";
@@ -134,13 +135,13 @@ export function EditorView({ deckId, cardId }: Props) {
           <div className={styles.importHint} data-testid="import-hint">
             <span>
               Importing from the{" "}
-              <a
+              <Link
                 href="https://en.wikipedia.org/wiki/System_Reference_Document"
                 target="_blank"
                 rel="noopener noreferrer"
               >
                 SRD
-              </a>
+              </Link>
               ? Browse the catalog instead.
             </span>
             <Button variant="secondary" size="sm" onPress={() => setBrowseOpen(true)}>

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -132,7 +132,17 @@ export function EditorView({ deckId, cardId }: Props) {
         )}
         {showImportHint && (
           <div className={styles.importHint} data-testid="import-hint">
-            <span>Importing from the SRD? Browse the catalog instead.</span>
+            <span>
+              Importing from the{" "}
+              <a
+                href="https://en.wikipedia.org/wiki/System_Reference_Document"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                SRD
+              </a>
+              ? Browse the catalog instead.
+            </span>
             <Button variant="secondary" size="sm" onPress={() => setBrowseOpen(true)}>
               Browse from API
             </Button>

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -144,7 +144,7 @@ export function EditorView({ deckId, cardId }: Props) {
               </Link>
               ? Browse the catalog instead.
             </span>
-            <Button variant="secondary" size="sm" onPress={() => setBrowseOpen(true)}>
+            <Button variant="secondary" onPress={() => setBrowseOpen(true)}>
               Browse from API
             </Button>
           </div>


### PR DESCRIPTION
### What are the relevant tickets?

N/A — small UX improvement surfaced while using the app.

### Description (What does it do?)

When the user clicked `New card`, they landed in the editor with no way to import from the SRD — they had to navigate back to the deck view to find the `Browse from API` button. This PR makes the import path discoverable from the editor itself.

Changes:

- New-card editor opens with an empty Name field (was hardcoded to `Untitled item`). The default value moves to a placeholder.
- Save is disabled until Name is non-empty (replaces the silent `Untitled item` default).
- When the editor opens for a new card with an empty name, an info-styled banner appears above the form: *"Importing from the SRD? Browse Items instead."* The button opens `BrowseApiModal`; selecting an item navigates straight to the imported card's editor (the unsaved blank draft was only component state and is discarded).
- The `SRD` in the banner copy is a link to Wikipedia — most players know what magic items they want, but the SRD scope (no Tasha's, Xanathar's, etc.) is a common point of confusion worth a one-click explanation.
- Renamed the existing `Browse from API` button (deck view + new banner) to `Browse Items`. `API` is jargon and doesn't describe what the button does.

Token additions:

- `--color-info-{bg,fg,border}` for the new banner — muted slate blue, picked to coexist with the warm parchment + burgundy palette without competing with the warning yellow used by the template-item notice.
- `--color-warning-border` for parity, replacing the unrelated `--color-border-strong` previously borrowed by the template notice.

New primitive:

- `src/lib/ui/Link.tsx` — inline external-link wrapper with `--color-accent` text + underline, `--color-accent-hover` on hover, `:visited` matches unvisited. Documented in the UI catalog. (TanStack Router's `<Link>` continues to handle in-app navigation.)

### Screenshots (if appropriate):
- [ ] Desktop — new-card editor showing the import banner with empty Name + disabled Save
- [ ] Desktop — banner button opening the existing `BrowseApiModal`
- [ ] Desktop — deck view with the renamed `Browse Items` button

### How can this be tested?

**Manual (`npm run dev`):**

1. Open any deck and click `New card`. The editor opens with Name empty (placeholder visible), Save disabled, and the slate import banner above the form.
2. Click the `SRD` link — Wikipedia article opens in a new tab.
3. Click `Browse Items` in the banner — `BrowseApiModal` opens. Pick an item and confirm you land on the imported card's editor (not back at the deck).
4. Type a Name. Banner disappears, Save enables.
5. Open an existing card. Banner is not shown.
6. Visit the deck-view header — the existing button now reads `Browse Items`.

**Automated:**

- `EditorView.test.tsx` adds 5 tests: empty default name, Save enabled/disabled toggle, banner visibility (new vs existing card), modal opens from the banner, and post-pick navigation routes to the imported card.
- `ItemEditor.test.tsx` adds the placeholder assertion.
- `Link.test.tsx` covers the new primitive (href, className merging, target/rel forwarding).

### Additional Context

**Why not just swap deck-view button priority?** Considered making `Browse Items` the primary button on the deck view so the natural reach goes to import. Decided against — the deck view already had both buttons, but users (me) still reflex-clicked `New card` and only realized after. An in-editor escape hatch is more forgiving than re-prioritizing the deck-view buttons.

**Banner trigger is `isNew && draft.name === ""`.** If a user types a name and then clears it, the banner reappears. Considered a one-shot dismiss with a `userTouchedName` flag; left the simpler condition because reappearance arguably reads as "you cleared the name — still need help?" rather than annoyance. Easy to swap if it grates in practice.

**Pristine-detection check change.** `isPristineNewCard` previously keyed on `name === "Untitled item"` (used by cancel-cleanup to delete an unedited row). Now keys on `name === ""` to match the new stub default. Theoretically a server-saved card whose name was the literal string `"Untitled item"` would no longer be auto-deleted as pristine, but Save was previously unconditional so such a row could only have been created on purpose — fine to leave alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)