### PR TITLE
feat: landscape 2-per-page printing + card title autofit

### DIFF
--- a/docs/superpowers/specs/2026-05-03-title-autofit-design.md
+++ b/docs/superpowers/specs/2026-05-03-title-autofit-design.md
@@ -1,0 +1,264 @@
+# Title autofit on `<Card>`
+
+## Problem
+
+Some item names — "Flame Tongue Trident", "Ring of Spell Storing", etc. —
+wrap to two lines at the current title size, often with a near-empty second
+line that wastes header space (and pushes the body down). A modest font-size
+nudge would let many of these collapse to one line, but currently the title
+font is fixed.
+
+A `AutoFitCard` wrapper used to scale the *whole card* via `--scale` to
+recover from body overflow; it was removed when body pagination shipped
+(commits `d6e9c7f` → `4bf6fa3`). This spec proposes a narrower analog: scale
+only the title, only when it wraps.
+
+## Solution
+
+Inside `<Card>`, measure the rendered title after layout. If it spans more
+than one line, try a smaller font-size. Step through `[1, 0.9, 0.8]`. If even
+0.8 still wraps, give up and render at 1.0 with the wrap accepted. Apply the
+result as an inline `font-size` on the `<h3>`.
+
+## Scope
+
+In scope:
+
+- A `useLayoutEffect` block inside `Card.tsx` that owns the title-scale state.
+- Inline `font-size` on the `<h3>` driven by that state.
+- Resetting the state when `card.id`, `card.name`, or `cardsPerPage` changes.
+- New unit tests on `Card.test.tsx` covering the three wrap-state branches.
+
+Out of scope:
+
+- Whole-card scaling (the body has pagination; only the title needs this).
+- Reviving the deleted `AutoFitCard` wrapper. The new code lives inside
+  `Card.tsx` because `Card` already manages its own non-trivial state (image
+  error fallback) — adding one more local concern is cleaner than introducing
+  a wrapper purely to host the effect.
+- Feeding the autofit result back into `paginate.ts` / `measurer.ts`. The
+  measurer renders titles at scale 1.0 (worst case), so pagination decisions
+  remain conservative — see "Pagination interaction" below.
+- Body, tag, or icon scaling.
+
+## Behavior
+
+### Algorithm
+
+After every render that changes the title's measured layout:
+
+1. Read `h3.offsetHeight` and `getComputedStyle(h3).lineHeight`.
+2. Compute `lineCount = Math.round(offsetHeight / lineHeightPx)`.
+3. If `lineCount === 1`, fixed point reached — keep current scale.
+4. If `lineCount > 1`:
+   - If current scale is `1.0`, set scale to `0.9`.
+   - If current scale is `0.9`, set scale to `0.8`.
+   - If current scale is `0.8`, set scale to `1.0` (give up, accept wrap).
+
+State machine in three steps gives at most 3 layout passes per card.
+
+### Reset triggers
+
+State resets to `1.0` when any of these change:
+
+- `card.id` — different card
+- `card.name` — title text changed (editor live-edit)
+- `cardsPerPage` — card width changed (4-up vs 2-up have different available widths)
+
+Implementation: a `useEffect` that watches a key string `${card.id}:${card.name}:${cardsPerPage}` and resets `scale` to `1.0` when it changes. The measurement effect then runs naturally on the next paint.
+
+### "Give up" semantics
+
+If 0.8 still wraps, set scale back to `1.0`. Per the user's stated rule:
+"if it does need a second line, go back up to 1.0". Accepting wrap at 1.0
+keeps title typography consistent with non-wrapping titles in the same deck
+when shrinkage doesn't help anyway.
+
+### Visual consistency
+
+Cards in the same deck may end up at 1.0, 0.9, or 0.8 — accepted by the user
+because the small-caps title styling already differentiates titles
+visually, and the variance only matters when paged together.
+
+## Architecture
+
+### Files
+
+```
+src/cards/
+  Card.tsx               ← add useState + useLayoutEffect + ref
+  Card.test.tsx          ← 3 new tests stubbing offsetHeight + line-height
+```
+
+No new files. No CSS changes — autofit is applied inline via `style={{ fontSize: ... }}`.
+
+### Code shape
+
+The state must track not just the current scale but whether we've already
+given up — otherwise after "give up at 0.8 → revert to 1.0", the next layout
+pass sees the wrap and tries to shrink again, looping forever.
+
+```tsx
+type AutofitState =
+  | { kind: "unmeasured" }                 // initial; needs measurement
+  | { kind: "fitted"; scale: 1 | 0.9 | 0.8 } // measurement says it fits at this scale
+  | { kind: "gave-up" };                   // wrapped at every scale; lock at 1.0
+
+export function Card({ card, cardsPerPage, ... }: Props) {
+  // … existing state …
+
+  const titleRef = useRef<HTMLHeadingElement>(null);
+  const [autofit, setAutofit] = useState<AutofitState>({ kind: "unmeasured" });
+
+  // Reset to unmeasured when content / layout changes that could affect wrapping.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset key tied to layout/content inputs
+  useEffect(() => {
+    setAutofit({ kind: "unmeasured" });
+  }, [card.id, card.name, cardsPerPage]);
+
+  useLayoutEffect(() => {
+    if (autofit.kind === "fitted" && autofit.scale === 1) return;
+    if (autofit.kind === "gave-up") return;
+    const el = titleRef.current;
+    if (!el) return;
+    const lineHeightPx = parseFloat(getComputedStyle(el).lineHeight);
+    if (!Number.isFinite(lineHeightPx) || lineHeightPx <= 0) return;
+    const wraps = Math.round(el.offsetHeight / lineHeightPx) > 1;
+
+    if (autofit.kind === "unmeasured") {
+      setAutofit(wraps ? { kind: "fitted", scale: 0.9 } : { kind: "fitted", scale: 1 });
+      return;
+    }
+    // autofit.kind === "fitted" with scale 0.9 or 0.8
+    if (!wraps) return; // current scale fits — done
+    if (autofit.scale === 0.9) setAutofit({ kind: "fitted", scale: 0.8 });
+    else setAutofit({ kind: "gave-up" }); // scale === 0.8 and still wraps
+  });
+
+  const titleStyle =
+    autofit.kind === "fitted" && autofit.scale !== 1
+      ? { fontSize: `${autofit.scale}em` }
+      : undefined;
+
+  return (
+    // …
+    <h3 className={styles.title} ref={titleRef} style={titleStyle}>
+      {card.name}
+    </h3>
+    // …
+  );
+}
+```
+
+Why this terminates:
+
+- `unmeasured` → either `fitted{1}` or `fitted{0.9}` (1 transition)
+- `fitted{0.9}` → either stays (no wrap) or `fitted{0.8}` (1 transition)
+- `fitted{0.8}` → either stays (no wrap) or `gave-up` (1 transition)
+- `fitted{1}` and `gave-up` early-return without setting state
+
+Maximum chain from `unmeasured` is `unmeasured → fitted{0.9} → fitted{0.8} →
+gave-up`, three state transitions, four layout passes. The reset effect on
+key change sends us back to `unmeasured` and the cycle can run again.
+
+Notes:
+
+- The reset effect uses `useEffect` (not layout) — the next paint runs the
+  layout effect from `unmeasured`, which then settles in at most 3 steps.
+- The layout effect has no dependency array (runs after every render) but
+  early-returns for terminal states (`fitted{1}` and `gave-up`), preventing
+  loops.
+- `getComputedStyle` returns `lineHeight` either as `"normal"` or as a px
+  string like `"19.55px"`. The CSS sets `line-height: 1.15` (unitless), so
+  the computed value resolves to a px string in all browsers and jsdom.
+  Defensive `isFinite/<=0` check guards against the rare `"normal"` case.
+
+### Pagination interaction
+
+`measurer.ts` renders an off-DOM scaffold with the title at the default scale
+(no autofit; the scaffold's `<h3>` doesn't run any effects). The body fit
+check therefore assumes a worst-case 1.0em title, which may be larger
+vertically than the rendered card. Consequence: a card whose title actually
+shrinks at render time has slightly more body room than the measurer
+predicted. Pagination is conservative — in rare cases an item might be split
+across two physical cards when it would have fit on one had the measurer
+known about the title shrink.
+
+**Decision: do not propagate autofit into the measurer.** Reasons:
+
+1. Title shrinking from 2 lines to 1 line saves ~1.4em of header height. A
+   card that splits at 1.4em-from-fit is uncommon.
+2. Wiring the autofit into the measurer would require running the iterative
+   scale-down inside the measurer's render path, which currently does
+   single-pass DOM measurement. Significant complexity for a marginal win.
+3. Worst-case behavior is "extra physical card" — same fallback the user
+   already accepts when bodies overflow. No correctness issue.
+
+## Testing
+
+### New tests in `Card.test.tsx`
+
+Each test stubs DOM measurement and asserts on the rendered inline style.
+
+Stub helpers (defined per-test):
+
+```ts
+function stubTitleHeight(px: number) {
+  Object.defineProperty(HTMLHeadingElement.prototype, "offsetHeight", {
+    configurable: true,
+    get() {
+      return this.classList.contains(/* styles.title hashed */) ? px : 0;
+    },
+  });
+}
+```
+
+The single-line height is `1.15 * 1.2 * 17 ≈ 23.46px` for 4-up. We assert via
+class match so only the title gets the stubbed height.
+
+If `getComputedStyle(h3).lineHeight` returns `"normal"` in jsdom (it might —
+jsdom's CSS resolution is partial), we'll need to also stub
+`getComputedStyle` or set an explicit pixel `line-height` in a test-only
+class. The implementation will pick whichever path actually works in jsdom;
+the spec just guarantees the *behavior* below.
+
+| Test | Stubbed offsetHeight | Expected outcome |
+|---|---|---|
+| Title fits on one line | ≈ single-line height (e.g. 23px) | h3 has no inline `font-size` |
+| Title wraps, fits at 0.9 | 50px when scale=1, 22px when scale=0.9 | h3 has `style="font-size: 0.9em"` |
+| Title wraps at every scale | 50px regardless of scale | h3 has no inline `font-size` (state lands on `gave-up`) |
+
+The third test verifies the `gave-up` terminal state — the most subtle
+behavior, and the one that prevents an infinite render loop.
+
+### Tests not affected
+
+- `paginate.test.ts` / `measurer.test.ts` — unchanged, since autofit doesn't
+  touch the measurer.
+- Existing `Card.test.tsx` cases render at fixed sizes; they don't stub
+  offsetHeight, so the layout effect bails out (jsdom returns 0 for
+  offsetHeight, lineCount = 0, no scale change).
+- `PrintView.test.tsx` — same reasoning.
+
+## Risks & non-risks
+
+- **Infinite render loop:** addressed by the four-state machine in
+  "Code shape". `fitted{1}` and `gave-up` are terminal — the layout effect
+  bails out without setting state, breaking what would otherwise be a
+  2-cycle (1.0 → 0.9 → 0.8 → 1.0 → 0.9 → …). Reset on key change clears
+  `gave-up` back to `unmeasured` so editor live-edits get a fresh attempt.
+
+- **jsdom `getComputedStyle` limitations.** As noted in Testing — if
+  jsdom returns `lineHeight: "normal"`, the layout effect bails out (no
+  scaling applied). For tests we stub measurements explicitly, so this
+  doesn't bite. In real browsers `line-height: 1.15` resolves to a px value.
+
+- **Print rendering.** `useLayoutEffect` runs in the browser before print.
+  When the user invokes print, the screen-side rendered card is what gets
+  printed (the `<Card>` is the same element). Title scale settles before
+  the print snapshot. No print-specific path needed.
+
+- **Editor live-edit.** As the user types in the title field, `card.name`
+  changes → reset effect fires → scale resets to `unmeasured` → layout
+  effect re-measures. One extra render per keystroke, all paint-aligned;
+  no flicker because layout effects run before paint.

--- a/docs/superpowers/specs/2026-05-03-title-autofit-design.md
+++ b/docs/superpowers/specs/2026-05-03-title-autofit-design.md
@@ -53,26 +53,32 @@ After every render that changes the title's measured layout:
 4. If `lineCount > 1`:
    - If current scale is `1.0`, set scale to `0.9`.
    - If current scale is `0.9`, set scale to `0.8`.
-   - If current scale is `0.8`, set scale to `1.0` (give up, accept wrap).
+   - If current scale is `0.8`, transition to a `gave-up` terminal state
+     (renders with no inline `font-size`, i.e. visually 1.0em, and the
+     measurement loop bails on subsequent passes).
 
 State machine in three steps gives at most 3 layout passes per card.
 
 ### Reset triggers
 
-State resets to `1.0` when any of these change:
+State resets to `unmeasured` when any of these change:
 
 - `card.id` — different card
 - `card.name` — title text changed (editor live-edit)
 - `cardsPerPage` — card width changed (4-up vs 2-up have different available widths)
 
-Implementation: a `useEffect` that watches a key string `${card.id}:${card.name}:${cardsPerPage}` and resets `scale` to `1.0` when it changes. The measurement effect then runs naturally on the next paint.
+Implementation: a single `useLayoutEffect` owns both reset and measurement.
+A `useRef<string | null>` tracks the last input key (`${card.id}:${card.name}:${cardsPerPage}`); when the effect runs and detects a key change, it resets `autofit` to `unmeasured` and returns. The next render then re-enters the effect and runs measurement. Folding both responsibilities into one layout effect avoids a race that would otherwise occur if reset lived in a separate `useEffect` (post-paint) while measurement was a `useLayoutEffect` (pre-paint) — the layout effect would fire first against stale state on rename.
 
 ### "Give up" semantics
 
-If 0.8 still wraps, set scale back to `1.0`. Per the user's stated rule:
-"if it does need a second line, go back up to 1.0". Accepting wrap at 1.0
-keeps title typography consistent with non-wrapping titles in the same deck
-when shrinkage doesn't help anyway.
+If 0.8 still wraps, the state transitions to `gave-up` (a terminal state).
+The rendered title carries no inline `font-size` and so renders at 1.0em.
+Per the user's stated rule: "if it does need a second line, go back up to
+1.0". Accepting wrap at 1.0 keeps title typography consistent with
+non-wrapping titles in the same deck when shrinkage doesn't help anyway.
+The terminal state (rather than transitioning back to `fitted{1}`) prevents
+a 2-cycle that would otherwise loop the layout effect indefinitely.
 
 ### Visual consistency
 
@@ -95,33 +101,42 @@ No new files. No CSS changes — autofit is applied inline via `style={{ fontSiz
 ### Code shape
 
 The state must track not just the current scale but whether we've already
-given up — otherwise after "give up at 0.8 → revert to 1.0", the next layout
-pass sees the wrap and tries to shrink again, looping forever.
+given up — otherwise after wrapping at every scale the loop would oscillate
+forever (1.0 → 0.9 → 0.8 → 1.0 → 0.9 → …). A `gave-up` terminal state
+short-circuits the loop.
+
+A single `useLayoutEffect` owns reset and measurement. A ref tracks the
+last input key; on key change the effect resets and returns, deferring
+measurement to the next render. This avoids a race that splitting reset
+into a separate `useEffect` would introduce — see "Reset triggers" above.
 
 ```tsx
 type AutofitState =
-  | { kind: "unmeasured" }                 // initial; needs measurement
+  | { kind: "unmeasured" }                   // initial; needs measurement
   | { kind: "fitted"; scale: 1 | 0.9 | 0.8 } // measurement says it fits at this scale
-  | { kind: "gave-up" };                   // wrapped at every scale; lock at 1.0
+  | { kind: "gave-up" };                     // wrapped at every scale; render at 1.0
 
 export function Card({ card, cardsPerPage, ... }: Props) {
   // … existing state …
 
   const titleRef = useRef<HTMLHeadingElement>(null);
   const [autofit, setAutofit] = useState<AutofitState>({ kind: "unmeasured" });
-
-  // Reset to unmeasured when content / layout changes that could affect wrapping.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: reset key tied to layout/content inputs
-  useEffect(() => {
-    setAutofit({ kind: "unmeasured" });
-  }, [card.id, card.name, cardsPerPage]);
+  const lastInputKeyRef = useRef<string | null>(null);
 
   useLayoutEffect(() => {
-    if (autofit.kind === "fitted" && autofit.scale === 1) return;
+    const inputKey = `${card.id}:${card.name}:${cardsPerPage}`;
+    if (lastInputKeyRef.current !== inputKey) {
+      lastInputKeyRef.current = inputKey;
+      if (autofit.kind !== "unmeasured") {
+        setAutofit({ kind: "unmeasured" });
+        return;
+      }
+    }
     if (autofit.kind === "gave-up") return;
+    if (autofit.kind === "fitted" && autofit.scale === 1) return;
     const el = titleRef.current;
     if (!el) return;
-    const lineHeightPx = parseFloat(getComputedStyle(el).lineHeight);
+    const lineHeightPx = Number.parseFloat(getComputedStyle(el).lineHeight);
     if (!Number.isFinite(lineHeightPx) || lineHeightPx <= 0) return;
     const wraps = Math.round(el.offsetHeight / lineHeightPx) > 1;
 
@@ -130,10 +145,10 @@ export function Card({ card, cardsPerPage, ... }: Props) {
       return;
     }
     // autofit.kind === "fitted" with scale 0.9 or 0.8
-    if (!wraps) return; // current scale fits — done
+    if (!wraps) return;
     if (autofit.scale === 0.9) setAutofit({ kind: "fitted", scale: 0.8 });
-    else setAutofit({ kind: "gave-up" }); // scale === 0.8 and still wraps
-  });
+    else setAutofit({ kind: "gave-up" });
+  }, [autofit, card.id, card.name, cardsPerPage]);
 
   const titleStyle =
     autofit.kind === "fitted" && autofit.scale !== 1
