### PR TITLE
chore: add justfile and refresh README for local dev bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Then open http://localhost:5173. On the login page, use the **dev** sign-in butt
 
 - **Add a migration:** `npx supabase migration new <name>`
 - **Reset the local database:** `npx supabase db reset`
-- **Production:** migrations apply automatically via [`.github/workflows/deploy-db.yml`](.github/workflows/deploy-db.yml) on merges to `main` that touch `supabase/migrations/**`.
+- **Deploy to production:** migrations apply automatically via [`.github/workflows/deploy-db.yml`](.github/workflows/deploy-db.yml) on merges to `main` that touch `supabase/migrations/**`.
 
-Schema: `decks` and `cards` tables, gated by row-level security on the deck owner.
+**Schema:** `decks` and `cards` tables, gated by row-level security on the deck owner.
 
 ## How to print
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Then open http://localhost:5173. On the login page, use the **dev** sign-in butt
 
 ## Database
 
-`just start` brings up a local Supabase stack and applies all migrations (`supabase start` + `supabase migration up`). The Vite dev server's [`scripts/vite-supabase-env.ts`](scripts/vite-supabase-env.ts) plugin injects the local Supabase URL and anon key at boot, so a `.env.local` file is only needed when pointing local dev at a non-local Supabase.
+`just start` brings up a local Supabase stack (`supabase start`) and applies all migrations (`supabase migration up`). The Vite dev server's [`scripts/vite-supabase-env.ts`](scripts/vite-supabase-env.ts) plugin injects the local Supabase URL and anon key at boot, so a `.env.local` file is only needed when pointing local dev at a non-local Supabase.
 
 - **Add a migration:** `npx supabase migration new <name>`
 - **Reset the local database:** `npx supabase db reset`

--- a/README.md
+++ b/README.md
@@ -4,21 +4,32 @@ A browser app for creating and printing **D&D 5e item cards** with a legibility-
 
 ## Run locally
 
