### PR TITLE
feat: switch deck breadcrumb to ancestors-only

### DIFF
--- a/docs/superpowers/specs/2026-05-03-deck-breadcrumbs-design.md
+++ b/docs/superpowers/specs/2026-05-03-deck-breadcrumbs-design.md
@@ -31,11 +31,11 @@ Out of scope:
 | Route | Breadcrumb |
 |---|---|
 | `/` (home), `/login`, `/auth/callback`, `/debug/icons` | `Decks` (link to `/`, current behavior) |
-| `/deck/$deckId` | `Decks` › `<deckName>` — `Decks` is a link, `<deckName>` is plain text with `aria-current="page"` |
-| `/deck/$deckId/edit/$cardId` | `Decks` › `<deckName>` — both clickable links |
-| `/deck/$deckId/print` | `Decks` › `<deckName>` — both clickable links |
+| `/deck/$deckId` | `Decks` (link only — deck name is shown by `DeckView`'s page H2; chrome doesn't repeat it) |
+| `/deck/$deckId/edit/$cardId` | `Decks` › `<deckName>` — both clickable, deck name links back to the deck |
+| `/deck/$deckId/print` | `Decks` › `<deckName>` — both clickable, deck name links back to the deck |
 
-The "current page" crumb is the deck name *only* on the deck-root route. On editor/print, neither crumb is `aria-current` because the leaf (the card or the print sheet) isn't represented in the trail.
+This is an **ancestors-only** breadcrumb: the current page is never represented in the trail. We chose this over the canonical "current-page-as-leaf" pattern because (a) the editor's leaf would be a card name that can be long or empty (new card), and (b) `DeckView` already prominently shows the deck name as an H2 — so on `/deck/$id` the breadcrumb stays minimal and the page content carries the orientation.
 
 ### Loading state
 