@@ -158,16 +173,13 @@ Why this terminates:
 - `fitted{1}` and `gave-up` early-return without setting state
 
 Maximum chain from `unmeasured` is `unmeasured → fitted{0.9} → fitted{0.8} →
-gave-up`, three state transitions, four layout passes. The reset effect on
-key change sends us back to `unmeasured` and the cycle can run again.
+gave-up`, three state transitions, four layout passes. A reset (key change)
+sends us back to `unmeasured` and the cycle can run again.
 
 Notes:
 
-- The reset effect uses `useEffect` (not layout) — the next paint runs the
-  layout effect from `unmeasured`, which then settles in at most 3 steps.
-- The layout effect has no dependency array (runs after every render) but
-  early-returns for terminal states (`fitted{1}` and `gave-up`), preventing
-  loops.
+- `[autofit, card.id, card.name, cardsPerPage]` deps mean the effect only
+  runs when one of these changes, not on every parent re-render.
 - `getComputedStyle` returns `lineHeight` either as `"normal"` or as a px
   string like `"19.55px"`. The CSS sets `line-height: 1.15` (unitless), so
   the computed value resolves to a px string in all browsers and jsdom.

--- a/src/cards/Card.module.css
+++ b/src/cards/Card.module.css
@@ -31,9 +31,9 @@
 
 .image {
   float: right;
-  margin: 0 0 0.2em 0.4em;
-  width: 3.5em;
-  height: 3.5em;
+  margin: 0 0 -0.1em 0.4em;
+  width: 3em;
+  height: 3em;
   background: var(--print-color-image-bg);
   border: 1px solid var(--print-color-image-frame);
   border-radius: 0.2em;
@@ -43,9 +43,9 @@
 
 .icon {
   float: right;
-  margin: 0 0 0.2em 0.4em;
-  width: 3.5em;
-  height: 3.5em;
+  margin: 0 0 -0.1em 0.4em;
+  width: 3em;
+  height: 3em;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -54,8 +54,8 @@
 }
 
 .icon svg {
-  width: 85%;
-  height: 85%;
+  width: 100%;
+  height: 100%;
 }
 
 .header {
@@ -74,7 +74,7 @@
   font-size: 0.9em;
   font-style: italic;
   color: var(--print-color-ink-muted);
-  line-height: 1.3;
+  line-height: 1.2;
 }
 
 .headerTag + .headerTag::before {

--- a/src/cards/Card.module.css
+++ b/src/cards/Card.module.css
@@ -71,6 +71,7 @@
 }
 
 .headerTags {
+  display: block;
   font-size: 0.9em;
   font-style: italic;
   color: var(--print-color-ink-muted);

--- a/src/cards/Card.module.css
+++ b/src/cards/Card.module.css
@@ -25,8 +25,8 @@
 
 .perPage2 {
   --card-base: 24px;
-  --card-width: 7.5in;
-  --card-height: 5in;
+  --card-width: 5in;
+  --card-height: 7.5in;
 }
 
 .image {

--- a/src/cards/Card.test.tsx
+++ b/src/cards/Card.test.tsx
@@ -162,6 +162,7 @@ describe("<Card> with pagination", () => {
 describe("<Card> with title autofit", () => {
   const LINE_HEIGHT_PX = 20;
   let titleHeights: Record<string, number> = {};
+  let measuredScales: string[] = [];
   let originalOffsetHeight: PropertyDescriptor | undefined;
   let originalGetComputedStyle: typeof window.getComputedStyle;
 
@@ -175,6 +176,7 @@ describe("<Card> with title autofit", () => {
       get(this: HTMLHeadingElement) {
         const fontSize = this.style.fontSize;
         const key = fontSize === "" ? "1" : fontSize.replace("em", "");
+        measuredScales.push(key);
         return titleHeights[key] ?? 0;
       },
     });
@@ -203,6 +205,7 @@ describe("<Card> with title autofit", () => {
     }
     window.getComputedStyle = originalGetComputedStyle;
     titleHeights = {};
+    measuredScales = [];
   });
 
   test("title that fits on one line gets no inline font-size", async () => {
@@ -225,7 +228,7 @@ describe("<Card> with title autofit", () => {
     });
   });
 
-  test("title that wraps at every scale ends up unstyled (gave-up state)", async () => {
+  test("title that wraps at every scale walks through 0.9 and 0.8 then gives up", async () => {
     titleHeights = {
       "1": LINE_HEIGHT_PX * 2,
       "0.9": LINE_HEIGHT_PX * 2,
@@ -235,7 +238,9 @@ describe("<Card> with title autofit", () => {
     render(<Card card={card} cardsPerPage={4} />);
     const heading = screen.getByRole("heading", { name: card.name });
     await waitFor(() => {
-      expect(heading.style.fontSize).toBe("");
+      expect(measuredScales).toContain("0.8");
     });
+    expect(measuredScales).toEqual(expect.arrayContaining(["1", "0.9", "0.8"]));
+    expect(heading.style.fontSize).toBe("");
   });
 });

--- a/src/cards/Card.test.tsx
+++ b/src/cards/Card.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, test } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { Card } from "./Card";
 import { itemCardFactory } from "./factories";
 
@@ -156,5 +156,86 @@ describe("<Card> with pagination", () => {
     render(<Card card={card} cardsPerPage={4} pagination={{ page: 1, total: 3 }} />);
     expect(screen.getByTestId("card-footer")).toBeInTheDocument();
     expect(screen.getByTestId("card-pagination")).toHaveTextContent(/^Card 1 of 3$/);
+  });
+});
+
+describe("<Card> with title autofit", () => {
+  const LINE_HEIGHT_PX = 20;
+  let titleHeights: Record<string, number> = {};
+  let originalOffsetHeight: PropertyDescriptor | undefined;
+  let originalGetComputedStyle: typeof window.getComputedStyle;
+
+  beforeEach(() => {
+    originalOffsetHeight = Object.getOwnPropertyDescriptor(
+      HTMLHeadingElement.prototype,
+      "offsetHeight",
+    );
+    Object.defineProperty(HTMLHeadingElement.prototype, "offsetHeight", {
+      configurable: true,
+      get(this: HTMLHeadingElement) {
+        const fontSize = this.style.fontSize;
+        const key = fontSize === "" ? "1" : fontSize.replace("em", "");
+        return titleHeights[key] ?? 0;
+      },
+    });
+
+    originalGetComputedStyle = window.getComputedStyle;
+    window.getComputedStyle = ((el: Element, pseudo?: string | null) => {
+      const real = originalGetComputedStyle.call(window, el, pseudo);
+      if (el instanceof HTMLHeadingElement) {
+        return new Proxy(real, {
+          get(target, prop, receiver) {
+            if (prop === "lineHeight") return `${LINE_HEIGHT_PX}px`;
+            const value = Reflect.get(target, prop, receiver);
+            return typeof value === "function" ? value.bind(target) : value;
+          },
+        });
+      }
+      return real;
+    }) as typeof window.getComputedStyle;
+  });
+
+  afterEach(() => {
+    if (originalOffsetHeight) {
+      Object.defineProperty(HTMLHeadingElement.prototype, "offsetHeight", originalOffsetHeight);
+    } else {
+      delete (HTMLHeadingElement.prototype as { offsetHeight?: number }).offsetHeight;
+    }
+    window.getComputedStyle = originalGetComputedStyle;
+    titleHeights = {};
+  });
+
+  test("title that fits on one line gets no inline font-size", async () => {
+    titleHeights = { "1": LINE_HEIGHT_PX };
+    const card = itemCardFactory.build();
+    render(<Card card={card} cardsPerPage={4} />);
+    const heading = screen.getByRole("heading", { name: card.name });
+    await waitFor(() => {
+      expect(heading.style.fontSize).toBe("");
+    });
+  });
+
+  test("title that wraps at 1.0 but fits at 0.9 shrinks to 0.9em", async () => {
+    titleHeights = { "1": LINE_HEIGHT_PX * 2, "0.9": LINE_HEIGHT_PX };
+    const card = itemCardFactory.build();
+    render(<Card card={card} cardsPerPage={4} />);
+    const heading = screen.getByRole("heading", { name: card.name });
+    await waitFor(() => {
+      expect(heading.style.fontSize).toBe("0.9em");
+    });
+  });
+
+  test("title that wraps at every scale ends up unstyled (gave-up state)", async () => {
+    titleHeights = {
+      "1": LINE_HEIGHT_PX * 2,
+      "0.9": LINE_HEIGHT_PX * 2,
+      "0.8": LINE_HEIGHT_PX * 2,
+    };
+    const card = itemCardFactory.build();
+    render(<Card card={card} cardsPerPage={4} />);
+    const heading = screen.getByRole("heading", { name: card.name });
+    await waitFor(() => {
+      expect(heading.style.fontSize).toBe("");
+    });
   });
 });

--- a/src/cards/Card.tsx
+++ b/src/cards/Card.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import styles from "./Card.module.css";
 import { pickIconKey } from "./iconRules";
 import { ResolvedIcon } from "./resolveIcon";
@@ -32,13 +32,17 @@ export function Card({ card, cardsPerPage, pagination, bodyOverride }: Props) {
 
   const titleRef = useRef<HTMLHeadingElement>(null);
   const [autofit, setAutofit] = useState<AutofitState>({ kind: "unmeasured" });
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: reset key tied to inputs that change wrap behaviour
-  useEffect(() => {
-    setAutofit({ kind: "unmeasured" });
-  }, [card.id, card.name, cardsPerPage]);
+  const lastInputKeyRef = useRef<string | null>(null);
 
   useLayoutEffect(() => {
+    const inputKey = `${card.id}:${card.name}:${cardsPerPage}`;
+    if (lastInputKeyRef.current !== inputKey) {
+      lastInputKeyRef.current = inputKey;
+      if (autofit.kind !== "unmeasured") {
+        setAutofit({ kind: "unmeasured" });
+        return;
+      }
+    }
     if (autofit.kind === "gave-up") return;
     if (autofit.kind === "fitted" && autofit.scale === 1) return;
     const el = titleRef.current;
@@ -54,7 +58,7 @@ export function Card({ card, cardsPerPage, pagination, bodyOverride }: Props) {
     if (!wraps) return;
     if (autofit.scale === 0.9) setAutofit({ kind: "fitted", scale: 0.8 });
     else setAutofit({ kind: "gave-up" });
-  });
+  }, [autofit, card.id, card.name, cardsPerPage]);
 
   const titleStyle =
     autofit.kind === "fitted" && autofit.scale !== 1

--- a/src/cards/Card.tsx
+++ b/src/cards/Card.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import styles from "./Card.module.css";
 import { pickIconKey } from "./iconRules";
 import { ResolvedIcon } from "./resolveIcon";
@@ -15,6 +15,11 @@ type Props = {
   bodyOverride?: string;
 };
 
+type AutofitState =
+  | { kind: "unmeasured" }
+  | { kind: "fitted"; scale: 1 | 0.9 | 0.8 }
+  | { kind: "gave-up" };
+
 const splitParagraphs = (text: string): string[] =>
   text
     .split(/\n\s*\n/)
@@ -24,6 +29,37 @@ const splitParagraphs = (text: string): string[] =>
 export function Card({ card, cardsPerPage, pagination, bodyOverride }: Props) {
   const layoutClass = cardsPerPage === 4 ? styles.perPage4 : styles.perPage2;
   const [brokenUrl, setBrokenUrl] = useState<string | null>(null);
+
+  const titleRef = useRef<HTMLHeadingElement>(null);
+  const [autofit, setAutofit] = useState<AutofitState>({ kind: "unmeasured" });
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset key tied to inputs that change wrap behaviour
+  useEffect(() => {
+    setAutofit({ kind: "unmeasured" });
+  }, [card.id, card.name, cardsPerPage]);
+
+  useLayoutEffect(() => {
+    if (autofit.kind === "gave-up") return;
+    if (autofit.kind === "fitted" && autofit.scale === 1) return;
+    const el = titleRef.current;
+    if (!el) return;
+    const lineHeightPx = Number.parseFloat(getComputedStyle(el).lineHeight);
+    if (!Number.isFinite(lineHeightPx) || lineHeightPx <= 0) return;
+    const wraps = Math.round(el.offsetHeight / lineHeightPx) > 1;
+
+    if (autofit.kind === "unmeasured") {
+      setAutofit(wraps ? { kind: "fitted", scale: 0.9 } : { kind: "fitted", scale: 1 });
+      return;
+    }
+    if (!wraps) return;
+    if (autofit.scale === 0.9) setAutofit({ kind: "fitted", scale: 0.8 });
+    else setAutofit({ kind: "gave-up" });
+  });
+
+  const titleStyle =
+    autofit.kind === "fitted" && autofit.scale !== 1
+      ? { fontSize: `${autofit.scale}em` }
+      : undefined;
 
   // Treat empty string the same as undefined: rendering <img src=""> makes the
   // browser refetch the document URL, which doesn't fire onError reliably and
@@ -52,7 +88,9 @@ export function Card({ card, cardsPerPage, pagination, bodyOverride }: Props) {
             <ResolvedIcon iconKey={iconKey} />
           </div>
         )}
-        <h3 className={styles.title}>{card.name}</h3>
+        <h3 className={styles.title} ref={titleRef} style={titleStyle}>
+          {card.name}
+        </h3>
         {isFirstPage && card.headerTags.length > 0 && (
           <span className={styles.headerTags}>
             {card.headerTags.map((tag) => (

--- a/src/views/PrintView.module.css
+++ b/src/views/PrintView.module.css
@@ -38,8 +38,6 @@
 }
 
 .page {
-  width: 8.5in;
-  height: 11in;
   background: var(--print-color-paper);
   padding: 0.5in;
   box-sizing: border-box;
@@ -50,6 +48,8 @@
 }
 
 .perPage4 {
+  width: 8.5in;
+  height: 11in;
   grid-template-columns: 3.75in 3.75in;
   grid-template-rows: 5in 5in;
   gap: 1px; /* blade kerf for cutting */
@@ -58,8 +58,10 @@
 }
 
 .perPage2 {
-  grid-template-columns: 7.5in;
-  grid-template-rows: 5in 5in;
+  width: 11in;
+  height: 8.5in;
+  grid-template-columns: 5in 5in;
+  grid-template-rows: 7.5in;
   gap: 1px; /* blade kerf for cutting */
   justify-content: center;
   align-content: center;
@@ -82,5 +84,11 @@
     box-shadow: none;
     padding: 0;
     break-after: page;
+  }
+  @page perPage2 {
+    size: letter landscape;
+  }
+  .perPage2 {
+    page: perPage2;
   }
 }

--- a/src/views/PrintView.test.tsx
+++ b/src/views/PrintView.test.tsx
@@ -46,8 +46,8 @@ describe("<PrintView>", () => {
     await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
     await userEvent.selectOptions(screen.getByRole("combobox", { name: /cards per page/i }), "2");
     for (const page of screen.getAllByTestId("page")) {
-      expect(page).toHaveClass(styles.perPage2);
-      expect(page).not.toHaveClass(styles.perPage4);
+      expect(page).toHaveClass(styles.perPage2 as string);
+      expect(page).not.toHaveClass(styles.perPage4 as string);
     }
   });
 

--- a/src/views/PrintView.test.tsx
+++ b/src/views/PrintView.test.tsx
@@ -35,7 +35,7 @@ describe("<PrintView>", () => {
     server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json(cards)));
     render(wrap(<PrintView deckId="d1" />));
     await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
-    await userEvent.selectOptions(screen.getByLabelText(/cards per page/i), "2");
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: /cards per page/i }), "2");
     expect(screen.getAllByTestId("page")).toHaveLength(2);
   });
 
@@ -44,7 +44,7 @@ describe("<PrintView>", () => {
     server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json(cards)));
     render(wrap(<PrintView deckId="d1" />));
     await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
-    await userEvent.selectOptions(screen.getByLabelText(/cards per page/i), "2");
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: /cards per page/i }), "2");
     for (const page of screen.getAllByTestId("page")) {
       expect(page).toHaveClass(styles.perPage2);
       expect(page).not.toHaveClass(styles.perPage4);

--- a/src/views/PrintView.test.tsx
+++ b/src/views/PrintView.test.tsx
@@ -8,6 +8,7 @@ import * as paginateModule from "../cards/paginate";
 import { makeCardRow } from "../test/factories";
 import { SB_URL as SB, server } from "../test/msw";
 import { PrintView } from "./PrintView";
+import styles from "./PrintView.module.css";
 
 function wrap(ui: ReactNode) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -36,6 +37,18 @@ describe("<PrintView>", () => {
     await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
     await userEvent.selectOptions(screen.getByLabelText(/cards per page/i), "2");
     expect(screen.getAllByTestId("page")).toHaveLength(2);
+  });
+
+  test("2-up pages carry the landscape layout class", async () => {
+    const cards = makeCardRow.buildList(2);
+    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json(cards)));
+    render(wrap(<PrintView deckId="d1" />));
+    await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
+    await userEvent.selectOptions(screen.getByLabelText(/cards per page/i), "2");
+    for (const page of screen.getAllByTestId("page")) {
+      expect(page).toHaveClass(styles.perPage2);
+      expect(page).not.toHaveClass(styles.perPage4);
+    }
   });
 
   test("renders multiple physical cards for an oversized item at 4-up", async () => {

--- a/src/views/PrintView.tsx
+++ b/src/views/PrintView.tsx
@@ -30,16 +30,14 @@ export function PrintView({ deckId }: Props) {
   return (
     <div>
       <div className={styles.controls}>
-        <label>
-          Cards per page{" "}
-          <select
-            value={perPage}
-            onChange={(e) => setPerPage(Number(e.target.value) as CardsPerPage)}
-          >
-            <option value={4}>4</option>
-            <option value={2}>2</option>
-          </select>
-        </label>
+        <select
+          aria-label="Cards per page"
+          value={perPage}
+          onChange={(e) => setPerPage(Number(e.target.value) as CardsPerPage)}
+        >
+          <option value={4}>4 per page (portrait)</option>
+          <option value={2}>2 per page (landscape)</option>
+        </select>
         <Button variant="primary" onPress={() => window.print()} isDisabled={items.length === 0}>
           Print
         </Button>


### PR DESCRIPTION
### What are the relevant tickets?

N/A — design and follow-up work specced in:

- `docs/superpowers/specs/2026-05-03-two-cards-landscape-design.md`
- `docs/superpowers/specs/2026-05-03-title-autofit-design.md`

### Description (What does it do?)

Three threads landed together because they all bore on print/screen card layout and surfaced in the same review session.

#### 1. Landscape printing for 2 cards per page

The `Cards per page` toggle's 2-up mode previously produced two **landscape 7.5″×5″** cards on portrait Letter — wider than tall, visually inconsistent with 4-up's portrait cards. Now 2-up produces **two portrait 5″×7.5″ cards on landscape Letter**, same aspect family as 4-up but bigger.

- `.perPage2` dimensions swap (`Card.module.css`)
- `.page` width/height moves into per-mode classes — each layout owns its own paper size
- Named `@page perPage2 { size: letter landscape }` scoped under `@media print` and bound only to `.perPage2`, so the print dialog auto-orients without user intervention
- Dropdown options renamed `4 per page (portrait)` / `2 per page (landscape)`; the `Cards per page` text moves to `aria-label` on the `<select>`
- New test pins the layout swap (every `[data-testid="page"]` in 2-up carries the `perPage2` class)

#### 2. Card header polish

Two visual nits surfaced while reviewing the 2-up output and apply equally to 4-up:

- **Icon footprint** shrunk from 3.5em → 3em with a small negative `margin-bottom`, so the float footprint stays under 2.96em — the y-coordinate where header tags begin after a two-line title. Previously the first line of tags wrapped against the icon and left noticeable whitespace; now it runs full-width when the title spans two lines while still wrapping nicely beside short titles. Inner SVG bumped to 100% (was 85%) to keep the icon glyph visually similar despite the smaller container.
- **Tag line spacing.** `.headerTags` is now `display: block` so its `line-height: 1.2` actually applies. As an inline span it inherited the parent `.header`'s strut (computed from the larger card-base font-size), which made wrapped tag lines noticeably loose. Float-wrap behavior is preserved — plain `display: block` doesn't create a new BFC.

#### 3. Title autofit

Item names like "Flame Tongue Trident" or "Ring of Spell Storing" wrap to two lines at the default title size, often with a near-empty second line. `<Card>` now measures the rendered title after layout and steps `font-size` through `1.0 → 0.9 → 0.8`, settling at the largest scale that fits on one line. If the title still wraps at 0.8 the state lands in a terminal `gave-up` branch and renders at 1.0 with the wrap accepted.

A single `useLayoutEffect` owns reset and measurement. A ref tracks the last input key (`${card.id}:${card.name}:${cardsPerPage}`); on key change the effect resets `autofit` to `unmeasured` and returns, deferring measurement to the next render. Folding both responsibilities into one layout effect (rather than splitting reset into a separate post-paint `useEffect`) avoids a race where the layout effect would otherwise fire first against stale state on rename.

Pagination measurer is intentionally left to assume a 1.0em title (worst-case header height); a card whose title shrinks at render gets slightly more body room than measured, leading to conservative pagination but never overflow.

A historical `AutoFitCard` wrapper used to scale the *whole card* via `--scale` to recover from body overflow; it was removed when body pagination shipped. This new code revives the iterate-and-shrink pattern but scoped to the title only.

### Screenshots (if appropriate):

- [ ] Desktop — print preview at 2-per-page showing landscape orientation with two portrait cards
- [ ] Desktop — card header with a long title that autofits to one line at 0.9 or 0.8
- [ ] Desktop — card header with a 2-line title; first wrapped tag line running full-width

### How can this be tested?

**Manual (`npm run dev`):**

1. **Landscape 2-up.** Open any deck → Print. Toggle the dropdown to *2 per page (landscape)* → `Cmd+P`. Print preview should show landscape orientation with two portrait 5″×7.5″ cards side-by-side.
2. **Header polish.** Pick a card whose title wraps to two lines (e.g., a long item name). The first wrapped line of header tags should run full-width rather than being cut short by the icon. Wrapped tag-to-tag line spacing should look tight.
3. **Title autofit.** Browse cards with long titles like "Flame Tongue Trident". They should fit on one line in the editor preview and on the print sheet at slightly reduced size. Edit the title live — autofit re-runs per keystroke without flicker. A truly oversized name (jam in 50 characters) should accept the wrap at 1.0.

**Automated:**

- `Card.test.tsx` — 3 new tests stub `HTMLHeadingElement.prototype.offsetHeight` and `window.getComputedStyle().lineHeight` to drive the autofit state machine through each branch (fits at 1.0, fits at 0.9, gives up). The give-up test also tracks which scales were measured, asserting the state machine walked through `0.9` and `0.8` before settling — locks in the regression that would slip past a `style.fontSize === ""` check alone.
- `PrintView.test.tsx` — new test asserting 2-up `[data-testid=page]` elements carry the `perPage2` CSS-modules class.

### Additional Context

**Why a single-effect autofit (rather than separate reset + measurement effects).** The earlier draft used `useEffect` for reset and `useLayoutEffect` for measurement. On a `card.name` change the layout effect fires first against stale state and could measure at the wrong scale before the post-paint reset cleared things. The single-effect / ref-tracked-key pattern eliminates this race. Documented in the spec under *Reset triggers*.

**Why pagination doesn't autofit.** The off-DOM measurer in `measurer.ts` would need to iterate-and-shrink to predict accurate body fit. That's more code for a marginal win — title shrinking from 2 lines to 1 saves ~1.4em of header height, and worst-case behavior is "extra physical card", which is already an accepted fallback for body overflow.

**One deferred type-safety nit.** A review flagged that `expect(page).toHaveClass(styles.perPage2 as string)` papers over `noUncheckedIndexedAccess` rather than fully guarding it. The project already uses similar idioms (`measurer.ts`'s `cardStyles.footerTags ?? ""`), so the cast was kept. Worth tightening if this pattern spreads across the test suite.

**Branch was rebased onto origin/main** to pick up #27. The original spec commit (`660f2de`, "docs: spec for landscape 2-per-page printing") was dropped during rebase as a duplicate patch — its content ships unchanged via that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)