+**Prerequisites:**
+
+- Docker (for the local Supabase stack)
+- [`just`](https://github.com/casey/just) — `brew install just`
+- [`pre-commit`](https://pre-commit.com/) — `brew install pre-commit`
+
+**First-time setup:**
+
 ```bash
-npm install
-npm run dev
+pre-commit install
+just start
 ```
 
-Then open http://localhost:5173.
+Then open http://localhost:5173. On the login page, use the **dev** sign-in button (creates `dev@local` / `devpass` on first run).
 
-## Scripts
+`just` recipes are thin wrappers around npm scripts; running npm directly works too.
 
-- `npm run dev` — start Vite dev server
-- `npm run build` — production build to `dist/`
-- `npm run preview` — preview the production build
-- `npm test` — run Vitest suite
-- `npm run lint` — Biome lint + format check
-- `npm run lint:fix` — auto-fix lint + format
+## Database
+
+`just start` brings up a local Supabase stack and applies all migrations (`supabase start` + `supabase migration up`). The Vite dev server's [`scripts/vite-supabase-env.ts`](scripts/vite-supabase-env.ts) plugin injects the local Supabase URL and anon key at boot, so a `.env.local` file is only needed when pointing local dev at a non-local Supabase.
+
+- **Add a migration:** `npx supabase migration new <name>`
+- **Reset the local database:** `npx supabase db reset`
+- **Production:** migrations apply automatically via [`.github/workflows/deploy-db.yml`](.github/workflows/deploy-db.yml) on merges to `main` that touch `supabase/migrations/**`.
+
+Schema: `decks` and `cards` tables, gated by row-level security on the deck owner.
 
 ## How to print
 
@@ -53,5 +64,3 @@ For rationale, see the [UI refinement spec](docs/superpowers/specs/2026-04-29-ui
 
 - Design: [`docs/superpowers/specs/2026-04-19-dnd-cards-design.md`](docs/superpowers/specs/2026-04-19-dnd-cards-design.md)
 - Implementation plan: [`docs/superpowers/plans/2026-04-19-dnd-cards-v1.md`](docs/superpowers/plans/2026-04-19-dnd-cards-v1.md)
-
-Deck data is persisted in Supabase (decks + cards tables, gated by row-level security on the deck owner). For local development, run a local Supabase via `supabase start` and use the **dev** sign-in button on the login page (creates `dev@local` / `devpass` on first run). You can also **Import JSON / Export JSON** from the deck view.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,17 @@
+start:
+    npm install
+    npx supabase start
+    npx supabase migration up
+    npm run dev
+
+stop:
+    npx supabase stop
+
+test:
+    npm test
+
+test-e2e:
+    npm run test:e2e
+
+typecheck:
+    npm run typecheck

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
+    "typecheck": "tsc -b --noEmit",
     "gen:schema": "tsx scripts/gen-card-schema.ts",
     "check:schema": "tsx scripts/gen-card-schema.ts --check"
   },


### PR DESCRIPTION
### What are the relevant tickets?

Closes:

- https://github.com/ChristopherChudzicki/dnd-cards/issues/18

### Description (What does it do?)

Three small additions that make a fresh-clone contributor's path to a working app one documented command, plus a `typecheck` npm script the rest of the workflow plugs into.

#### 1. New `justfile`

Five thin recipes wrapping existing npm / `npx supabase` commands:

| Recipe | Wraps |
|---|---|
| `just start` | `npm install` → `npx supabase start` → `npx supabase migration up` → `npm run dev` |
| `just stop` | `npx supabase stop` |
| `just test` | `npm test` |
| `just test-e2e` | `npm run test:e2e` |
| `just typecheck` | `npm run typecheck` |

`just` runs each recipe line in its own shell and halts on the first non-zero exit, so a missing Docker daemon surfaces from `supabase start` and dev server is never started in a broken state — no `set -e` wiring needed. `migration up` (not `db reset`) keeps `start` non-destructive and idempotent. No comments in the file, per repo CLAUDE.md.

#### 2. New `typecheck` npm script

`"typecheck": "tsc -b --noEmit"`, clustered with the other test/check scripts. Gives `just typecheck` a real script to wrap and converges on a single source with CI's existing inline `npx tsc -b --noEmit` step.

#### 3. README rewrite

- **"Run locally"** is now `just`-first: prerequisites (Docker, `just`, `pre-commit`), then `pre-commit install` + `just start`, then a one-line acknowledgement that `just` recipes wrap npm scripts and running npm directly works too. No parallel npm block — readers who want raw commands can read `package.json` directly.
- **"Scripts" section deleted** (the npm-script bullet list). It duplicated `package.json`.
- **New "Database" section** covers local seed (`just start` runs `supabase start` + `migration up`), `npx supabase migration new <name>`, `npx supabase db reset`, the production deploy via `.github/workflows/deploy-db.yml`, and a note that `scripts/vite-supabase-env.ts` injects local creds at boot so `.env.local` is only needed when pointing local dev at non-local Supabase.
- **"Project docs" trailing paragraph slimmed** — the dev-login fact moved to "Run locally", the RLS/supabase facts moved to "Database".

### How can this be tested?

**Manual smoke (with Docker running):**

1. From a fresh clone: `brew install just pre-commit`, then `pre-commit install`, then `just start`.
2. App should come up at http://localhost:5173 with a working DB. Use the **dev** sign-in button on the login page.
3. `just stop` shuts down the local Supabase stack.
4. `just typecheck` exits 0; `just test` exits 0; `just test-e2e --help` prints Playwright usage.

**README sanity:**

```bash
grep -n -- '--dry-run' README.md          # no matches
grep -n '## Database' README.md           # exactly one match
grep -n '## Scripts' README.md            # no matches
```

Section order top-to-bottom: Run locally → Database → How to print → Design system → Project docs.

### Additional Context

**Why a justfile in a pure-npm repo at all.** This project is all npm, so a justfile is mildly superfluous *in isolation*. The point isn't local utility — it's **consistency across personal projects**. `just start` / `just test` / `just typecheck` mean the same thing whichever of my repos I'm in, even when one's npm and another's uv or cargo. LLM-friendliness is unaffected: the npm scripts stay first-class and intuitive `npm run …` commands continue to work fine.

**Why no `just dev` (skipping supabase).** Out of scope. `npm run dev` covers the iterate-without-touching-supabase loop directly; the README's npm-acknowledgement line points readers there if they want it.

**Why no `just lint` / `just format`.** Lint runs via `pre-commit` locally and `pre-commit ci` on PRs. Adding a duplicate `just` recipe would add a second source for the same thing.

**Why `just start` re-runs `npm install`.** It's the *bootstrap* verb, not the *resume work* verb. `npm install` is fast on a warm cache; the day-to-day loop can use `npm run dev` directly. If a daily-loop verb proves useful, follow-up.

**Stale issue text:** the issue mentions deploy-db.yml being "in `--dry-run` mode" and lists removing that as out-of-scope. PR #14 already removed `--dry-run`; production push is live. The new "Database" section reflects reality and doesn't reference the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)