--- a/e2e/breadcrumb.spec.ts
+++ b/e2e/breadcrumb.spec.ts
@@ -8,13 +8,13 @@ const card = {
 };
 
 test.describe("deck breadcrumb", () => {
-  test("shows deck name on the deck route, with Decks linking home", async ({ page }) => {
+  test("shows only the Decks link on the deck root route", async ({ page }) => {
     await seedDeck(page, [card]);
     await page.goto(`/deck/${TEST_DECK_ID}`);
 
     const breadcrumb = page.getByRole("navigation", { name: "Breadcrumb" });
     await expect(breadcrumb.getByRole("link", { name: "Decks" })).toHaveAttribute("href", "/");
-    await expect(breadcrumb.getByText("E2E Test Deck")).toHaveAttribute("aria-current", "page");
+    await expect(breadcrumb.getByText("E2E Test Deck")).toHaveCount(0);
   });
 
   test("shows deck name as a back-link on the editor route", async ({ page }) => {

--- a/src/app/DeckBreadcrumb.test.tsx
+++ b/src/app/DeckBreadcrumb.test.tsx
@@ -50,16 +50,15 @@ describe("DeckBreadcrumb", () => {
     expect(screen.queryByText("›")).not.toBeInTheDocument();
   });
 
-  it("renders the deck name as current page on /deck/$id", async () => {
+  it("renders just a Decks link on the deck root route", () => {
     const deck = makeDeckRow.build();
     mockPathname = `/deck/${deck.id}`;
     server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([deck])));
     render(wrap(<DeckBreadcrumb />));
 
     expect(screen.getByRole("link", { name: "Decks" })).toHaveAttribute("href", "/");
-    const current = await screen.findByText(deck.name);
-    expect(current).toHaveAttribute("aria-current", "page");
-    expect(current.tagName).not.toBe("A");
+    expect(screen.queryByText("›")).not.toBeInTheDocument();
+    expect(screen.queryByText(deck.name)).not.toBeInTheDocument();
   });
 
   it("renders the deck name as a link on the editor route", async () => {
@@ -85,7 +84,7 @@ describe("DeckBreadcrumb", () => {
 
   it("shows an ellipsis while the deck query is pending", async () => {
     const deck = makeDeckRow.build();
-    mockPathname = `/deck/${deck.id}`;
+    mockPathname = `/deck/${deck.id}/edit/new`;
     let resolve: ((res: Response) => void) | undefined;
     server.use(
       http.get(
@@ -106,7 +105,7 @@ describe("DeckBreadcrumb", () => {
   });
 
   it("collapses to just Decks when the deck is not found", async () => {
-    mockPathname = "/deck/missing";
+    mockPathname = "/deck/missing/edit/new";
     server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([])));
     render(wrap(<DeckBreadcrumb />));
 

--- a/src/app/DeckBreadcrumb.tsx
+++ b/src/app/DeckBreadcrumb.tsx
@@ -4,7 +4,7 @@ import styles from "./root.module.css";
 
 export function DeckBreadcrumb() {
   const { pathname } = useLocation();
-  const { deckId, isAtDeckRoot } = parsePathname(pathname);
+  const deckId = parseSubdeckRoute(pathname);
   const deckQuery = useDeck(deckId);
 
   return (
@@ -20,7 +20,7 @@ export function DeckBreadcrumb() {
             <li aria-hidden="true" className={styles.separator}>
               ›
             </li>
-            <li>{renderDeckCrumb(deckQuery.data?.name, isAtDeckRoot, deckId)}</li>
+            <li>{renderDeckLink(deckQuery.data?.name, deckId)}</li>
           </>
         )}
       </ol>
@@ -28,15 +28,8 @@ export function DeckBreadcrumb() {
   );
 }
 
-function renderDeckCrumb(name: string | undefined, isAtDeckRoot: boolean, deckId: string) {
+function renderDeckLink(name: string | undefined, deckId: string) {
   if (!name) return "…";
-  if (isAtDeckRoot) {
-    return (
-      <span aria-current="page" className={styles.crumbCurrent} title={name}>
-        {name}
-      </span>
-    );
-  }
   return (
     <Link to="/deck/$deckId" params={{ deckId }} className={styles.link} title={name}>
       {name}
@@ -44,8 +37,10 @@ function renderDeckCrumb(name: string | undefined, isAtDeckRoot: boolean, deckId
   );
 }
 
-function parsePathname(pathname: string): { deckId: string | undefined; isAtDeckRoot: boolean } {
-  const m = pathname.match(/^\/deck\/([^/]+)(\/.*)?$/);
-  if (!m) return { deckId: undefined, isAtDeckRoot: false };
-  return { deckId: m[1], isAtDeckRoot: !m[2] };
+// Matches /deck/$deckId/<something>. Returns undefined on the deck root itself,
+// so the breadcrumb collapses to just "Decks" there (the deck name is already
+// shown as the page H2; chrome doesn't repeat it).
+function parseSubdeckRoute(pathname: string): string | undefined {
+  const m = pathname.match(/^\/deck\/([^/]+)\/.+$/);
+  return m?.[1];
 }

--- a/src/app/root.module.css
+++ b/src/app/root.module.css
@@ -60,11 +60,7 @@
   color: var(--color-text-muted);
 }
 
-.crumbCurrent {
-  font-weight: 600;
-}
-
-.crumbList :is(.crumbCurrent, .link) {
+.crumbList .link {
   max-width: 24ch;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
### What are the relevant tickets?

Follow-up to #24 — captures a behavior change discussed after that PR had already been merged.

### Description (What does it do?)

Drops the deck name from the breadcrumb on `/deck/$deckId` (the deck root). The trail there now shows just `Decks`. Editor and print routes are unchanged — they still show `Decks › <DeckName>` with the deck name as a back-link.

| Route | Before (#24) | After |
|---|---|---|
| `/deck/$deckId` | `Decks › <DeckName>` (deck name as `aria-current="page"` plain text) | `Decks` |
| `/deck/$deckId/edit/$cardId` | `Decks › <DeckName>` (both links) | unchanged |
| `/deck/$deckId/print` | `Decks › <DeckName>` (both links) | unchanged |

This is an **ancestors-only** breadcrumb pattern — the current page is never represented in the trail.

#### Why

Two reasons:

1. **Inconsistency.** On the editor and print routes, we already declined to show the leaf (the card name or "Print") because card titles can be long and "Print" adds no value. Showing the deck name as the leaf on `/deck/$id` while hiding the leaf on its sibling routes was the inconsistency.
2. **Redundancy.** `DeckView` already shows the deck name as a prominent H2 on the page itself. The breadcrumb chrome doesn't need to repeat it.

The tradeoff: on `/deck/$id` itself, the header gives no extra orientation beyond what's on the page. Acceptable because the H2 is right there.

### Screenshots (if appropriate):

- [ ] Desktop — `/deck/<id>` showing just `Decks` (no deck name in chrome)
- [ ] Desktop — `/deck/<id>/edit/<cardId>` showing `Decks › <DeckName>` (unchanged)

### How can this be tested?

**Manual smoke (`npm run dev`):**

1. Open any deck — header shows just `Decks` (link).
2. Click "Edit" on a card — header now shows `Decks › <DeckName>` with both clickable. Click `<DeckName>` → returns to the deck.
3. Click "Print" — same `Decks › <DeckName>` pattern.

**Automated:**

- `src/app/DeckBreadcrumb.test.tsx` — the `/deck/$id` test was rewritten to assert the absence of `›` and the deck name. Loading and not-found tests were moved to the editor route (the only route that still triggers the deck fetch).
- `e2e/breadcrumb.spec.ts` — first spec rewritten to `expect(deckName).toHaveCount(0)` on the deck root.

### Additional Context

**Why this is a separate PR.** The behavior change was decided after #24 was already merged, so the commit (`1fb2ab2` on the now-orphaned `deck-breadcrumbs` branch) couldn't ride along. This is a clean cherry-pick onto current main — single commit, no conflicts with PRs #25–#28 that landed in between.

**Spec updated.** `docs/superpowers/specs/2026-05-03-deck-breadcrumbs-design.md` was edited to reflect the ancestors-only rule and the rationale, so the spec doc no longer contradicts the code.

**Code-level cleanup that came along:** `parsePathname` (which returned `{deckId, isAtDeckRoot}`) collapsed to `parseSubdeckRoute` (returns `deckId` only when the URL is *deeper* than the deck root). The `renderDeckCrumb` helper simplified to `renderDeckLink` since the current-page branch is gone, and the unused `.crumbCurrent` CSS class was deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)