### PR TITLE
feat: two-step magic-item import wizard with optional enrichment

### DIFF
--- a/docs/dnd5eapi-feedback.md
+++ b/docs/dnd5eapi-feedback.md
@@ -1,0 +1,116 @@
+# dnd5eapi integration notes — suggested enhancements
+
+Notes from building a magic-item import wizard against dnd5eapi. The items below surface structural fields that, if added upstream, would let consumers stop hand-parsing prose to recover information that's already logically present in the data.
+
+Endpoints involved: `/api/2014/magic-items/{index}` and `/api/2024/magic-items/{index}`.
+
+---
+
+## 1. Structured base-item reference on weapon/armor magic items
+
+**Pain:** Determining whether a magic weapon/armor applies to a specific base item or any item matching a category requires parsing `desc[0]` (2014) or the first line of `desc` (2024) with a regex — and even then, distinguishing "specific" (`Sun Blade` is always a longsword) from "any" (`Flame Tongue` works on any melee weapon) from "options" (`Dwarven Plate 2024` lists `"Half Plate Armor or Plate Armor"`) requires further heuristics.
+
+**What we currently parse:**
+
+```
+// 2014 desc[0]:  "Weapon (longsword), rare (requires attunement)"  → specific
+// 2014 desc[0]:  "Weapon (any sword), legendary (requires attunement by a paladin)" → any
+// 2024 desc[0]:  "Weapon (Any Melee Weapon)"  → any
+// 2024 desc[0]:  "Weapon (Longsword), Rare"   → specific
+```
+
+**What we wish was structured:**
+
+```jsonc
+{
+  // null when the item works on any matching base (Flame Tongue, Holy Avenger)
+  "base_equipment": { "index": "longsword", "url": "/api/equipment/longsword" },
+  // "any" | "specific" | "options"
+  "template_kind": "specific"
+}
+```
+
+A `base_equipment: null` + `template_kind: "any"` pair would let consumers build pickers ("which weapon do you want to apply this to?") without parsing prose. `"options"` would cover multi-choice cases like Dwarven Plate 2024.
+
+---
+
+## 2. Attunement parity between rulesets
+
+**Pain:** The 2024 API exposes `attunement: boolean` as a top-level field. The 2014 API does not — attunement is only encoded in `desc[0]` prose, requiring consumers to regex-detect it:
+
+```ts
+const needsAttunement = /requires attunement/i.test(desc[0]);
+```
+
+This is fragile: phrasing variants like "requires attunement by a paladin" work, but any future wording change in the content repo would silently break detection.
+
+**Suggested addition to 2014 records:**
+
+```jsonc
+{
+  "attunement": true,
+  "attunement_classes": ["paladin"]   // empty array when no class restriction
+}
+```
+
+`attunement_classes` would also be useful for 2024 records where prose currently says "requires attunement by a paladin or cleric" — that restriction is currently only in the body text.
+
+---
+
+## 3. Drop the metadata header from the `desc` body
+
+**Pain:** Both rulesets prepend `desc` (or `desc[0]`) with a line that restates information already available as structured fields — `equipment_category`, `rarity`, and `attunement`. Consumers must detect and strip this header to avoid displaying redundant information alongside the structured fields.
+
+**Current shapes:**
+
+- 2014: `desc[0]` is always `"<Type>[ (<base>)], <rarity>[, requires attunement[ by ...]]"`. Body starts at `desc[1]`.
+- 2024: the first line of the `desc` string is `"<Type>[ (<base>)]"` followed by two trailing spaces (Markdown hard-break) and `\n`. Body follows.
+
+**What we wish:** Either a separate `body` field containing only the prose description, or simply omitting the metadata line from `desc` / `desc[0]`. The metadata is already in `equipment_category`, `rarity`, and `attunement` — duplicating it in `desc` forces every consumer to strip it or display it twice.
+
+---
+
+## 4. Subtype field on non-weapon/armor magic items
+
+**Pain:** `equipment_category.name` is coarse for wondrous items and similar — it says `"Wondrous Items"` regardless of whether the item is a Wand, Rod, Staff, Ring, Potion, or Scroll. The narrower subtype only appears inside `desc[0]` (e.g. `"Wand, very rare"` or `"Ring, rare (requires attunement)"`).
+
+**Examples:**
+
+```
+// All of these share equipment_category = "Wondrous Items" in 2014:
+desc[0]: "Wand of Fireballs — Wand, rare (requires attunement by a spellcaster)"
+desc[0]: "Ring of Feather Falling — Ring, rare (requires attunement)"
+desc[0]: "Bag of Holding — Wondrous item, uncommon"
+```
+
+**Suggested addition:**
+
+```jsonc
+{ "subtype": "wand" }   // "wand" | "rod" | "staff" | "ring" | "potion" | "scroll" | null
+```
+
+This would allow icon selection, category filtering, and display grouping without prose parsing.
+
+---
+
+## 5. Shape parity between rulesets
+
+**Pain:** Several fields differ in type or presence between the 2014 and 2024 APIs, requiring branched consumer code:
+
+| Field | 2014 shape | 2024 shape |
+|---|---|---|
+| `desc` | `string[]` (array) | `string` (single string) |
+| `equipment_category` | singular object | singular object (consistent here) |
+| `attunement` | absent | `boolean` |
+
+The `desc` type flip is the most disruptive — it forces separate parsing paths for every string operation (join, slice, search).
+
+**Suggested:** Align `desc` to `string` in both rulesets (joining 2014's array with `\n\n` at the API layer), and backfill the `attunement` boolean on 2014 records. Documenting these divergences explicitly in the API reference would also help consumers who discover the difference at runtime.
+
+---
+
+## 6. Cost guidance for magic items
+
+**Pain:** Magic items have no cost field. This is canonically correct — the DMG uses rarity bands rather than fixed prices — but it creates a gap for consumers who want to display approximate value. More importantly, the absence isn't documented in the schema, so consumers must infer it from trial and error.
+
+**Suggested:** Either document in the schema that `cost` is intentionally absent on magic items and why, or add a nullable `suggested_cost?: { quantity: number; unit: "gp" } | null` for the small number of items where a canonical price exists. At minimum, a schema comment or README note would prevent confusion.

--- a/docs/dnd5eapi-feedback.md
+++ b/docs/dnd5eapi-feedback.md
@@ -8,7 +8,7 @@ Endpoints involved: `/api/2014/magic-items/{index}` and `/api/2024/magic-items/{
 
 ## 1. Structured base-item reference on weapon/armor magic items
 
-**Pain:** Determining whether a magic weapon/armor applies to a specific base item or any item matching a category requires parsing `desc[0]` (2014) or the first line of `desc` (2024) with a regex — and even then, distinguishing "specific" (`Sun Blade` is always a longsword) from "any" (`Flame Tongue` works on any melee weapon) from "options" (`Dwarven Plate 2024` lists `"Half Plate Armor or Plate Armor"`) requires further heuristics.
+**Pain:** Determining whether a magic weapon/armor applies to a specific base item or any item matching a category requires parsing `desc[0]` (2014) or the first line of `desc` (2024) with a regex — and even then, distinguishing "specific" (`Sun Blade` is always a longsword) from "any" (`Flame Tongue` works on any melee weapon) requires heuristics.
 
 **What we currently parse:**
 
@@ -25,12 +25,12 @@ Endpoints involved: `/api/2014/magic-items/{index}` and `/api/2024/magic-items/{
 {
   // null when the item works on any matching base (Flame Tongue, Holy Avenger)
   "base_equipment": { "index": "longsword", "url": "/api/equipment/longsword" },
-  // "any" | "specific" | "options"
+  // "any" | "specific"
   "template_kind": "specific"
 }
 ```
 
-A `base_equipment: null` + `template_kind: "any"` pair would let consumers build pickers ("which weapon do you want to apply this to?") without parsing prose. `"options"` would cover multi-choice cases like Dwarven Plate 2024.
+A `base_equipment: null` + `template_kind: "any"` pair would let consumers build pickers ("which weapon do you want to apply this to?") without parsing prose.
 
 ---
 
@@ -44,16 +44,23 @@ const needsAttunement = /requires attunement/i.test(desc[0]);
 
 This is fragile: phrasing variants like "requires attunement by a paladin" work, but any future wording change in the content repo would silently break detection.
 
-**Suggested addition to 2014 records:**
+Additionally, the 2024 API already exposes a `limited-to` string field for class-restricted attunement (e.g. `holy-avenger` has `"limited-to": "Paladin"`; `staff-of-power` has `"limited-to": "Sorcerer, Warlock, or Wizard"`). This is currently a prose string, which prevents machine-readable filtering.
+
+**Suggested additions:**
 
 ```jsonc
 {
   "attunement": true,
+  // structured array replacing the prose "limited-to" string in 2024;
+  // backfilled from desc[0] prose for 2014 records
   "attunement_classes": ["paladin"]   // empty array when no class restriction
 }
 ```
 
-`attunement_classes` would also be useful for 2024 records where prose currently says "requires attunement by a paladin or cleric" — that restriction is currently only in the body text.
+This would:
+1. Backfill `attunement: boolean` on 2014 records (currently absent).
+2. Structure the existing 2024 `limited-to` prose string as a typed array for machine-readability.
+3. Backfill the same `attunement_classes` field to 2014 records, where attunement constraints currently live only in `desc[0]` prose.
 
 ---
 
@@ -64,36 +71,13 @@ This is fragile: phrasing variants like "requires attunement by a paladin" work,
 **Current shapes:**
 
 - 2014: `desc[0]` is always `"<Type>[ (<base>)], <rarity>[, requires attunement[ by ...]]"`. Body starts at `desc[1]`.
-- 2024: the first line of the `desc` string is `"<Type>[ (<base>)]"` followed by two trailing spaces (Markdown hard-break) and `\n`. Body follows.
+- 2024: the first line of the `desc` string is `"<Type>[ (<base>)]"` followed by a newline. Body follows. Consumers strip through the first `\n` and trim.
 
 **What we wish:** Either a separate `body` field containing only the prose description, or simply omitting the metadata line from `desc` / `desc[0]`. The metadata is already in `equipment_category`, `rarity`, and `attunement` — duplicating it in `desc` forces every consumer to strip it or display it twice.
 
 ---
 
-## 4. Subtype field on non-weapon/armor magic items
-
-**Pain:** `equipment_category.name` is coarse for wondrous items and similar — it says `"Wondrous Items"` regardless of whether the item is a Wand, Rod, Staff, Ring, Potion, or Scroll. The narrower subtype only appears inside `desc[0]` (e.g. `"Wand, very rare"` or `"Ring, rare (requires attunement)"`).
-
-**Examples:**
-
-```
-// All of these share equipment_category = "Wondrous Items" in 2014:
-desc[0]: "Wand of Fireballs — Wand, rare (requires attunement by a spellcaster)"
-desc[0]: "Ring of Feather Falling — Ring, rare (requires attunement)"
-desc[0]: "Bag of Holding — Wondrous item, uncommon"
-```
-
-**Suggested addition:**
-
-```jsonc
-{ "subtype": "wand" }   // "wand" | "rod" | "staff" | "ring" | "potion" | "scroll" | null
-```
-
-This would allow icon selection, category filtering, and display grouping without prose parsing.
-
----
-
-## 5. Shape parity between rulesets
+## 4. Shape parity between rulesets
 
 **Pain:** Several fields differ in type or presence between the 2014 and 2024 APIs, requiring branched consumer code:
 
@@ -102,6 +86,7 @@ This would allow icon selection, category filtering, and display grouping withou
 | `desc` | `string[]` (array) | `string` (single string) |
 | `equipment_category` | singular object | singular object (consistent here) |
 | `attunement` | absent | `boolean` |
+| `limited-to` | absent | `string` (prose) |
 
 The `desc` type flip is the most disruptive — it forces separate parsing paths for every string operation (join, slice, search).
 
@@ -109,7 +94,7 @@ The `desc` type flip is the most disruptive — it forces separate parsing paths
 
 ---
 
-## 6. Cost guidance for magic items
+## 5. Cost guidance for magic items
 
 **Pain:** Magic items have no cost field. This is canonically correct — the DMG uses rarity bands rather than fixed prices — but it creates a gap for consumers who want to display approximate value. More importantly, the absence isn't documented in the schema, so consumers must infer it from trial and error.
 

--- a/docs/superpowers/plans/2026-05-03-import-enrichment-wizard.md
+++ b/docs/superpowers/plans/2026-05-03-import-enrichment-wizard.md
@@ -1,0 +1,1359 @@
+# Card Metadata + Import Enrichment Wizard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Adopt a canonical tag order on item cards (header = `[type, damage/AC, attunement]`; footer = `[rarity, cost, weight]`), and turn the magic-item importer into a two-step wizard whose optional second step pulls structured damage/AC/weight from the corresponding mundane equipment record.
+
+**Architecture:** The dnd5eapi splits "magic items" and "equipment" across two endpoints. Magic items expose `equipment_category`, `rarity`, `attunement` (2024 only — 2014 is parsed from prose), and `desc`, but no structured damage/AC/cost/weight. Equipment exposes `damage`, `armor_class`, `weight`, `cost`. We layer a second import step on top of the existing magic-items pick: classify the magic item by `equipment_category` and the parenthetical in `desc[0]`, then either skip (wands, wondrous items, …), pre-filter the equipment picker (templates like Flame Tongue's "any sword"), or auto-select the obvious base (specific items like Sun Blade's "longsword"). User can override or skip in any case. Cost is **never** auto-filled — a mundane longsword's 15 gp is misleading for Sun Blade. Weight, damage, and AC are filled because they genuinely transfer.
+
+**Tech Stack:** React 19 + TypeScript, react-aria-components, TanStack Query, Vitest + RTL + user-event, MSW, Fishery + faker.
+
+**Reference background:** Spec discussion in conversation on 2026-05-03 (no separate spec doc). Confirmed against the live API for Flame Tongue (template), Sun Blade / Holy Avenger / Dwarven Thrower (specific weapons), Dwarven Plate (specific armor), and the corresponding `/equipment` records (longsword, plate-armor, trident).
+
+**Out of scope (explicit):**
+
+- Spell import (separate plan; wizard shell should remain extensible but we won't add the kind selector here).
+- Mundane-item primary import (likewise).
+- Auto-fill of cost.
+- Free-text damage parsing for magic riders (e.g. Flame Tongue's "+2d6 fire", Sun Blade's "+1d8 vs undead"). User edits if they want them.
+
+---
+
+## Tag layout & canonical order
+
+After this plan, a freshly imported magic item produces tags in this order:
+
+| Slot | Source | Example (Sun Blade with longsword enrichment) |
+|---|---|---|
+| header[0] | `equipment_category.name` | `Weapon` |
+| header[1] | enrichment damage (if weapon) | `1d8 slashing` |
+| header[1] | enrichment AC (if armor) | `AC 18` |
+| header[2] | attunement | `requires attunement` |
+| footer[0] | `rarity.name` (lowercased) | `rare` |
+| footer[1] | enrichment weight | `3 lb` |
+
+Note: rarity **moves from header → footer** (current code puts it in header). The display separator (`·`) and rendering already exist in `Card.tsx`.
+
+For non-enrichable magic items (wand, wondrous item, potion, ring, …): header = `[type, attunement?]`; footer = `[rarity]`. No equipment lookup.
+
+For "any X" templates (`Weapon (any sword)`, `Weapon (Any Melee Weapon)`): the picker opens with the equipment list pre-filtered to the hint, no auto-pick, user chooses or skips.
+
+For specific items (`Weapon (longsword)`, `Armor (plate)`): the picker opens with a single equipment item auto-selected (when exactly one match), still user-overridable; pressing Skip lands the card without enrichment.
+
+---
+
+## File map
+
+**Create:**
+
+- `src/api/endpoints/equipment.ts` — `fetchEquipmentIndex(ruleset)`, `fetchEquipmentDetail(ruleset, slug)`, ruleset-tagged types
+- `src/api/endpoints/equipment.test.ts` — endpoint tests via MSW
+- `src/api/mappers/equipment.ts` — pure helpers: `equipmentToHeaderInsert`, `equipmentToFooterInsert`
+- `src/api/mappers/equipment.test.ts`
+- `src/api/mappers/baseHint.ts` — `parseBaseHint(desc0)` → `{ kind: "specific" | "any" | "none", hint: string }`
+- `src/api/mappers/baseHint.test.ts`
+- `src/views/EnrichmentStep.tsx` — step-2 equipment picker (filtered list, auto-selection, Skip / Confirm)
+- `src/views/EnrichmentStep.module.css`
+- `src/views/EnrichmentStep.test.tsx`
+
+**Modify:**
+
+- `src/api/mappers/magicItems.ts` — rarity moves from header to footer; export `magicItemDetailToCard(detail, enrichment?)`; `enrichment` splices damage/AC into header position 1 and weight into footer position 1
+- `src/api/mappers/magicItems.test.ts` — assertions updated for new layout; add enrichment cases (with weapon, with armor, no enrichment)
+- `src/api/hooks.ts` — add `useEquipmentIndex(ruleset)`
+- `src/views/BrowseApiModal.tsx` — refactored into a two-step state machine; step 1 unchanged in behavior except that picking now branches into "save & close" vs "advance to enrichment"
+- `src/views/BrowseApiModal.test.tsx` — add wizard flow tests (template path, specific path, skip path, non-enrichable path)
+- `src/cards/ItemEditor.tsx` — add help text under each TagInput field
+- `src/cards/ItemEditor.test.tsx` — assert help text is present
+- `src/test/msw.ts` — add `/api/{ruleset}/equipment` index + detail handlers (+ a couple of fixture entries: `longsword`, `plate-armor`)
+- `src/api/factories.ts` — add `equipmentDetailFactory` (or similar) for tests if the existing factory style benefits
+
+**No change required:**
+
+- `src/cards/Card.tsx`, `src/cards/types.ts` — `headerTags`/`footerTags` already render correctly; the canonical order is enforced by the import path, not the type.
+
+---
+
+## Order of work
+
+Each task lands as its own commit. The repo compiles and tests pass green at every task boundary.
+
+1. **Tag layout shift + form help text** — move rarity from header to footer in the magic-item mapper; update existing tests; add help text in ItemEditor. Small, no new files.
+2. **`baseHint` parser** — pure function, fully tested, no UI consumers yet.
+3. **Equipment endpoint** — fetch + types + MSW handlers + endpoint tests.
+4. **Equipment tag mappers** — pure helpers for header (damage / AC) and footer (weight) insertions.
+5. **`magicItemDetailToCard` accepts enrichment** — extend signature, splice tags at canonical positions.
+6. **`useEquipmentIndex` hook** — TanStack Query wrapper.
+7. **`EnrichmentStep` component** — equipment picker with auto-select, search, Skip / Confirm.
+8. **`BrowseApiModal` step machine** — refactor to two-step flow; integrate `EnrichmentStep`.
+9. **Verification** — type-check, full test run, manual exercise of each branch.
+
+Tasks 2, 3, 4 are independent; they could be done in parallel by separate workers. Task 5 depends on 4. Task 7 depends on 2, 3, 6. Task 8 depends on 5 and 7.
+
+---
+
+## Conventions reminder
+
+Repo CLAUDE.md and user CLAUDE.md set norms that apply throughout:
+
+- Tests: prefer `getByRole`. Factories pass no values they don't assert on.
+- Code: default no comments; only when WHY is non-obvious.
+- React Aria primitives expose accurate roles — don't add `data-testid` when a role is available.
+- Don't push or open PRs without explicit instruction.
+- `npm test`, `npm run dev`, `npm run build`, `npm run typecheck` are pre-approved.
+
+---
+
+## Task 1: Move rarity to footer + add ItemEditor help text
+
+**Files:**
+
+- Modify: `src/api/mappers/magicItems.ts`
+- Modify: `src/api/mappers/magicItems.test.ts`
+- Modify: `src/cards/ItemEditor.tsx`
+- Modify: `src/cards/ItemEditor.test.tsx`
+
+- [ ] **Step 1: Update mapper tests for the new layout**
+
+In `src/api/mappers/magicItems.test.ts`, change assertions so that rarity is in `footerTags`, not `headerTags`.
+
+```ts
+// 2014 magic item without attunement
+expect(card.headerTags).toEqual(["Weapon"]);
+expect(card.footerTags).toEqual(["rare"]);
+
+// 2014 magic item with attunement (parsed from desc[0])
+expect(card.headerTags).toEqual(["Weapon", "requires attunement"]);
+expect(card.footerTags).toEqual(["rare"]);
+
+// 2024 magic item with attunement boolean
+expect(card.headerTags).toEqual(["Weapon", "requires attunement"]);
+expect(card.footerTags).toEqual(["rare"]);
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```
+npm test -- src/api/mappers/magicItems.test.ts
+```
+
+Expected: failures showing rarity still in `headerTags`.
+
+- [ ] **Step 3: Update mapper to put rarity in footer**
+
+In `src/api/mappers/magicItems.ts`, replace the existing `composeHeaderTags` with two helpers:
+
+```ts
+const composeHeaderTags = (category: string, attunement: boolean): string[] => {
+  const tags = [category];
+  if (attunement) tags.push("requires attunement");
+  return tags;
+};
+
+const composeFooterTags = (rarity: string): string[] => [rarity.toLowerCase()];
+```
+
+Update both `if (detail.ruleset === "2024")` and the 2014 fallback:
+
+```ts
+return {
+  ...common,
+  headerTags: composeHeaderTags(
+    detail.equipment_category.name,
+    detail.attunement,
+  ),
+  body: detail.desc,
+  footerTags: composeFooterTags(detail.rarity.name),
+};
+```
+
+```ts
+return {
+  ...common,
+  headerTags: composeHeaderTags(
+    detail.equipment_category.name,
+    detectAttunement2014(detail.desc[0]),
+  ),
+  body: detail.desc.join("\n\n"),
+  footerTags: composeFooterTags(detail.rarity.name),
+};
+```
+
+- [ ] **Step 4: Run mapper tests**
+
+```
+npm test -- src/api/mappers/magicItems.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Add a failing test for ItemEditor help text**
+
+In `src/cards/ItemEditor.test.tsx`, add a test that the help text is rendered:
+
+```ts
+it("renders header tag help text", () => {
+  const card = makeItemCard();
+  render(<ItemEditor card={card} onChange={vi.fn()} />);
+  expect(
+    screen.getByText(/type first, then damage\/AC, then attunement/i),
+  ).toBeInTheDocument();
+});
+
+it("renders footer tag help text", () => {
+  const card = makeItemCard();
+  render(<ItemEditor card={card} onChange={vi.fn()} />);
+  expect(
+    screen.getByText(/rarity first, then cost, then weight/i),
+  ).toBeInTheDocument();
+});
+```
+
+(Use whatever item-card factory already exists — search `src/cards/factories.ts`. If the factory is named differently, swap.)
+
+- [ ] **Step 6: Run new tests; confirm they fail**
+
+```
+npm test -- src/cards/ItemEditor.test.tsx
+```
+
+Expected: failures — text not found.
+
+- [ ] **Step 7: Add help text to ItemEditor**
+
+In `src/cards/ItemEditor.tsx`, add a `<span className={styles.help}>` under each TagInput:
+
+```tsx
+<div className={styles.field}>
+  <span className={styles.label} id={ids.headerTagsLabel}>
+    Header tags
+  </span>
+  <TagInput
+    id={ids.headerTags}
+    aria-labelledby={ids.headerTagsLabel}
+    value={card.headerTags}
+    onChange={handleHeaderTagsChange}
+    placeholder="Type and press Enter — e.g. Weapon, 1d6 piercing, requires attunement"
+  />
+  <span className={styles.help}>
+    Type first, then damage/AC, then attunement.
+  </span>
+</div>
+```
+
+```tsx
+<div className={styles.field}>
+  <span className={styles.label} id={ids.footerTagsLabel}>
+    Footer tags
+  </span>
+  <TagInput
+    id={ids.footerTags}
+    aria-labelledby={ids.footerTagsLabel}
+    value={card.footerTags}
+    onChange={handleFooterTagsChange}
+    placeholder="Type and press Enter — e.g. rare, 100 gp, 10 lb"
+  />
+  <span className={styles.help}>
+    Rarity first, then cost, then weight.
+  </span>
+</div>
+```
+
+Update placeholders as shown above (the old "rare" was technically header; new placeholders match the canonical layout).
+
+Drop the `(type, rarity, …)` / `(cost, weight, …)` parenthetical hints in the labels since the help text now covers that more precisely.
+
+- [ ] **Step 8: Add `.help` style**
+
+In `src/cards/ItemEditor.module.css`, add a `.help` class. Match the existing `.iconHint` style — same intent (small, muted helper text):
+
+```css
+.help {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  margin-top: var(--space-1);
+}
+```
+
+(Confirm the actual token names in `src/index.css` and adjust if the project uses different names.)
+
+- [ ] **Step 9: Run tests**
+
+```
+npm test -- src/cards/ItemEditor.test.tsx
+npm test -- src/api/mappers/magicItems.test.ts
+```
+
+Expected: all pass.
+
+- [ ] **Step 10: Run full suite and typecheck**
+
+```
+npm test
+npm run typecheck
+```
+
+Expected: green.
+
+- [ ] **Step 11: Commit**
+
+```
+git add src/api/mappers/magicItems.ts src/api/mappers/magicItems.test.ts \
+        src/cards/ItemEditor.tsx src/cards/ItemEditor.module.css src/cards/ItemEditor.test.tsx
+git commit -m "feat: canonical tag order — rarity in footer, ItemEditor help text"
+```
+
+---
+
+## Task 2: `baseHint` parser
+
+**Files:**
+
+- Create: `src/api/mappers/baseHint.ts`
+- Create: `src/api/mappers/baseHint.test.ts`
+
+**Purpose:** Given the first paragraph of a magic-item description, classify it as a "specific" base, an "any X" template, or no signal. The hint is later used to filter / auto-select an equipment record.
+
+**Inputs observed in API:**
+
+- `"Weapon (any sword), legendary (requires attunement by a paladin)"` → `{ kind: "any", hint: "sword" }`
+- `"Weapon (longsword), rare (requires attunement)"` → `{ kind: "specific", hint: "longsword" }`
+- `"Weapon (warhammer), very rare (requires attunement by a dwarf)"` → `{ kind: "specific", hint: "warhammer" }`
+- `"Armor (plate), very rare"` → `{ kind: "specific", hint: "plate" }`
+- `"Weapon (any sword), rare (requires attunement)"` (Flame Tongue 2014) → `{ kind: "any", hint: "sword" }`
+- `"Weapon (Any Melee Weapon)"` (Flame Tongue 2024 — capitalized) → `{ kind: "any", hint: "melee weapon" }`
+- `"Wondrous item, rare (requires attunement by a sorcerer, warlock, or wizard)"` → `{ kind: "none", hint: "" }`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// src/api/mappers/baseHint.test.ts
+import { describe, it, expect } from "vitest";
+import { parseBaseHint } from "./baseHint";
+
+describe("parseBaseHint", () => {
+  it("identifies a specific weapon base", () => {
+    expect(parseBaseHint("Weapon (longsword), rare (requires attunement)"))
+      .toEqual({ kind: "specific", hint: "longsword" });
+  });
+
+  it("identifies an 'any X' weapon template", () => {
+    expect(parseBaseHint("Weapon (any sword), legendary (requires attunement by a paladin)"))
+      .toEqual({ kind: "any", hint: "sword" });
+  });
+
+  it("identifies a specific armor base", () => {
+    expect(parseBaseHint("Armor (plate), very rare"))
+      .toEqual({ kind: "specific", hint: "plate" });
+  });
+
+  it("normalizes mixed-case 2024-style hints", () => {
+    expect(parseBaseHint("Weapon (Any Melee Weapon)"))
+      .toEqual({ kind: "any", hint: "melee weapon" });
+    expect(parseBaseHint("Weapon (Longsword), Rare"))
+      .toEqual({ kind: "specific", hint: "longsword" });
+  });
+
+  it("returns 'none' for non-weapon/armor descriptions", () => {
+    expect(parseBaseHint("Wondrous item, rare (requires attunement)"))
+      .toEqual({ kind: "none", hint: "" });
+    expect(parseBaseHint("Wand, very rare"))
+      .toEqual({ kind: "none", hint: "" });
+  });
+
+  it("returns 'none' for empty / undefined input", () => {
+    expect(parseBaseHint(undefined)).toEqual({ kind: "none", hint: "" });
+    expect(parseBaseHint("")).toEqual({ kind: "none", hint: "" });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests; confirm they fail**
+
+```
+npm test -- src/api/mappers/baseHint.test.ts
+```
+
+Expected: module-not-found / function-not-defined.
+
+- [ ] **Step 3: Implement parser**
+
+```ts
+// src/api/mappers/baseHint.ts
+export type BaseHint =
+  | { kind: "specific"; hint: string }
+  | { kind: "any"; hint: string }
+  | { kind: "none"; hint: "" };
+
+const RE = /^(?:Weapon|Armor)\s*\(([^)]+)\)/i;
+
+export const parseBaseHint = (desc0: string | undefined): BaseHint => {
+  if (!desc0) return { kind: "none", hint: "" };
+  const match = RE.exec(desc0.trim());
+  if (!match) return { kind: "none", hint: "" };
+  const inner = match[1].trim().toLowerCase();
+  if (inner.startsWith("any ")) {
+    return { kind: "any", hint: inner.slice(4).trim() };
+  }
+  return { kind: "specific", hint: inner };
+};
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+npm test -- src/api/mappers/baseHint.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/api/mappers/baseHint.ts src/api/mappers/baseHint.test.ts
+git commit -m "feat: parseBaseHint — classify magic-item base from desc[0]"
+```
+
+---
+
+## Task 3: Equipment endpoint + MSW
+
+**Files:**
+
+- Create: `src/api/endpoints/equipment.ts`
+- Create: `src/api/endpoints/equipment.test.ts`
+- Modify: `src/test/msw.ts`
+
+**Note on shape:** 2014 equipment uses `equipment_category` (single object); 2024 uses `equipment_categories` (array). Our consumer only needs the fields that ARE shared: `damage`, `armor_class`, `weight`, `cost`, `name`, `index`. Type cleanly to those.
+
+`armor_class` shape varies: 2014 returns `{ base, dex_bonus, max_bonus? }`; 2024 returns the same in practice for plate/half-plate. Type as a union if needed; for our use we only read `base`.
+
+`damage` shape: `{ damage_dice: string, damage_type: { name: string } }`. Both rulesets.
+
+- [ ] **Step 1: Write failing endpoint tests**
+
+```ts
+// src/api/endpoints/equipment.test.ts
+import { describe, it, expect } from "vitest";
+import { fetchEquipmentIndex, fetchEquipmentDetail } from "./equipment";
+
+describe("equipment endpoints", () => {
+  it("fetches index for 2014", async () => {
+    const idx = await fetchEquipmentIndex("2014");
+    expect(idx.results.length).toBeGreaterThan(0);
+    expect(idx.results.find((e) => e.index === "longsword")).toBeDefined();
+  });
+
+  it("fetches a 2014 weapon detail", async () => {
+    const detail = await fetchEquipmentDetail("2014", "longsword");
+    expect(detail.name).toBe("Longsword");
+    expect(detail.damage?.damage_dice).toBe("1d8");
+    expect(detail.damage?.damage_type.name).toBe("Slashing");
+    expect(detail.weight).toBe(3);
+  });
+
+  it("fetches a 2014 armor detail", async () => {
+    const detail = await fetchEquipmentDetail("2014", "plate-armor");
+    expect(detail.name).toBe("Plate Armor");
+    expect(detail.armor_class?.base).toBe(18);
+    expect(detail.weight).toBe(65);
+  });
+});
+```
+
+- [ ] **Step 2: Add MSW handlers + fixtures**
+
+In `src/test/msw.ts`, add handlers mirroring the existing magic-item ones. Put two fixtures inline (keep tests self-contained) — `longsword`, `plate-armor` for 2014.
+
+```ts
+// inside the existing handlers array
+http.get("https://www.dnd5eapi.co/api/2014/equipment", () =>
+  HttpResponse.json({
+    count: 2,
+    results: [
+      { index: "longsword", name: "Longsword", url: "/api/2014/equipment/longsword" },
+      { index: "plate-armor", name: "Plate Armor", url: "/api/2014/equipment/plate-armor" },
+    ],
+  }),
+),
+http.get("https://www.dnd5eapi.co/api/2014/equipment/longsword", () =>
+  HttpResponse.json({
+    index: "longsword",
+    name: "Longsword",
+    equipment_category: { index: "weapon", name: "Weapon", url: "" },
+    weapon_category: "Martial",
+    weapon_range: "Melee",
+    cost: { quantity: 15, unit: "gp" },
+    damage: { damage_dice: "1d8", damage_type: { index: "slashing", name: "Slashing", url: "" } },
+    weight: 3,
+  }),
+),
+http.get("https://www.dnd5eapi.co/api/2014/equipment/plate-armor", () =>
+  HttpResponse.json({
+    index: "plate-armor",
+    name: "Plate Armor",
+    equipment_category: { index: "armor", name: "Armor", url: "" },
+    armor_category: "Heavy",
+    armor_class: { base: 18, dex_bonus: false },
+    str_minimum: 15,
+    stealth_disadvantage: true,
+    weight: 65,
+    cost: { quantity: 1500, unit: "gp" },
+  }),
+),
+```
+
+(If `src/test/msw.ts` exposes its handler list differently, follow the existing pattern. Look at the magic-items handlers for a template.)
+
+- [ ] **Step 3: Run tests; confirm they fail**
+
+```
+npm test -- src/api/endpoints/equipment.test.ts
+```
+
+Expected: module-not-found.
+
+- [ ] **Step 4: Implement endpoint module**
+
+```ts
+// src/api/endpoints/equipment.ts
+import { apiGet } from "../apiClient";
+import type { Ruleset } from "./magicItems";
+
+export type EquipmentIndexEntry = {
+  index: string;
+  name: string;
+  url: string;
+};
+
+export type EquipmentIndex = {
+  count: number;
+  results: EquipmentIndexEntry[];
+};
+
+export type EquipmentDamage = {
+  damage_dice: string;
+  damage_type: { name: string };
+};
+
+export type EquipmentArmorClass = {
+  base: number;
+  dex_bonus?: boolean;
+  max_bonus?: number;
+};
+
+export type EquipmentDetail = {
+  index: string;
+  name: string;
+  damage?: EquipmentDamage;
+  armor_class?: EquipmentArmorClass;
+  weight?: number;
+  cost?: { quantity: number; unit: string };
+};
+
+export const fetchEquipmentIndex = (ruleset: Ruleset): Promise<EquipmentIndex> =>
+  apiGet<EquipmentIndex>(`/api/${ruleset}/equipment`);
+
+export const fetchEquipmentDetail = (
+  ruleset: Ruleset,
+  slug: string,
+): Promise<EquipmentDetail> =>
+  apiGet<EquipmentDetail>(`/api/${ruleset}/equipment/${slug}`);
+```
+
+- [ ] **Step 5: Run tests**
+
+```
+npm test -- src/api/endpoints/equipment.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/api/endpoints/equipment.ts src/api/endpoints/equipment.test.ts src/test/msw.ts
+git commit -m "feat: equipment endpoint (index + detail) for both rulesets"
+```
+
+---
+
+## Task 4: Equipment tag mappers
+
+**Files:**
+
+- Create: `src/api/mappers/equipment.ts`
+- Create: `src/api/mappers/equipment.test.ts`
+
+**Purpose:** Pure functions producing the strings to splice into header / footer when enriching a magic item.
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// src/api/mappers/equipment.test.ts
+import { describe, it, expect } from "vitest";
+import { equipmentToHeaderInsert, equipmentToFooterInsert } from "./equipment";
+import type { EquipmentDetail } from "../endpoints/equipment";
+
+const longsword: EquipmentDetail = {
+  index: "longsword",
+  name: "Longsword",
+  damage: { damage_dice: "1d8", damage_type: { name: "Slashing" } },
+  weight: 3,
+};
+
+const plateArmor: EquipmentDetail = {
+  index: "plate-armor",
+  name: "Plate Armor",
+  armor_class: { base: 18, dex_bonus: false },
+  weight: 65,
+};
+
+const noShape: EquipmentDetail = { index: "abacus", name: "Abacus" };
+
+describe("equipmentToHeaderInsert", () => {
+  it("formats weapon damage", () => {
+    expect(equipmentToHeaderInsert(longsword)).toBe("1d8 slashing");
+  });
+
+  it("formats armor AC", () => {
+    expect(equipmentToHeaderInsert(plateArmor)).toBe("AC 18");
+  });
+
+  it("returns null for items with neither damage nor AC", () => {
+    expect(equipmentToHeaderInsert(noShape)).toBeNull();
+  });
+});
+
+describe("equipmentToFooterInsert", () => {
+  it("formats weight in lb", () => {
+    expect(equipmentToFooterInsert(longsword)).toBe("3 lb");
+    expect(equipmentToFooterInsert(plateArmor)).toBe("65 lb");
+  });
+
+  it("returns null when weight is missing or zero", () => {
+    expect(equipmentToFooterInsert(noShape)).toBeNull();
+    expect(equipmentToFooterInsert({ ...longsword, weight: 0 })).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests; confirm they fail**
+
+```
+npm test -- src/api/mappers/equipment.test.ts
+```
+
+- [ ] **Step 3: Implement helpers**
+
+```ts
+// src/api/mappers/equipment.ts
+import type { EquipmentDetail } from "../endpoints/equipment";
+
+export const equipmentToHeaderInsert = (e: EquipmentDetail): string | null => {
+  if (e.damage) {
+    return `${e.damage.damage_dice} ${e.damage.damage_type.name.toLowerCase()}`;
+  }
+  if (e.armor_class) {
+    return `AC ${e.armor_class.base}`;
+  }
+  return null;
+};
+
+export const equipmentToFooterInsert = (e: EquipmentDetail): string | null => {
+  if (!e.weight) return null;
+  return `${e.weight} lb`;
+};
+```
+
+- [ ] **Step 4: Run tests**
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/api/mappers/equipment.ts src/api/mappers/equipment.test.ts
+git commit -m "feat: equipment tag mappers (damage/AC header, weight footer)"
+```
+
+---
+
+## Task 5: `magicItemDetailToCard` accepts enrichment
+
+**Files:**
+
+- Modify: `src/api/mappers/magicItems.ts`
+- Modify: `src/api/mappers/magicItems.test.ts`
+
+**Goal:** When called with a second argument (the resolved equipment detail), splice damage/AC into header position 1 (between type and attunement) and weight into footer position 1 (between rarity and any future cost).
+
+- [ ] **Step 1: Add failing tests**
+
+```ts
+// in src/api/mappers/magicItems.test.ts
+import type { EquipmentDetail } from "../endpoints/equipment";
+
+const longsword: EquipmentDetail = {
+  index: "longsword",
+  name: "Longsword",
+  damage: { damage_dice: "1d8", damage_type: { name: "Slashing" } },
+  weight: 3,
+};
+
+const plate: EquipmentDetail = {
+  index: "plate-armor",
+  name: "Plate Armor",
+  armor_class: { base: 18 },
+  weight: 65,
+};
+
+it("splices weapon damage into header and weight into footer", () => {
+  const card = magicItemDetailToCard(sunBlade2014Detail, longsword);
+  expect(card.headerTags).toEqual(["Weapon", "1d8 slashing", "requires attunement"]);
+  expect(card.footerTags).toEqual(["rare", "3 lb"]);
+});
+
+it("splices armor AC into header and weight into footer", () => {
+  const card = magicItemDetailToCard(dwarvenPlate2014Detail, plate);
+  expect(card.headerTags).toEqual(["Armor", "AC 18"]);
+  expect(card.footerTags).toEqual(["very rare", "65 lb"]);
+});
+
+it("omits header insert when equipment has neither damage nor AC", () => {
+  const card = magicItemDetailToCard(sunBlade2014Detail, {
+    index: "x", name: "X",
+  });
+  expect(card.headerTags).toEqual(["Weapon", "requires attunement"]);
+  expect(card.footerTags).toEqual(["rare"]);
+});
+
+it("works without enrichment (existing behavior)", () => {
+  const card = magicItemDetailToCard(sunBlade2014Detail);
+  expect(card.headerTags).toEqual(["Weapon", "requires attunement"]);
+  expect(card.footerTags).toEqual(["rare"]);
+});
+```
+
+(`sunBlade2014Detail` and `dwarvenPlate2014Detail` are local test fixtures — define them at the top of the test file. The existing test file already has fixtures for the basic cases; mirror that style.)
+
+- [ ] **Step 2: Run tests; confirm they fail**
+
+```
+npm test -- src/api/mappers/magicItems.test.ts
+```
+
+- [ ] **Step 3: Refactor mapper to accept enrichment**
+
+```ts
+// src/api/mappers/magicItems.ts
+import type { ItemCard } from "../../cards/types";
+import { newId } from "../../lib/id";
+import { nowIso } from "../../lib/time";
+import type { EquipmentDetail } from "../endpoints/equipment";
+import {
+  equipmentToFooterInsert,
+  equipmentToHeaderInsert,
+} from "./equipment";
+import type { MagicItemDetail } from "../endpoints/magicItems";
+
+const IMAGE_BASE = "https://www.dnd5eapi.co";
+
+const composeHeaderTags = (
+  category: string,
+  attunement: boolean,
+  enrichment: EquipmentDetail | undefined,
+): string[] => {
+  const tags = [category];
+  const insert = enrichment ? equipmentToHeaderInsert(enrichment) : null;
+  if (insert) tags.push(insert);
+  if (attunement) tags.push("requires attunement");
+  return tags;
+};
+
+const composeFooterTags = (
+  rarity: string,
+  enrichment: EquipmentDetail | undefined,
+): string[] => {
+  const tags = [rarity.toLowerCase()];
+  const insert = enrichment ? equipmentToFooterInsert(enrichment) : null;
+  if (insert) tags.push(insert);
+  return tags;
+};
+
+const detectAttunement2014 = (firstLine: string | undefined): boolean =>
+  firstLine !== undefined && /requires attunement/i.test(firstLine);
+
+export const magicItemDetailToCard = (
+  detail: MagicItemDetail,
+  enrichment?: EquipmentDetail,
+): ItemCard => {
+  const now = nowIso();
+  const common = {
+    id: newId(),
+    kind: "item" as const,
+    name: detail.name,
+    source: "api" as const,
+    apiRef: {
+      system: "dnd5eapi" as const,
+      slug: detail.index,
+      ruleset: detail.ruleset,
+    },
+    imageUrl: detail.image ? `${IMAGE_BASE}${detail.image}` : undefined,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  if (detail.ruleset === "2024") {
+    return {
+      ...common,
+      headerTags: composeHeaderTags(
+        detail.equipment_category.name,
+        detail.attunement,
+        enrichment,
+      ),
+      body: detail.desc,
+      footerTags: composeFooterTags(detail.rarity.name, enrichment),
+    };
+  }
+
+  return {
+    ...common,
+    headerTags: composeHeaderTags(
+      detail.equipment_category.name,
+      detectAttunement2014(detail.desc[0]),
+      enrichment,
+    ),
+    body: detail.desc.join("\n\n"),
+    footerTags: composeFooterTags(detail.rarity.name, enrichment),
+  };
+};
+```
+
+- [ ] **Step 4: Run tests**
+
+```
+npm test -- src/api/mappers/magicItems.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/api/mappers/magicItems.ts src/api/mappers/magicItems.test.ts
+git commit -m "feat: magicItemDetailToCard accepts optional equipment enrichment"
+```
+
+---
+
+## Task 6: `useEquipmentIndex` hook
+
+**Files:**
+
+- Modify: `src/api/hooks.ts`
+
+- [ ] **Step 1: Add the hook**
+
+```ts
+// src/api/hooks.ts — append
+import {
+  fetchEquipmentDetail,
+  fetchEquipmentIndex,
+} from "./endpoints/equipment";
+
+export const useEquipmentIndex = (ruleset: Ruleset) =>
+  useQuery({
+    queryKey: ["equipment", ruleset, "index"],
+    queryFn: () => fetchEquipmentIndex(ruleset),
+    staleTime: DAY_MS,
+    gcTime: DAY_MS,
+  });
+
+export const useEquipmentDetail = (ruleset: Ruleset, slug: string | null) =>
+  useQuery({
+    enabled: slug !== null,
+    queryKey: ["equipment", ruleset, "detail", slug],
+    queryFn: () => fetchEquipmentDetail(ruleset, slug as string),
+    staleTime: DAY_MS,
+    gcTime: DAY_MS,
+  });
+```
+
+(`useEquipmentDetail` is added speculatively for the picker but is not strictly required — the picker fetches detail imperatively via `queryClient.fetchQuery` mirroring `BrowseApiModal.handlePick`. Keep it for symmetry; small surface.)
+
+- [ ] **Step 2: Run typecheck**
+
+```
+npm run typecheck
+```
+
+Expected: green.
+
+- [ ] **Step 3: Commit**
+
+```
+git add src/api/hooks.ts
+git commit -m "feat: useEquipmentIndex / useEquipmentDetail hooks"
+```
+
+---
+
+## Task 7: `EnrichmentStep` component
+
+**Files:**
+
+- Create: `src/views/EnrichmentStep.tsx`
+- Create: `src/views/EnrichmentStep.module.css`
+- Create: `src/views/EnrichmentStep.test.tsx`
+
+**Behavior:**
+
+- Receives: `ruleset`, `categoryFilter` (`"weapon" | "armor"`), `hint`: `BaseHint` (from Task 2).
+- Renders the equipment index, filtered:
+  - Always filtered to weapons or armor by name match against the equipment category. Easiest: scope by name — the index doesn't expose category. **Better**: keep two pre-known sub-lists per ruleset by reading `equipment_category` from each fetched detail. Since the index endpoint doesn't expose category at all, we approximate via the magic-item's category and use that to label the picker; the equipment list is filtered by `hint` (substring match, lowercased) and not by category. This is a known limitation: a user could pick `Plate Armor` while looking at a magic weapon, which would still produce sensible output (AC tag instead of damage). We'll live with it; the alternative (fetching every equipment detail upfront) is too expensive.
+- Pre-filters by `hint.hint` (substring on name, lowercased) when present.
+- Auto-selects exactly one item if `hint.kind === "specific"` AND there is exactly one filtered match.
+- Search input lets user override the filter and pick freely.
+- Footer: **Skip** (saves card without enrichment), **Confirm** (saves card with selected equipment as enrichment). Confirm is disabled when no selection.
+
+The component does NOT save the card itself — it calls `onConfirm(detail | null)` where `null` means "skip". The parent (`BrowseApiModal`) does the save.
+
+- [ ] **Step 1: Write failing tests**
+
+```tsx
+// src/views/EnrichmentStep.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { EnrichmentStep } from "./EnrichmentStep";
+
+const renderWithClient = (ui: React.ReactNode) => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+};
+
+describe("EnrichmentStep", () => {
+  it("auto-selects the single match for a specific hint", async () => {
+    const onConfirm = vi.fn();
+    renderWithClient(
+      <EnrichmentStep
+        ruleset="2014"
+        hint={{ kind: "specific", hint: "longsword" }}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+    // wait for index load
+    await screen.findByRole("button", { name: /Longsword/ });
+    expect(screen.getByRole("button", { name: /Longsword/ })).toHaveAttribute("aria-pressed", "true");
+    await userEvent.click(screen.getByRole("button", { name: /confirm/i }));
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+    expect(onConfirm.mock.calls[0][0]).toMatchObject({ index: "longsword" });
+  });
+
+  it("does not auto-select for an 'any X' template; allows skip", async () => {
+    const onConfirm = vi.fn();
+    renderWithClient(
+      <EnrichmentStep
+        ruleset="2014"
+        hint={{ kind: "any", hint: "sword" }}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+    await screen.findByRole("button", { name: /Longsword/ });
+    expect(screen.getByRole("button", { name: /confirm/i })).toBeDisabled();
+    await userEvent.click(screen.getByRole("button", { name: /skip/i }));
+    expect(onConfirm).toHaveBeenCalledWith(null);
+  });
+
+  it("lets the user override the auto-selection", async () => {
+    const onConfirm = vi.fn();
+    renderWithClient(
+      <EnrichmentStep
+        ruleset="2014"
+        hint={{ kind: "specific", hint: "longsword" }}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+    await screen.findByRole("button", { name: /Longsword/ });
+    await userEvent.click(screen.getByRole("button", { name: /Plate Armor/ }));
+    await userEvent.click(screen.getByRole("button", { name: /confirm/i }));
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+    expect(onConfirm.mock.calls[0][0]).toMatchObject({ index: "plate-armor" });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests; confirm they fail**
+
+```
+npm test -- src/views/EnrichmentStep.test.tsx
+```
+
+Expected: module-not-found.
+
+- [ ] **Step 3: Implement EnrichmentStep**
+
+```tsx
+// src/views/EnrichmentStep.tsx
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { TextField } from "react-aria-components";
+import {
+  fetchEquipmentDetail,
+  type EquipmentDetail,
+  type EquipmentIndexEntry,
+} from "../api/endpoints/equipment";
+import type { Ruleset } from "../api/endpoints/magicItems";
+import { useEquipmentIndex } from "../api/hooks";
+import type { BaseHint } from "../api/mappers/baseHint";
+import { Button } from "../lib/ui/Button";
+import { Input } from "../lib/ui/Input";
+import { LoadingState } from "../lib/ui/LoadingState";
+import styles from "./EnrichmentStep.module.css";
+
+type Props = {
+  ruleset: Ruleset;
+  hint: BaseHint;
+  onConfirm: (enrichment: EquipmentDetail | null) => void;
+  onCancel: () => void;
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function EnrichmentStep({ ruleset, hint, onConfirm, onCancel }: Props) {
+  const index = useEquipmentIndex(ruleset);
+  const queryClient = useQueryClient();
+  const [query, setQuery] = useState(hint.hint);
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
+  const [resolving, setResolving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const filtered: EquipmentIndexEntry[] = useMemo(() => {
+    const all = index.data?.results ?? [];
+    const q = query.trim().toLowerCase();
+    if (q === "") return all;
+    return all.filter((e) => e.name.toLowerCase().includes(q));
+  }, [index.data, query]);
+
+  // Auto-select for specific hint with exactly one match
+  useEffect(() => {
+    if (selectedSlug !== null) return;
+    if (hint.kind !== "specific") return;
+    if (filtered.length !== 1) return;
+    setSelectedSlug(filtered[0].index);
+  }, [filtered, hint.kind, selectedSlug]);
+
+  const handleConfirm = async () => {
+    if (selectedSlug === null) return;
+    setResolving(true);
+    setError(null);
+    try {
+      const detail = await queryClient.fetchQuery({
+        queryKey: ["equipment", ruleset, "detail", selectedSlug],
+        queryFn: () => fetchEquipmentDetail(ruleset, selectedSlug),
+        staleTime: DAY_MS,
+      });
+      onConfirm(detail);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Couldn't load this item.");
+    } finally {
+      setResolving(false);
+    }
+  };
+
+  return (
+    <>
+      <div className={styles.searchRow}>
+        <TextField aria-label="Search equipment" className={styles.searchField}>
+          <Input
+            type="search"
+            placeholder="Search equipment…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            autoFocus
+          />
+        </TextField>
+      </div>
+
+      <div className={styles.results}>
+        {index.isLoading && <LoadingState />}
+        {index.isError && <div className={styles.state}>Couldn't load equipment.</div>}
+        {index.isSuccess && filtered.length === 0 && (
+          <div className={styles.state}>No equipment matches your search.</div>
+        )}
+        {error && <div className={styles.state} role="alert">{error}</div>}
+        {index.isSuccess &&
+          filtered.map((entry) => (
+            <button
+              key={entry.index}
+              type="button"
+              className={styles.row}
+              aria-pressed={selectedSlug === entry.index}
+              onClick={() => setSelectedSlug(entry.index)}
+            >
+              <span className={styles.rowName}>{entry.name}</span>
+            </button>
+          ))}
+      </div>
+
+      <div className={styles.actions}>
+        <Button variant="secondary" onPress={onCancel}>Back</Button>
+        <Button variant="secondary" onPress={() => onConfirm(null)}>Skip</Button>
+        <Button onPress={handleConfirm} isDisabled={selectedSlug === null || resolving}>
+          {resolving ? "Loading…" : "Confirm"}
+        </Button>
+      </div>
+    </>
+  );
+}
+```
+
+- [ ] **Step 4: Add CSS module**
+
+Mirror the styles in `BrowseApiModal.module.css` so visual parity holds. Look up the existing class names and copy the relevant ones (`.searchRow`, `.searchField`, `.results`, `.row`, `.rowName`, `.state`, `.actions`). Add an `aria-pressed="true"` selector on `.row` for the selected state.
+
+```css
+/* src/views/EnrichmentStep.module.css */
+.searchRow { /* same as BrowseApiModal.module.css .searchRow */ }
+.searchField { /* … */ }
+.results { /* … */ }
+.row { /* … */ }
+.row[aria-pressed="true"] {
+  background: var(--color-surface-selected);
+}
+.rowName { /* … */ }
+.state { /* … */ }
+.actions {
+  display: flex;
+  gap: var(--space-2);
+  justify-content: flex-end;
+  padding: var(--space-3);
+}
+```
+
+(Confirm token names against `src/index.css`. The point is: don't invent new visual style — reuse the picker visuals.)
+
+- [ ] **Step 5: Run tests**
+
+```
+npm test -- src/views/EnrichmentStep.test.tsx
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/views/EnrichmentStep.tsx src/views/EnrichmentStep.module.css src/views/EnrichmentStep.test.tsx
+git commit -m "feat: EnrichmentStep — equipment picker with auto-select + skip"
+```
+
+---
+
+## Task 8: `BrowseApiModal` step machine
+
+**Files:**
+
+- Modify: `src/views/BrowseApiModal.tsx`
+- Modify: `src/views/BrowseApiModal.test.tsx`
+
+**Refactor outline:**
+
+The current `BrowseApiModal` couples the picker UI with the save side-effect inside `handlePick`. We split that into:
+
+1. **Step state machine** at the top level of `BrowseApiModal`. States: `{ step: "pick" } | { step: "enrich"; magicDetail; hint; ruleset }`.
+2. **Step 1 ("pick")**: same picker UI as today, but on click it fetches detail, parses base hint, classifies enrichability, and either:
+   - *Not enrichable* (category is not "weapon"/"armor", case-insensitive — covers `weapon`, `weapons`, `armor`): save card immediately (existing flow), close.
+   - *Enrichable* (`weapon`/`weapons` or `armor`): advance to `enrich` step with the loaded detail and computed hint.
+3. **Step 2 ("enrich")**: render `<EnrichmentStep>`. On `onConfirm(equipment | null)`, save card with optional enrichment, close. On `onCancel`, return to step 1.
+
+The DialogHeader title swaps between "Browse magic items" (step 1) and `<magic item name>` (step 2).
+
+The existing `magicItemDetailToCard(detail)` call becomes `magicItemDetailToCard(detail, enrichment ?? undefined)`.
+
+**Enrichability check:**
+
+```ts
+const isEnrichable = (categoryIndex: string): boolean => {
+  const k = categoryIndex.toLowerCase();
+  return k === "weapon" || k === "weapons" || k === "armor";
+};
+```
+
+(2024's `equipment_category.index` is `"weapons"`, plural. 2014's is `"weapon"`. Armor is `"armor"` in both.)
+
+- [ ] **Step 1: Write failing tests for the new flows**
+
+Add cases to `src/views/BrowseApiModal.test.tsx`:
+
+```tsx
+it("imports a non-enrichable magic item directly", async () => {
+  const onSelected = vi.fn();
+  renderModal({ onSelected });
+  await userEvent.click(await screen.findByRole("button", { name: /Wand of Wonder/ }));
+  await waitFor(() => expect(onSelected).toHaveBeenCalled());
+  // We never advanced to step 2:
+  expect(screen.queryByRole("button", { name: /Skip/ })).not.toBeInTheDocument();
+});
+
+it("opens the enrichment step for a specific weapon and auto-selects the base", async () => {
+  renderModal();
+  await userEvent.click(await screen.findByRole("button", { name: /Sun Blade/ }));
+  // Step 2 visible
+  await screen.findByRole("button", { name: /Skip/ });
+  // Auto-selected longsword
+  expect(screen.getByRole("button", { name: /Longsword/ })).toHaveAttribute("aria-pressed", "true");
+});
+
+it("opens the enrichment step for an 'any X' template with no auto-selection", async () => {
+  renderModal();
+  await userEvent.click(await screen.findByRole("button", { name: /Flame Tongue/ }));
+  await screen.findByRole("button", { name: /Skip/ });
+  // No row is pre-selected
+  const rows = screen.getAllByRole("button", { name: /Longsword|Plate Armor/ });
+  for (const row of rows) {
+    expect(row).toHaveAttribute("aria-pressed", "false");
+  }
+});
+
+it("Skip from enrichment step lands the card without enrichment", async () => {
+  const onSelected = vi.fn();
+  renderModal({ onSelected });
+  await userEvent.click(await screen.findByRole("button", { name: /Flame Tongue/ }));
+  await userEvent.click(await screen.findByRole("button", { name: /Skip/ }));
+  await waitFor(() => expect(onSelected).toHaveBeenCalled());
+});
+```
+
+You'll need MSW fixtures for `Wand of Wonder` (non-enrichable), `Sun Blade` (specific), `Flame Tongue` (any sword). Add those alongside the equipment fixtures in `src/test/msw.ts`.
+
+- [ ] **Step 2: Refactor `BrowseApiModal.tsx`**
+
+Pseudocode of the new structure (write actual code; the existing imports + `DialogShell` + `DialogHeader` stay the same):
+
+```tsx
+type Step =
+  | { step: "pick" }
+  | { step: "enrich"; magicDetail: MagicItemDetail; hint: BaseHint };
+
+const [step, setStep] = useState<Step>({ step: "pick" });
+
+const isEnrichable = (categoryIndex: string): boolean => {
+  const k = categoryIndex.toLowerCase();
+  return k === "weapon" || k === "weapons" || k === "armor";
+};
+
+const handlePick = async (slug: string) => {
+  if (pickingSlug !== null) return;
+  setPickingSlug(slug);
+  setPickError(null);
+  try {
+    const detail = await queryClient.fetchQuery({
+      queryKey: ["magic-items", ruleset, "detail", slug],
+      queryFn: () => fetchMagicItemDetail(ruleset, slug),
+      staleTime: DAY_MS,
+    });
+    if (!isEnrichable(detail.equipment_category.index)) {
+      const card = magicItemDetailToCard(detail);
+      await saveCard.mutateAsync({ card, deckId, isNew: true });
+      onSelected(card.id);
+      return;
+    }
+    const desc0 = detail.ruleset === "2024" ? detail.desc : detail.desc[0];
+    const hint = parseBaseHint(desc0);
+    setStep({ step: "enrich", magicDetail: detail, hint });
+  } catch (err) {
+    setPickError(err instanceof Error ? err.message : "Couldn't load this card.");
+  } finally {
+    setPickingSlug(null);
+  }
+};
+
+const handleEnrichmentConfirm = async (enrichment: EquipmentDetail | null) => {
+  if (step.step !== "enrich") return;
+  const card = magicItemDetailToCard(step.magicDetail, enrichment ?? undefined);
+  await saveCard.mutateAsync({ card, deckId, isNew: true });
+  onSelected(card.id);
+};
+```
+
+In the JSX, branch on `step.step` to render either the existing picker or `<EnrichmentStep ruleset={ruleset} hint={step.hint} onConfirm={handleEnrichmentConfirm} onCancel={() => setStep({ step: "pick" })} />`. Update the DialogHeader title to `step.step === "enrich" ? step.magicDetail.name : "Browse magic items"`.
+
+- [ ] **Step 3: Run BrowseApiModal tests**
+
+```
+npm test -- src/views/BrowseApiModal.test.tsx
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Run full suite + typecheck**
+
+```
+npm test
+npm run typecheck
+```
+
+Expected: green.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/views/BrowseApiModal.tsx src/views/BrowseApiModal.test.tsx src/test/msw.ts
+git commit -m "feat: two-step magic-item import wizard with optional enrichment"
+```
+
+---
+
+## Task 9: Manual verification
+
+- [ ] **Step 1: Start dev server**
+
+```
+npm run dev
+```
+
+- [ ] **Step 2: Exercise each branch in the browser**
+
+In the new-card editor, open the SRD import modal and verify:
+
+1. **Non-enrichable item** (e.g., search "wand of wonder", "potion of healing", "bag of holding"): clicking imports immediately, no second step. Resulting card has type in header, rarity in footer.
+2. **Specific weapon** (e.g., "Sun Blade", "Holy Avenger", "Dwarven Thrower"): clicking shows the equipment step with a base auto-selected. Confirm imports with damage + weight; Skip imports without.
+3. **Specific armor** (e.g., "Dwarven Plate"): same as above; auto-selection is "Plate Armor". Confirm produces `AC 18` in header and weight in footer.
+4. **"Any X" template** (e.g., "Flame Tongue"): equipment step opens with no auto-selection, picker pre-filtered to swords / melee weapons (the `hint` populates the search box). Pick something, confirm; or Skip.
+5. **Back button** at step 2 returns to step 1 with state preserved (search query, ruleset toggle).
+6. **Help text** is visible under both TagInput fields in the editor.
+7. **Print view** still renders cards correctly (sanity-check 2-up and 4-up; verify nothing regressed visually with the new tag layout).
+
+- [ ] **Step 3: Final lint + build**
+
+```
+npm run build
+```
+
+Expected: green.
+
+- [ ] **Step 4: Optional cleanup commit if anything came up during manual testing**
+
+If the manual pass surfaced anything (typo, off-by-one in the picker, etc.), fix inline and commit:
+
+```
+git add <files>
+git commit -m "fix: <what>"
+```
+
+If nothing came up, no commit.
+
+---
+
+## Self-review notes
+
+- **Spec coverage**: every bullet in the user's original spec has a task home — tag model (Task 5), canonical order (Tasks 1, 4, 5), help text (Task 1), API import normalization (Task 5), no programmatic enforcement on user input (Task 1: help text only).
+- **Cost auto-fill**: explicitly excluded; not implemented anywhere in the plan.
+- **Type consistency**: `EquipmentDetail` defined in Task 3, used in Tasks 4, 5, 7, 8 with the same shape. `BaseHint` defined in Task 2, used in Tasks 7, 8. `magicItemDetailToCard` signature change in Task 5 is the only API break and is consumed only in `BrowseApiModal` (Task 8).
+- **Open question (acknowledged in plan, not blocking)**: equipment index endpoint doesn't expose category, so step 2 doesn't filter weapons-only when invoked from a magic weapon. We rely on the user not deliberately picking armor for a magic weapon. If this turns out to matter, a follow-up task could pre-fetch category metadata.

--- a/src/api/endpoints/equipment.test.ts
+++ b/src/api/endpoints/equipment.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { fetchEquipmentDetail, fetchEquipmentIndex } from "./equipment";
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("fetchEquipmentIndex", () => {
+  test("hits /api/2024/equipment when ruleset is 2024", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ count: 0, results: [] }), { status: 200 }));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await fetchEquipmentIndex("2024");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://www.dnd5eapi.co/api/2024/equipment",
+      expect.anything(),
+    );
+  });
+
+  test("hits /api/2014/equipment when ruleset is 2014", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ count: 0, results: [] }), { status: 200 }));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await fetchEquipmentIndex("2014");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://www.dnd5eapi.co/api/2014/equipment",
+      expect.anything(),
+    );
+  });
+});
+
+describe("fetchEquipmentDetail", () => {
+  test("hits the right path and returns parsed detail", async () => {
+    const raw = {
+      index: "longsword",
+      name: "Longsword",
+      damage: { damage_dice: "1d8", damage_type: { name: "Slashing" } },
+      weight: 3,
+      cost: { quantity: 15, unit: "gp" },
+    };
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify(raw), { status: 200 }));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await fetchEquipmentDetail("2014", "longsword");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://www.dnd5eapi.co/api/2014/equipment/longsword",
+      expect.anything(),
+    );
+    expect(result.name).toBe("Longsword");
+    expect(result.damage?.damage_dice).toBe("1d8");
+    expect(result.weight).toBe(3);
+  });
+});

--- a/src/api/endpoints/equipment.test.ts
+++ b/src/api/endpoints/equipment.test.ts
@@ -59,4 +59,25 @@ describe("fetchEquipmentDetail", () => {
     expect(result.damage?.damage_dice).toBe("1d8");
     expect(result.weight).toBe(3);
   });
+
+  test("parses an armor detail with armor_class", async () => {
+    const raw = {
+      index: "plate-armor",
+      name: "Plate Armor",
+      armor_class: { base: 18, dex_bonus: false },
+      weight: 65,
+      cost: { quantity: 1500, unit: "gp" },
+    };
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify(raw), { status: 200 }));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const result = await fetchEquipmentDetail("2014", "plate-armor");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://www.dnd5eapi.co/api/2014/equipment/plate-armor",
+      expect.anything(),
+    );
+    expect(result.armor_class?.base).toBe(18);
+    expect(result.damage).toBeUndefined();
+  });
 });

--- a/src/api/endpoints/equipment.ts
+++ b/src/api/endpoints/equipment.ts
@@ -1,0 +1,39 @@
+import { apiGet } from "../apiClient";
+import type { Ruleset } from "./magicItems";
+
+export type EquipmentIndexEntry = {
+  index: string;
+  name: string;
+  url: string;
+};
+
+export type EquipmentIndex = {
+  count: number;
+  results: EquipmentIndexEntry[];
+};
+
+export type EquipmentDamage = {
+  damage_dice: string;
+  damage_type: { name: string };
+};
+
+export type EquipmentArmorClass = {
+  base: number;
+  dex_bonus?: boolean;
+  max_bonus?: number;
+};
+
+export type EquipmentDetail = {
+  index: string;
+  name: string;
+  damage?: EquipmentDamage;
+  armor_class?: EquipmentArmorClass;
+  weight?: number;
+  cost?: { quantity: number; unit: string };
+};
+
+export const fetchEquipmentIndex = (ruleset: Ruleset): Promise<EquipmentIndex> =>
+  apiGet<EquipmentIndex>(`/api/${ruleset}/equipment`);
+
+export const fetchEquipmentDetail = (ruleset: Ruleset, slug: string): Promise<EquipmentDetail> =>
+  apiGet<EquipmentDetail>(`/api/${ruleset}/equipment/${slug}`);

--- a/src/api/factories.ts
+++ b/src/api/factories.ts
@@ -9,10 +9,10 @@ import type {
 
 const rarities = ["Common", "Uncommon", "Rare", "Very Rare", "Legendary"];
 const categories = [
-  { index: "wondrous-items", name: "Wondrous Items" },
-  { index: "rings", name: "Rings" },
-  { index: "rods", name: "Rods" },
-  { index: "weapons", name: "Weapons" },
+  { index: "wondrous-items", name: "Wondrous Items", descName: "Wondrous Item" },
+  { index: "rings", name: "Rings", descName: "Ring" },
+  { index: "rods", name: "Rods", descName: "Rod" },
+  { index: "weapons", name: "Weapons", descName: "Weapon" },
 ];
 
 export const magicItemIndexEntryFactory = Factory.define<MagicItemIndexEntry>(() => {
@@ -35,7 +35,7 @@ export const magicItemIndexFactory = Factory.define<MagicItemIndex, MagicItemInd
 );
 
 export const magicItemDetail2024Factory = Factory.define<MagicItemDetail2024>(() => {
-  const category = faker.helpers.arrayElement(categories);
+  const { descName, ...category } = faker.helpers.arrayElement(categories);
   const slug = faker.helpers.slugify(faker.commerce.productName()).toLowerCase();
   return {
     ruleset: "2024",
@@ -44,7 +44,7 @@ export const magicItemDetail2024Factory = Factory.define<MagicItemDetail2024>(()
     equipment_category: { ...category, url: `/api/2024/equipment-categories/${category.index}` },
     rarity: { name: faker.helpers.arrayElement(rarities) },
     attunement: faker.datatype.boolean(),
-    desc: `${category.name}  \n ${faker.lorem.paragraph()}`,
+    desc: `${descName}  \n${faker.lorem.paragraph()}`,
     image: `/api/images/magic-items/${slug}.png`,
     variants: [],
     variant: false,
@@ -52,7 +52,7 @@ export const magicItemDetail2024Factory = Factory.define<MagicItemDetail2024>(()
 });
 
 export const magicItemDetail2014Factory = Factory.define<MagicItemDetail2014>(() => {
-  const category = faker.helpers.arrayElement(categories);
+  const { descName, ...category } = faker.helpers.arrayElement(categories);
   const rarity = faker.helpers.arrayElement(rarities);
   const slug = faker.helpers.slugify(faker.commerce.productName()).toLowerCase();
   return {
@@ -62,7 +62,7 @@ export const magicItemDetail2014Factory = Factory.define<MagicItemDetail2014>(()
     equipment_category: { ...category, url: `/api/2014/equipment-categories/${category.index}` },
     rarity: { name: rarity },
     desc: [
-      `${category.name.slice(0, -1)}, ${rarity.toLowerCase()}`,
+      `${descName}, ${rarity.toLowerCase()}`,
       faker.lorem.paragraph(),
       faker.lorem.paragraph(),
     ],

--- a/src/api/hooks.ts
+++ b/src/api/hooks.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { fetchEquipmentDetail, fetchEquipmentIndex } from "./endpoints/equipment";
 import { fetchMagicItemDetail, fetchMagicItemIndex, type Ruleset } from "./endpoints/magicItems";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -16,6 +17,23 @@ export const useMagicItemDetail = (ruleset: Ruleset, slug: string | null) =>
     enabled: slug !== null,
     queryKey: ["magic-items", ruleset, "detail", slug],
     queryFn: () => fetchMagicItemDetail(ruleset, slug as string),
+    staleTime: DAY_MS,
+    gcTime: DAY_MS,
+  });
+
+export const useEquipmentIndex = (ruleset: Ruleset) =>
+  useQuery({
+    queryKey: ["equipment", ruleset, "index"],
+    queryFn: () => fetchEquipmentIndex(ruleset),
+    staleTime: DAY_MS,
+    gcTime: DAY_MS,
+  });
+
+export const useEquipmentDetail = (ruleset: Ruleset, slug: string | null) =>
+  useQuery({
+    enabled: slug !== null,
+    queryKey: ["equipment", ruleset, "detail", slug],
+    queryFn: () => fetchEquipmentDetail(ruleset, slug as string),
     staleTime: DAY_MS,
     gcTime: DAY_MS,
   });

--- a/src/api/hooks.ts
+++ b/src/api/hooks.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { fetchEquipmentDetail, fetchEquipmentIndex } from "./endpoints/equipment";
+import { fetchEquipmentIndex } from "./endpoints/equipment";
 import { fetchMagicItemDetail, fetchMagicItemIndex, type Ruleset } from "./endpoints/magicItems";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -25,15 +25,6 @@ export const useEquipmentIndex = (ruleset: Ruleset) =>
   useQuery({
     queryKey: ["equipment", ruleset, "index"],
     queryFn: () => fetchEquipmentIndex(ruleset),
-    staleTime: DAY_MS,
-    gcTime: DAY_MS,
-  });
-
-export const useEquipmentDetail = (ruleset: Ruleset, slug: string | null) =>
-  useQuery({
-    enabled: slug !== null,
-    queryKey: ["equipment", ruleset, "detail", slug],
-    queryFn: () => fetchEquipmentDetail(ruleset, slug as string),
     staleTime: DAY_MS,
     gcTime: DAY_MS,
   });

--- a/src/api/hooks.ts
+++ b/src/api/hooks.ts
@@ -1,8 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { fetchEquipmentIndex } from "./endpoints/equipment";
 import { fetchMagicItemDetail, fetchMagicItemIndex, type Ruleset } from "./endpoints/magicItems";
-
-const DAY_MS = 24 * 60 * 60 * 1000;
+import { DAY_MS } from "./timing";
 
 export const useMagicItemIndex = (ruleset: Ruleset) =>
   useQuery({

--- a/src/api/mappers/baseHint.test.ts
+++ b/src/api/mappers/baseHint.test.ts
@@ -6,19 +6,21 @@ describe("parseBaseHint", () => {
     expect(parseBaseHint("Weapon (longsword), rare (requires attunement)")).toEqual({
       kind: "specific",
       hint: "longsword",
+      source: "Weapon (longsword)",
     });
   });
 
   it("identifies an 'any X' weapon template", () => {
     expect(
       parseBaseHint("Weapon (any sword), legendary (requires attunement by a paladin)"),
-    ).toEqual({ kind: "any", hint: "sword" });
+    ).toEqual({ kind: "any", hint: "sword", source: "Weapon (any sword)" });
   });
 
   it("identifies a specific armor base", () => {
     expect(parseBaseHint("Armor (plate), very rare")).toEqual({
       kind: "specific",
       hint: "plate",
+      source: "Armor (plate)",
     });
   });
 
@@ -26,6 +28,7 @@ describe("parseBaseHint", () => {
     expect(parseBaseHint("Weapon (Any Melee Weapon)")).toEqual({
       kind: "any",
       hint: "melee weapon",
+      source: "Weapon (Any Melee Weapon)",
     });
   });
 
@@ -33,6 +36,7 @@ describe("parseBaseHint", () => {
     expect(parseBaseHint("Weapon (Longsword), Rare")).toEqual({
       kind: "specific",
       hint: "longsword",
+      source: "Weapon (Longsword)",
     });
   });
 
@@ -40,12 +44,13 @@ describe("parseBaseHint", () => {
     expect(parseBaseHint("Wondrous item, rare (requires attunement)")).toEqual({
       kind: "none",
       hint: "",
+      source: "",
     });
-    expect(parseBaseHint("Wand, very rare")).toEqual({ kind: "none", hint: "" });
+    expect(parseBaseHint("Wand, very rare")).toEqual({ kind: "none", hint: "", source: "" });
   });
 
   it("returns 'none' for empty / undefined input", () => {
-    expect(parseBaseHint(undefined)).toEqual({ kind: "none", hint: "" });
-    expect(parseBaseHint("")).toEqual({ kind: "none", hint: "" });
+    expect(parseBaseHint(undefined)).toEqual({ kind: "none", hint: "", source: "" });
+    expect(parseBaseHint("")).toEqual({ kind: "none", hint: "", source: "" });
   });
 });

--- a/src/api/mappers/baseHint.test.ts
+++ b/src/api/mappers/baseHint.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { parseBaseHint } from "./baseHint";
+
+describe("parseBaseHint", () => {
+  it("identifies a specific weapon base", () => {
+    expect(parseBaseHint("Weapon (longsword), rare (requires attunement)")).toEqual({
+      kind: "specific",
+      hint: "longsword",
+    });
+  });
+
+  it("identifies an 'any X' weapon template", () => {
+    expect(
+      parseBaseHint("Weapon (any sword), legendary (requires attunement by a paladin)"),
+    ).toEqual({ kind: "any", hint: "sword" });
+  });
+
+  it("identifies a specific armor base", () => {
+    expect(parseBaseHint("Armor (plate), very rare")).toEqual({
+      kind: "specific",
+      hint: "plate",
+    });
+  });
+
+  it("normalizes mixed-case 2024-style hints", () => {
+    expect(parseBaseHint("Weapon (Any Melee Weapon)")).toEqual({
+      kind: "any",
+      hint: "melee weapon",
+    });
+    expect(parseBaseHint("Weapon (Longsword), Rare")).toEqual({
+      kind: "specific",
+      hint: "longsword",
+    });
+  });
+
+  it("returns 'none' for non-weapon/armor descriptions", () => {
+    expect(parseBaseHint("Wondrous item, rare (requires attunement)")).toEqual({
+      kind: "none",
+      hint: "",
+    });
+    expect(parseBaseHint("Wand, very rare")).toEqual({ kind: "none", hint: "" });
+  });
+
+  it("returns 'none' for empty / undefined input", () => {
+    expect(parseBaseHint(undefined)).toEqual({ kind: "none", hint: "" });
+    expect(parseBaseHint("")).toEqual({ kind: "none", hint: "" });
+  });
+});

--- a/src/api/mappers/baseHint.test.ts
+++ b/src/api/mappers/baseHint.test.ts
@@ -22,11 +22,14 @@ describe("parseBaseHint", () => {
     });
   });
 
-  it("normalizes mixed-case 2024-style hints", () => {
+  it("normalizes a mixed-case 2024-style 'any' hint", () => {
     expect(parseBaseHint("Weapon (Any Melee Weapon)")).toEqual({
       kind: "any",
       hint: "melee weapon",
     });
+  });
+
+  it("normalizes a mixed-case 2024-style specific hint", () => {
     expect(parseBaseHint("Weapon (Longsword), Rare")).toEqual({
       kind: "specific",
       hint: "longsword",

--- a/src/api/mappers/baseHint.ts
+++ b/src/api/mappers/baseHint.ts
@@ -9,7 +9,7 @@ export const parseBaseHint = (desc0: string | undefined): BaseHint => {
   if (!desc0) return { kind: "none", hint: "" };
   const match = RE.exec(desc0.trim());
   if (!match) return { kind: "none", hint: "" };
-  const inner = match[1].trim().toLowerCase();
+  const inner = match[1]!.trim().toLowerCase();
   if (inner.startsWith("any ")) {
     return { kind: "any", hint: inner.slice(4).trim() };
   }

--- a/src/api/mappers/baseHint.ts
+++ b/src/api/mappers/baseHint.ts
@@ -1,0 +1,17 @@
+export type BaseHint =
+  | { kind: "specific"; hint: string }
+  | { kind: "any"; hint: string }
+  | { kind: "none"; hint: "" };
+
+const RE = /^(?:Weapon|Armor)\s*\(([^)]+)\)/i;
+
+export const parseBaseHint = (desc0: string | undefined): BaseHint => {
+  if (!desc0) return { kind: "none", hint: "" };
+  const match = RE.exec(desc0.trim());
+  if (!match) return { kind: "none", hint: "" };
+  const inner = match[1].trim().toLowerCase();
+  if (inner.startsWith("any ")) {
+    return { kind: "any", hint: inner.slice(4).trim() };
+  }
+  return { kind: "specific", hint: inner };
+};

--- a/src/api/mappers/baseHint.ts
+++ b/src/api/mappers/baseHint.ts
@@ -1,17 +1,18 @@
 export type BaseHint =
-  | { kind: "specific"; hint: string }
-  | { kind: "any"; hint: string }
-  | { kind: "none"; hint: "" };
+  | { kind: "specific"; hint: string; source: string }
+  | { kind: "any"; hint: string; source: string }
+  | { kind: "none"; hint: ""; source: "" };
 
 const RE = /^(?:Weapon|Armor)\s*\(([^)]+)\)/i;
 
 export const parseBaseHint = (desc0: string | undefined): BaseHint => {
-  if (!desc0) return { kind: "none", hint: "" };
+  if (!desc0) return { kind: "none", hint: "", source: "" };
   const match = RE.exec(desc0.trim());
-  if (!match) return { kind: "none", hint: "" };
+  if (!match) return { kind: "none", hint: "", source: "" };
+  const source = match[0]!.trim();
   const inner = match[1]!.trim().toLowerCase();
   if (inner.startsWith("any ")) {
-    return { kind: "any", hint: inner.slice(4).trim() };
+    return { kind: "any", hint: inner.slice(4).trim(), source };
   }
-  return { kind: "specific", hint: inner };
+  return { kind: "specific", hint: inner, source };
 };

--- a/src/api/mappers/equipment.test.ts
+++ b/src/api/mappers/equipment.test.ts
@@ -30,6 +30,10 @@ describe("equipmentToHeaderInsert", () => {
   it("returns null for items with neither damage nor AC", () => {
     expect(equipmentToHeaderInsert(noShape)).toBeNull();
   });
+
+  it("returns null when given undefined", () => {
+    expect(equipmentToHeaderInsert(undefined)).toBeNull();
+  });
 });
 
 describe("equipmentToFooterInsert", () => {
@@ -44,5 +48,9 @@ describe("equipmentToFooterInsert", () => {
 
   it("returns null when weight is zero", () => {
     expect(equipmentToFooterInsert({ ...longsword, weight: 0 })).toBeNull();
+  });
+
+  it("returns null when given undefined", () => {
+    expect(equipmentToFooterInsert(undefined)).toBeNull();
   });
 });

--- a/src/api/mappers/equipment.test.ts
+++ b/src/api/mappers/equipment.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { EquipmentDetail } from "../endpoints/equipment";
+import { equipmentToFooterInsert, equipmentToHeaderInsert } from "./equipment";
+
+const longsword: EquipmentDetail = {
+  index: "longsword",
+  name: "Longsword",
+  damage: { damage_dice: "1d8", damage_type: { name: "Slashing" } },
+  weight: 3,
+};
+
+const plateArmor: EquipmentDetail = {
+  index: "plate-armor",
+  name: "Plate Armor",
+  armor_class: { base: 18, dex_bonus: false },
+  weight: 65,
+};
+
+const noShape: EquipmentDetail = { index: "abacus", name: "Abacus" };
+
+describe("equipmentToHeaderInsert", () => {
+  it("formats weapon damage", () => {
+    expect(equipmentToHeaderInsert(longsword)).toBe("1d8 slashing");
+  });
+
+  it("formats armor AC", () => {
+    expect(equipmentToHeaderInsert(plateArmor)).toBe("AC 18");
+  });
+
+  it("returns null for items with neither damage nor AC", () => {
+    expect(equipmentToHeaderInsert(noShape)).toBeNull();
+  });
+});
+
+describe("equipmentToFooterInsert", () => {
+  it("formats weight in lb", () => {
+    expect(equipmentToFooterInsert(longsword)).toBe("3 lb");
+    expect(equipmentToFooterInsert(plateArmor)).toBe("65 lb");
+  });
+
+  it("returns null when weight is missing", () => {
+    expect(equipmentToFooterInsert(noShape)).toBeNull();
+  });
+
+  it("returns null when weight is zero", () => {
+    expect(equipmentToFooterInsert({ ...longsword, weight: 0 })).toBeNull();
+  });
+});

--- a/src/api/mappers/equipment.test.ts
+++ b/src/api/mappers/equipment.test.ts
@@ -12,7 +12,7 @@ const longsword: EquipmentDetail = {
 const plateArmor: EquipmentDetail = {
   index: "plate-armor",
   name: "Plate Armor",
-  armor_class: { base: 18, dex_bonus: false },
+  armor_class: { base: 18 },
   weight: 65,
 };
 

--- a/src/api/mappers/equipment.ts
+++ b/src/api/mappers/equipment.ts
@@ -1,6 +1,7 @@
 import type { EquipmentDetail } from "../endpoints/equipment";
 
-export const equipmentToHeaderInsert = (e: EquipmentDetail): string | null => {
+export const equipmentToHeaderInsert = (e: EquipmentDetail | undefined): string | null => {
+  if (!e) return null;
   if (e.damage) {
     return `${e.damage.damage_dice} ${e.damage.damage_type.name.toLowerCase()}`;
   }
@@ -10,7 +11,8 @@ export const equipmentToHeaderInsert = (e: EquipmentDetail): string | null => {
   return null;
 };
 
-export const equipmentToFooterInsert = (e: EquipmentDetail): string | null => {
+export const equipmentToFooterInsert = (e: EquipmentDetail | undefined): string | null => {
+  if (!e) return null;
   if (!e.weight) return null;
   return `${e.weight} lb`;
 };

--- a/src/api/mappers/equipment.ts
+++ b/src/api/mappers/equipment.ts
@@ -1,0 +1,16 @@
+import type { EquipmentDetail } from "../endpoints/equipment";
+
+export const equipmentToHeaderInsert = (e: EquipmentDetail): string | null => {
+  if (e.damage) {
+    return `${e.damage.damage_dice} ${e.damage.damage_type.name.toLowerCase()}`;
+  }
+  if (e.armor_class) {
+    return `AC ${e.armor_class.base}`;
+  }
+  return null;
+};
+
+export const equipmentToFooterInsert = (e: EquipmentDetail): string | null => {
+  if (!e.weight) return null;
+  return `${e.weight} lb`;
+};

--- a/src/api/mappers/magicItems.test.ts
+++ b/src/api/mappers/magicItems.test.ts
@@ -86,46 +86,42 @@ describe("magicItemDetailToCard — 2014", () => {
 });
 
 describe("magicItemDetailToCard — enrichment", () => {
+  const sunBladeLike: MagicItemDetail2014 = magicItemDetail2014Factory.build({
+    equipment_category: { index: "weapon", name: "Weapon", url: "" },
+    rarity: { name: "Rare" },
+    desc: ["Weapon (longsword), rare (requires attunement)", "..."],
+  });
+  const dwarvenPlateLike: MagicItemDetail2014 = magicItemDetail2014Factory.build({
+    equipment_category: { index: "armor", name: "Armor", url: "" },
+    rarity: { name: "Very Rare" },
+    desc: ["Armor (plate), very rare", "..."],
+  });
+  const longsword: EquipmentDetail = {
+    index: "longsword",
+    name: "Longsword",
+    damage: { damage_dice: "1d8", damage_type: { name: "Slashing" } },
+    weight: 3,
+  };
+  const plate: EquipmentDetail = {
+    index: "plate-armor",
+    name: "Plate Armor",
+    armor_class: { base: 18 },
+    weight: 65,
+  };
+
   test("splices weapon damage into header and weight into footer", () => {
-    const sunBladeLike: MagicItemDetail2014 = magicItemDetail2014Factory.build({
-      equipment_category: { index: "weapon", name: "Weapon", url: "" },
-      rarity: { name: "Rare" },
-      desc: ["Weapon (longsword), rare (requires attunement)", "..."],
-    });
-    const longsword: EquipmentDetail = {
-      index: "longsword",
-      name: "Longsword",
-      damage: { damage_dice: "1d8", damage_type: { name: "Slashing" } },
-      weight: 3,
-    };
     const card = magicItemDetailToCard(sunBladeLike, longsword);
     expect(card.headerTags).toEqual(["Weapon", "1d8 slashing", "requires attunement"]);
     expect(card.footerTags).toEqual(["rare", "3 lb"]);
   });
 
   test("splices armor AC into header and weight into footer", () => {
-    const dwarvenPlateLike: MagicItemDetail2014 = magicItemDetail2014Factory.build({
-      equipment_category: { index: "armor", name: "Armor", url: "" },
-      rarity: { name: "Very Rare" },
-      desc: ["Armor (plate), very rare", "..."],
-    });
-    const plate: EquipmentDetail = {
-      index: "plate-armor",
-      name: "Plate Armor",
-      armor_class: { base: 18 },
-      weight: 65,
-    };
     const card = magicItemDetailToCard(dwarvenPlateLike, plate);
     expect(card.headerTags).toEqual(["Armor", "AC 18"]);
     expect(card.footerTags).toEqual(["very rare", "65 lb"]);
   });
 
   test("omits header insert when enrichment has neither damage nor AC", () => {
-    const sunBladeLike: MagicItemDetail2014 = magicItemDetail2014Factory.build({
-      equipment_category: { index: "weapon", name: "Weapon", url: "" },
-      rarity: { name: "Rare" },
-      desc: ["Weapon (longsword), rare (requires attunement)", "..."],
-    });
     const empty: EquipmentDetail = { index: "x", name: "X" };
     const card = magicItemDetailToCard(sunBladeLike, empty);
     expect(card.headerTags).toEqual(["Weapon", "requires attunement"]);
@@ -133,11 +129,6 @@ describe("magicItemDetailToCard — enrichment", () => {
   });
 
   test("works without enrichment (existing behavior)", () => {
-    const sunBladeLike: MagicItemDetail2014 = magicItemDetail2014Factory.build({
-      equipment_category: { index: "weapon", name: "Weapon", url: "" },
-      rarity: { name: "Rare" },
-      desc: ["Weapon (longsword), rare (requires attunement)", "..."],
-    });
     const card = magicItemDetailToCard(sunBladeLike);
     expect(card.headerTags).toEqual(["Weapon", "requires attunement"]);
     expect(card.footerTags).toEqual(["rare"]);

--- a/src/api/mappers/magicItems.test.ts
+++ b/src/api/mappers/magicItems.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { itemCardSchema } from "../../decks/schema";
+import type { EquipmentDetail } from "../endpoints/equipment";
+import type { MagicItemDetail2014 } from "../endpoints/magicItems";
 import { magicItemDetail2014Factory, magicItemDetail2024Factory } from "../factories";
 import { magicItemDetailToCard } from "./magicItems";
 
@@ -79,6 +81,65 @@ describe("magicItemDetailToCard — 2014", () => {
     });
     const card = magicItemDetailToCard(detail);
     expect(card.headerTags).toEqual(["Rings", "requires attunement"]);
+    expect(card.footerTags).toEqual(["rare"]);
+  });
+});
+
+describe("magicItemDetailToCard — enrichment", () => {
+  test("splices weapon damage into header and weight into footer", () => {
+    const sunBladeLike: MagicItemDetail2014 = magicItemDetail2014Factory.build({
+      equipment_category: { index: "weapon", name: "Weapon", url: "" },
+      rarity: { name: "Rare" },
+      desc: ["Weapon (longsword), rare (requires attunement)", "..."],
+    });
+    const longsword: EquipmentDetail = {
+      index: "longsword",
+      name: "Longsword",
+      damage: { damage_dice: "1d8", damage_type: { name: "Slashing" } },
+      weight: 3,
+    };
+    const card = magicItemDetailToCard(sunBladeLike, longsword);
+    expect(card.headerTags).toEqual(["Weapon", "1d8 slashing", "requires attunement"]);
+    expect(card.footerTags).toEqual(["rare", "3 lb"]);
+  });
+
+  test("splices armor AC into header and weight into footer", () => {
+    const dwarvenPlateLike: MagicItemDetail2014 = magicItemDetail2014Factory.build({
+      equipment_category: { index: "armor", name: "Armor", url: "" },
+      rarity: { name: "Very Rare" },
+      desc: ["Armor (plate), very rare", "..."],
+    });
+    const plate: EquipmentDetail = {
+      index: "plate-armor",
+      name: "Plate Armor",
+      armor_class: { base: 18 },
+      weight: 65,
+    };
+    const card = magicItemDetailToCard(dwarvenPlateLike, plate);
+    expect(card.headerTags).toEqual(["Armor", "AC 18"]);
+    expect(card.footerTags).toEqual(["very rare", "65 lb"]);
+  });
+
+  test("omits header insert when enrichment has neither damage nor AC", () => {
+    const sunBladeLike: MagicItemDetail2014 = magicItemDetail2014Factory.build({
+      equipment_category: { index: "weapon", name: "Weapon", url: "" },
+      rarity: { name: "Rare" },
+      desc: ["Weapon (longsword), rare (requires attunement)", "..."],
+    });
+    const empty: EquipmentDetail = { index: "x", name: "X" };
+    const card = magicItemDetailToCard(sunBladeLike, empty);
+    expect(card.headerTags).toEqual(["Weapon", "requires attunement"]);
+    expect(card.footerTags).toEqual(["rare"]);
+  });
+
+  test("works without enrichment (existing behavior)", () => {
+    const sunBladeLike: MagicItemDetail2014 = magicItemDetail2014Factory.build({
+      equipment_category: { index: "weapon", name: "Weapon", url: "" },
+      rarity: { name: "Rare" },
+      desc: ["Weapon (longsword), rare (requires attunement)", "..."],
+    });
+    const card = magicItemDetailToCard(sunBladeLike);
+    expect(card.headerTags).toEqual(["Weapon", "requires attunement"]);
     expect(card.footerTags).toEqual(["rare"]);
   });
 });

--- a/src/api/mappers/magicItems.test.ts
+++ b/src/api/mappers/magicItems.test.ts
@@ -10,7 +10,7 @@ describe("magicItemDetailToCard — 2024", () => {
     expect(itemCardSchema.safeParse(card).success).toBe(true);
   });
 
-  test("composes headerTags from category + rarity", () => {
+  test("composes headerTags from category, footerTags from rarity", () => {
     const detail = magicItemDetail2024Factory.build({
       equipment_category: {
         index: "wondrous-items",
@@ -21,17 +21,19 @@ describe("magicItemDetailToCard — 2024", () => {
       attunement: false,
     });
     const card = magicItemDetailToCard(detail);
-    expect(card.headerTags).toEqual(["Wondrous Items", "uncommon"]);
+    expect(card.headerTags).toEqual(["Wondrous Items"]);
+    expect(card.footerTags).toEqual(["uncommon"]);
   });
 
-  test("adds attunement tag when attunement is true", () => {
+  test("adds attunement tag to headerTags when attunement is true", () => {
     const detail = magicItemDetail2024Factory.build({
       equipment_category: { index: "rings", name: "Rings", url: "" },
       rarity: { name: "Rare" },
       attunement: true,
     });
     const card = magicItemDetailToCard(detail);
-    expect(card.headerTags).toEqual(["Rings", "rare", "requires attunement"]);
+    expect(card.headerTags).toEqual(["Rings", "requires attunement"]);
+    expect(card.footerTags).toEqual(["rare"]);
   });
 
   test("carries through source + apiRef with ruleset", () => {
@@ -76,6 +78,7 @@ describe("magicItemDetailToCard — 2014", () => {
       desc: ["Ring, rare (requires attunement)", "body"],
     });
     const card = magicItemDetailToCard(detail);
-    expect(card.headerTags).toEqual(["Rings", "rare", "requires attunement"]);
+    expect(card.headerTags).toEqual(["Rings", "requires attunement"]);
+    expect(card.footerTags).toEqual(["rare"]);
   });
 });

--- a/src/api/mappers/magicItems.test.ts
+++ b/src/api/mappers/magicItems.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { itemCardSchema } from "../../decks/schema";
 import type { EquipmentDetail } from "../endpoints/equipment";
-import type { MagicItemDetail2014 } from "../endpoints/magicItems";
+import type { MagicItemDetail2014, MagicItemDetail2024 } from "../endpoints/magicItems";
 import { magicItemDetail2014Factory, magicItemDetail2024Factory } from "../factories";
 import { magicItemDetailToCard } from "./magicItems";
 
@@ -56,6 +56,23 @@ describe("magicItemDetailToCard — 2024", () => {
     const card = magicItemDetailToCard(detail);
     expect(card.imageUrl).toBe("https://www.dnd5eapi.co/api/images/magic-items/bag-of-holding.png");
   });
+
+  test("strips metadata header from body", () => {
+    const detail = magicItemDetail2024Factory.build({
+      desc: "Wondrous Item  \nWhile you hold this bag, you can use it to store items.",
+    });
+    const card = magicItemDetailToCard(detail);
+    expect(card.body).not.toMatch(/^Wondrous Item/);
+    expect(card.body).toContain("While you hold this bag");
+  });
+
+  test("leaves desc unchanged when first line does not match a known type prefix", () => {
+    const detail = magicItemDetail2024Factory.build({
+      desc: "Unknown format\nSome body text.",
+    });
+    const card = magicItemDetailToCard(detail);
+    expect(card.body).toBe("Unknown format\nSome body text.");
+  });
 });
 
 describe("magicItemDetailToCard — 2014", () => {
@@ -65,12 +82,13 @@ describe("magicItemDetailToCard — 2014", () => {
     expect(itemCardSchema.safeParse(card).success).toBe(true);
   });
 
-  test("joins desc array with blank-line separators for body", () => {
+  test("strips metadata header (desc[0]) and joins remaining lines for body", () => {
     const detail = magicItemDetail2014Factory.build({
-      desc: ["line A", "line B", "line C"],
+      desc: ["Weapon (any sword), rare (requires attunement)", "line B", "line C"],
     });
     const card = magicItemDetailToCard(detail);
-    expect(card.body).toBe("line A\n\nline B\n\nline C");
+    expect(card.body).not.toContain("Weapon (any sword)");
+    expect(card.body).toBe("line B\n\nline C");
   });
 
   test("detects requires-attunement from desc[0]", () => {
@@ -87,6 +105,7 @@ describe("magicItemDetailToCard — 2014", () => {
 
 describe("magicItemDetailToCard — enrichment", () => {
   const sunBladeLike: MagicItemDetail2014 = magicItemDetail2014Factory.build({
+    name: "Sun Blade",
     equipment_category: { index: "weapon", name: "Weapon", url: "" },
     rarity: { name: "Rare" },
     desc: ["Weapon (longsword), rare (requires attunement)", "..."],
@@ -132,5 +151,76 @@ describe("magicItemDetailToCard — enrichment", () => {
     const card = magicItemDetailToCard(sunBladeLike);
     expect(card.headerTags).toEqual(["Weapon", "requires attunement"]);
     expect(card.footerTags).toEqual(["rare"]);
+  });
+});
+
+describe("magicItemDetailToCard — composeName", () => {
+  const trident: EquipmentDetail = {
+    index: "trident",
+    name: "Trident",
+    damage: { damage_dice: "1d6", damage_type: { name: "Piercing" } },
+    weight: 4,
+  };
+  const longsword: EquipmentDetail = {
+    index: "longsword",
+    name: "Longsword",
+    damage: { damage_dice: "1d8", damage_type: { name: "Slashing" } },
+    weight: 3,
+  };
+
+  test("appends base name when hint is 'any' and enrichment is supplied (2014)", () => {
+    const flameTongueLike: MagicItemDetail2014 = magicItemDetail2014Factory.build({
+      name: "Flame Tongue",
+      equipment_category: { index: "weapon", name: "Weapon", url: "" },
+      rarity: { name: "Rare" },
+      desc: ["Weapon (any melee weapon), rare (requires attunement)", "While ablaze..."],
+    });
+    const card = magicItemDetailToCard(flameTongueLike, trident);
+    expect(card.name).toBe("Flame Tongue (Trident)");
+  });
+
+  test("appends base name when hint is 'any' and enrichment is supplied (2024)", () => {
+    const holyAvengerLike: MagicItemDetail2024 = magicItemDetail2024Factory.build({
+      name: "Holy Avenger",
+      equipment_category: { index: "weapon", name: "Weapon", url: "" },
+      rarity: { name: "Legendary" },
+      attunement: true,
+      desc: "Weapon (Any Simple or Martial)  \nYou gain a +3 bonus to attack rolls...",
+    });
+    const card = magicItemDetailToCard(holyAvengerLike, longsword);
+    expect(card.name).toBe("Holy Avenger (Longsword)");
+  });
+
+  test("does NOT append base name when hint is 'specific' and enrichment is supplied (2014)", () => {
+    const sunBladeLike: MagicItemDetail2014 = magicItemDetail2014Factory.build({
+      name: "Sun Blade",
+      equipment_category: { index: "weapon", name: "Weapon", url: "" },
+      rarity: { name: "Rare" },
+      desc: ["Weapon (longsword), rare (requires attunement)", "..."],
+    });
+    const card = magicItemDetailToCard(sunBladeLike, longsword);
+    expect(card.name).toBe("Sun Blade");
+  });
+
+  test("does NOT append base name when no enrichment is supplied", () => {
+    const flameTongueLike: MagicItemDetail2014 = magicItemDetail2014Factory.build({
+      name: "Flame Tongue",
+      equipment_category: { index: "weapon", name: "Weapon", url: "" },
+      rarity: { name: "Rare" },
+      desc: ["Weapon (any melee weapon), rare (requires attunement)", "While ablaze..."],
+    });
+    const card = magicItemDetailToCard(flameTongueLike);
+    expect(card.name).toBe("Flame Tongue");
+  });
+
+  test("does NOT append base name for non-weapon/armor items (hint is 'none') with enrichment", () => {
+    const bagOfHoldingLike: MagicItemDetail2014 = magicItemDetail2014Factory.build({
+      name: "Bag of Holding",
+      equipment_category: { index: "wondrous-items", name: "Wondrous Items", url: "" },
+      rarity: { name: "Uncommon" },
+      desc: ["Wondrous item, uncommon", "This bag has an interior space..."],
+    });
+    const card = magicItemDetailToCard(bagOfHoldingLike);
+    expect(card.name).toBe("Bag of Holding");
   });
 });

--- a/src/api/mappers/magicItems.ts
+++ b/src/api/mappers/magicItems.ts
@@ -1,22 +1,38 @@
 import type { ItemCard } from "../../cards/types";
 import { newId } from "../../lib/id";
 import { nowIso } from "../../lib/time";
+import type { EquipmentDetail } from "../endpoints/equipment";
 import type { MagicItemDetail } from "../endpoints/magicItems";
+import { equipmentToFooterInsert, equipmentToHeaderInsert } from "./equipment";
 
 const IMAGE_BASE = "https://www.dnd5eapi.co";
 
-const composeHeaderTags = (category: string, attunement: boolean): string[] => {
+const composeHeaderTags = (
+  category: string,
+  attunement: boolean,
+  enrichment: EquipmentDetail | undefined,
+): string[] => {
   const tags = [category];
+  const insert = enrichment ? equipmentToHeaderInsert(enrichment) : null;
+  if (insert) tags.push(insert);
   if (attunement) tags.push("requires attunement");
   return tags;
 };
 
-const composeFooterTags = (rarity: string): string[] => [rarity.toLowerCase()];
+const composeFooterTags = (rarity: string, enrichment: EquipmentDetail | undefined): string[] => {
+  const tags = [rarity.toLowerCase()];
+  const insert = enrichment ? equipmentToFooterInsert(enrichment) : null;
+  if (insert) tags.push(insert);
+  return tags;
+};
 
 const detectAttunement2014 = (firstLine: string | undefined): boolean =>
   firstLine !== undefined && /requires attunement/i.test(firstLine);
 
-export const magicItemDetailToCard = (detail: MagicItemDetail): ItemCard => {
+export const magicItemDetailToCard = (
+  detail: MagicItemDetail,
+  enrichment?: EquipmentDetail,
+): ItemCard => {
   const now = nowIso();
   const common = {
     id: newId(),
@@ -36,9 +52,9 @@ export const magicItemDetailToCard = (detail: MagicItemDetail): ItemCard => {
   if (detail.ruleset === "2024") {
     return {
       ...common,
-      headerTags: composeHeaderTags(detail.equipment_category.name, detail.attunement),
+      headerTags: composeHeaderTags(detail.equipment_category.name, detail.attunement, enrichment),
       body: detail.desc,
-      footerTags: composeFooterTags(detail.rarity.name),
+      footerTags: composeFooterTags(detail.rarity.name, enrichment),
     };
   }
 
@@ -47,8 +63,9 @@ export const magicItemDetailToCard = (detail: MagicItemDetail): ItemCard => {
     headerTags: composeHeaderTags(
       detail.equipment_category.name,
       detectAttunement2014(detail.desc[0]),
+      enrichment,
     ),
     body: detail.desc.join("\n\n"),
-    footerTags: composeFooterTags(detail.rarity.name),
+    footerTags: composeFooterTags(detail.rarity.name, enrichment),
   };
 };

--- a/src/api/mappers/magicItems.ts
+++ b/src/api/mappers/magicItems.ts
@@ -102,9 +102,7 @@ export const magicItemDetailToCard = (
   };
 
   if (detail.ruleset === "2024") {
-    const hint = parseBaseHint(
-      detail.desc.slice(0, detail.desc.indexOf("\n")).trim() || detail.desc,
-    );
+    const hint = parseBaseHint(detail.desc);
     return {
       ...common,
       name: composeName(detail.name, hint, enrichment),

--- a/src/api/mappers/magicItems.ts
+++ b/src/api/mappers/magicItems.ts
@@ -3,10 +3,15 @@ import { newId } from "../../lib/id";
 import { nowIso } from "../../lib/time";
 import type { EquipmentDetail } from "../endpoints/equipment";
 import type { MagicItemDetail } from "../endpoints/magicItems";
+import { type BaseHint, parseBaseHint } from "./baseHint";
 import { equipmentToFooterInsert, equipmentToHeaderInsert } from "./equipment";
 
 const IMAGE_BASE = "https://www.dnd5eapi.co";
 
+// Tags are built from structured fields (equipment_category, attunement, rarity)
+// plus an optional insert derived from the enrichment base item. The enrichment
+// insert lets callers see "1d8 slashing" or "AC 18" in the header without
+// reaching into the body prose.
 const composeHeaderTags = (
   category: string,
   attunement: boolean,
@@ -29,6 +34,54 @@ const composeFooterTags = (rarity: string, enrichment: EquipmentDetail | undefin
 const detectAttunement2014 = (firstLine: string | undefined): boolean =>
   firstLine !== undefined && /requires attunement/i.test(firstLine);
 
+// dnd5eapi 2024 magic-item desc is a single string whose first line is
+// a metadata header like "Weapon (Any Melee Weapon)" followed by two
+// trailing spaces (Markdown hard-break) and a newline, then the body.
+// We strip that header line so it doesn't duplicate the tags + "Described
+// as:" surface elsewhere in the UI. If the first line doesn't match a
+// known type prefix we leave the desc unchanged — defensive against the
+// API returning a shape we haven't observed.
+const TYPE_PREFIX_2024 = /^(Weapon|Armor|Wondrous Item|Wand|Rod|Staff|Ring|Potion|Scroll)\b/i;
+
+const stripBodyPrefix2024 = (desc: string): string => {
+  const idx = desc.indexOf("\n");
+  if (idx < 0) return desc;
+  const head = desc.slice(0, idx).trim();
+  if (!TYPE_PREFIX_2024.test(head)) return desc;
+  return desc.slice(idx + 1).trim();
+};
+
+// dnd5eapi 2014 magic-item desc is a string[]. desc[0] is the metadata
+// header line ("Weapon (any sword), rare (requires attunement)"); body
+// content starts at desc[1]. Pattern verified across all observed types.
+const stripBodyPrefix2014 = (desc: string[]): string => desc.slice(1).join("\n\n");
+
+// For "any X" templates (Flame Tongue's "Weapon (Any Melee Weapon)",
+// Holy Avenger 2024's "Weapon (Any Simple or Martial)"), the API name
+// alone doesn't say which base the user picked. Append the base name in
+// parens so the title reads "Flame Tongue (Trident)". For "specific"
+// items (Sun Blade is always a longsword) and non-enrichable items, the
+// API name is already complete and we leave it unchanged.
+const composeName = (
+  baseName: string,
+  hint: BaseHint,
+  enrichment: EquipmentDetail | undefined,
+): string => {
+  if (!enrichment) return baseName;
+  if (hint.kind !== "any") return baseName;
+  return `${baseName} (${enrichment.name})`;
+};
+
+/**
+ * Maps a dnd5eapi magic-item detail response to an ItemCard.
+ *
+ * Key API contract differences between rulesets:
+ * - 2024: `attunement` is a boolean field; `desc` is a single string whose
+ *   first line is a metadata header (stripped here).
+ * - 2014: attunement must be regex-detected from `desc[0]` prose; `desc` is
+ *   a string[] where `desc[0]` is the metadata header and body starts at
+ *   `desc[1]`.
+ */
 export const magicItemDetailToCard = (
   detail: MagicItemDetail,
   enrichment?: EquipmentDetail,
@@ -37,7 +90,6 @@ export const magicItemDetailToCard = (
   const common = {
     id: newId(),
     kind: "item" as const,
-    name: detail.name,
     source: "api" as const,
     apiRef: {
       system: "dnd5eapi" as const,
@@ -50,22 +102,28 @@ export const magicItemDetailToCard = (
   };
 
   if (detail.ruleset === "2024") {
+    const hint = parseBaseHint(
+      detail.desc.slice(0, detail.desc.indexOf("\n")).trim() || detail.desc,
+    );
     return {
       ...common,
+      name: composeName(detail.name, hint, enrichment),
       headerTags: composeHeaderTags(detail.equipment_category.name, detail.attunement, enrichment),
-      body: detail.desc,
+      body: stripBodyPrefix2024(detail.desc),
       footerTags: composeFooterTags(detail.rarity.name, enrichment),
     };
   }
 
+  const hint = parseBaseHint(detail.desc[0]);
   return {
     ...common,
+    name: composeName(detail.name, hint, enrichment),
     headerTags: composeHeaderTags(
       detail.equipment_category.name,
       detectAttunement2014(detail.desc[0]),
       enrichment,
     ),
-    body: detail.desc.join("\n\n"),
+    body: stripBodyPrefix2014(detail.desc),
     footerTags: composeFooterTags(detail.rarity.name, enrichment),
   };
 };

--- a/src/api/mappers/magicItems.ts
+++ b/src/api/mappers/magicItems.ts
@@ -5,11 +5,13 @@ import type { MagicItemDetail } from "../endpoints/magicItems";
 
 const IMAGE_BASE = "https://www.dnd5eapi.co";
 
-const composeHeaderTags = (category: string, rarity: string, attunement: boolean): string[] => {
-  const tags = [category, rarity.toLowerCase()];
+const composeHeaderTags = (category: string, attunement: boolean): string[] => {
+  const tags = [category];
   if (attunement) tags.push("requires attunement");
   return tags;
 };
+
+const composeFooterTags = (rarity: string): string[] => [rarity.toLowerCase()];
 
 const detectAttunement2014 = (firstLine: string | undefined): boolean =>
   firstLine !== undefined && /requires attunement/i.test(firstLine);
@@ -34,13 +36,9 @@ export const magicItemDetailToCard = (detail: MagicItemDetail): ItemCard => {
   if (detail.ruleset === "2024") {
     return {
       ...common,
-      headerTags: composeHeaderTags(
-        detail.equipment_category.name,
-        detail.rarity.name,
-        detail.attunement,
-      ),
+      headerTags: composeHeaderTags(detail.equipment_category.name, detail.attunement),
       body: detail.desc,
-      footerTags: [],
+      footerTags: composeFooterTags(detail.rarity.name),
     };
   }
 
@@ -48,10 +46,9 @@ export const magicItemDetailToCard = (detail: MagicItemDetail): ItemCard => {
     ...common,
     headerTags: composeHeaderTags(
       detail.equipment_category.name,
-      detail.rarity.name,
       detectAttunement2014(detail.desc[0]),
     ),
     body: detail.desc.join("\n\n"),
-    footerTags: [],
+    footerTags: composeFooterTags(detail.rarity.name),
   };
 };

--- a/src/api/mappers/magicItems.ts
+++ b/src/api/mappers/magicItems.ts
@@ -13,7 +13,7 @@ const composeHeaderTags = (
   enrichment: EquipmentDetail | undefined,
 ): string[] => {
   const tags = [category];
-  const insert = enrichment ? equipmentToHeaderInsert(enrichment) : null;
+  const insert = equipmentToHeaderInsert(enrichment);
   if (insert) tags.push(insert);
   if (attunement) tags.push("requires attunement");
   return tags;
@@ -21,7 +21,7 @@ const composeHeaderTags = (
 
 const composeFooterTags = (rarity: string, enrichment: EquipmentDetail | undefined): string[] => {
   const tags = [rarity.toLowerCase()];
-  const insert = enrichment ? equipmentToFooterInsert(enrichment) : null;
+  const insert = equipmentToFooterInsert(enrichment);
   if (insert) tags.push(insert);
   return tags;
 };

--- a/src/api/timing.ts
+++ b/src/api/timing.ts
@@ -1,0 +1,1 @@
+export const DAY_MS = 24 * 60 * 60 * 1000;

--- a/src/cards/ItemEditor.module.css
+++ b/src/cards/ItemEditor.module.css
@@ -28,6 +28,11 @@
   margin-top: var(--space-1);
 }
 
+.help {
+  font-size: var(--fs-xs);
+  color: var(--color-text-muted);
+}
+
 .row {
   display: flex;
   gap: var(--space-4);

--- a/src/cards/ItemEditor.module.css
+++ b/src/cards/ItemEditor.module.css
@@ -31,6 +31,7 @@
 .help {
   font-size: var(--fs-xs);
   color: var(--color-text-muted);
+  margin-top: var(--space-1);
 }
 
 .row {

--- a/src/cards/ItemEditor.test.tsx
+++ b/src/cards/ItemEditor.test.tsx
@@ -157,13 +157,13 @@ describe("<ItemEditor>", () => {
   test("renders header tag help text", () => {
     const card = itemCardFactory.build();
     render(<Harness initial={card} />);
-    expect(screen.getByText(/type first, then damage\/AC, then attunement/i)).toBeInTheDocument();
+    expect(screen.getByText(/suggested order: type, damage\/AC, attunement/i)).toBeInTheDocument();
   });
 
   test("renders footer tag help text", () => {
     const card = itemCardFactory.build();
     render(<Harness initial={card} />);
-    expect(screen.getByText(/rarity first, then cost, then weight/i)).toBeInTheDocument();
+    expect(screen.getByText(/suggested order: rarity, cost, weight/i)).toBeInTheDocument();
   });
 
   test("Name and Icon controls share a row container", () => {

--- a/src/cards/ItemEditor.test.tsx
+++ b/src/cards/ItemEditor.test.tsx
@@ -154,6 +154,18 @@ describe("<ItemEditor>", () => {
     expect(seen[seen.length - 1]?.footerTags).toEqual(["10 lb"]);
   });
 
+  test("renders header tag help text", () => {
+    const card = itemCardFactory.build();
+    render(<Harness initial={card} />);
+    expect(screen.getByText(/type first, then damage\/AC, then attunement/i)).toBeInTheDocument();
+  });
+
+  test("renders footer tag help text", () => {
+    const card = itemCardFactory.build();
+    render(<Harness initial={card} />);
+    expect(screen.getByText(/rarity first, then cost, then weight/i)).toBeInTheDocument();
+  });
+
   test("Name and Icon controls share a row container", () => {
     const card = itemCardFactory.build();
     render(<Harness initial={card} />);

--- a/src/cards/ItemEditor.tsx
+++ b/src/cards/ItemEditor.tsx
@@ -42,10 +42,12 @@ export function ItemEditor({ card, onChange }: Props) {
     name: `${idBase}-name`,
     headerTags: `${idBase}-headerTags`,
     headerTagsLabel: `${idBase}-headerTagsLabel`,
+    headerTagsHelp: `${idBase}-headerTagsHelp`,
     icon: `${idBase}-icon`,
     body: `${idBase}-body`,
     footerTags: `${idBase}-footerTags`,
     footerTagsLabel: `${idBase}-footerTagsLabel`,
+    footerTagsHelp: `${idBase}-footerTagsHelp`,
     imageUrl: `${idBase}-imageUrl`,
   };
 
@@ -77,11 +79,14 @@ export function ItemEditor({ card, onChange }: Props) {
         <TagInput
           id={ids.headerTags}
           aria-labelledby={ids.headerTagsLabel}
+          aria-describedby={ids.headerTagsHelp}
           value={card.headerTags}
           onChange={handleHeaderTagsChange}
           placeholder="Type and press Enter — e.g. Weapon, 1d6 piercing, requires attunement"
         />
-        <span className={styles.help}>Suggested order: type, damage/AC, attunement.</span>
+        <span id={ids.headerTagsHelp} className={styles.help}>
+          Suggested order: type, damage/AC, attunement.
+        </span>
       </div>
       <label className={styles.field} htmlFor={ids.body}>
         <span className={styles.label}>Body</span>
@@ -94,11 +99,14 @@ export function ItemEditor({ card, onChange }: Props) {
         <TagInput
           id={ids.footerTags}
           aria-labelledby={ids.footerTagsLabel}
+          aria-describedby={ids.footerTagsHelp}
           value={card.footerTags}
           onChange={handleFooterTagsChange}
           placeholder="Type and press Enter — e.g. rare, 100 gp, 10 lb"
         />
-        <span className={styles.help}>Suggested order: rarity, cost, weight.</span>
+        <span id={ids.footerTagsHelp} className={styles.help}>
+          Suggested order: rarity, cost, weight.
+        </span>
       </div>
       <label className={styles.field} htmlFor={ids.imageUrl}>
         <span className={styles.label}>Image URL (optional)</span>

--- a/src/cards/ItemEditor.tsx
+++ b/src/cards/ItemEditor.tsx
@@ -72,15 +72,16 @@ export function ItemEditor({ card, onChange }: Props) {
       </div>
       <div className={styles.field}>
         <span className={styles.label} id={ids.headerTagsLabel}>
-          Header tags (type, rarity, …)
+          Header tags
         </span>
         <TagInput
           id={ids.headerTags}
           aria-labelledby={ids.headerTagsLabel}
           value={card.headerTags}
           onChange={handleHeaderTagsChange}
-          placeholder="Type and press Enter — e.g. Wondrous item, uncommon, requires attunement"
+          placeholder="Type and press Enter — e.g. Weapon, 1d6 piercing, requires attunement"
         />
+        <span className={styles.help}>Type first, then damage/AC, then attunement.</span>
       </div>
       <label className={styles.field} htmlFor={ids.body}>
         <span className={styles.label}>Body</span>
@@ -88,15 +89,16 @@ export function ItemEditor({ card, onChange }: Props) {
       </label>
       <div className={styles.field}>
         <span className={styles.label} id={ids.footerTagsLabel}>
-          Footer tags (cost, weight, …)
+          Footer tags
         </span>
         <TagInput
           id={ids.footerTags}
           aria-labelledby={ids.footerTagsLabel}
           value={card.footerTags}
           onChange={handleFooterTagsChange}
-          placeholder="Type and press Enter — e.g. 500 gp, 10 lb, rare"
+          placeholder="Type and press Enter — e.g. rare, 100 gp, 10 lb"
         />
+        <span className={styles.help}>Rarity first, then cost, then weight.</span>
       </div>
       <label className={styles.field} htmlFor={ids.imageUrl}>
         <span className={styles.label}>Image URL (optional)</span>

--- a/src/cards/ItemEditor.tsx
+++ b/src/cards/ItemEditor.tsx
@@ -81,7 +81,7 @@ export function ItemEditor({ card, onChange }: Props) {
           onChange={handleHeaderTagsChange}
           placeholder="Type and press Enter — e.g. Weapon, 1d6 piercing, requires attunement"
         />
-        <span className={styles.help}>Type first, then damage/AC, then attunement.</span>
+        <span className={styles.help}>Suggested order: type, damage/AC, attunement.</span>
       </div>
       <label className={styles.field} htmlFor={ids.body}>
         <span className={styles.label}>Body</span>
@@ -98,7 +98,7 @@ export function ItemEditor({ card, onChange }: Props) {
           onChange={handleFooterTagsChange}
           placeholder="Type and press Enter — e.g. rare, 100 gp, 10 lb"
         />
-        <span className={styles.help}>Rarity first, then cost, then weight.</span>
+        <span className={styles.help}>Suggested order: rarity, cost, weight.</span>
       </div>
       <label className={styles.field} htmlFor={ids.imageUrl}>
         <span className={styles.label}>Image URL (optional)</span>

--- a/src/lib/ui/TagInput.tsx
+++ b/src/lib/ui/TagInput.tsx
@@ -10,6 +10,7 @@ export type TagInputProps = {
   placeholder?: string;
   "aria-label"?: string;
   "aria-labelledby"?: string;
+  "aria-describedby"?: string;
 };
 
 export function TagInput({
@@ -20,6 +21,7 @@ export function TagInput({
   placeholder,
   "aria-label": ariaLabel,
   "aria-labelledby": ariaLabelledBy,
+  "aria-describedby": ariaDescribedBy,
 }: TagInputProps) {
   const [draft, setDraft] = useState("");
 
@@ -68,6 +70,7 @@ export function TagInput({
         type="text"
         aria-label={ariaLabelledBy ? undefined : (ariaLabel ?? "Tags")}
         aria-labelledby={ariaLabelledBy}
+        aria-describedby={ariaDescribedBy}
         className={styles.input}
         value={draft}
         onChange={(e) => setDraft(e.target.value)}

--- a/src/test/msw.ts
+++ b/src/test/msw.ts
@@ -1,5 +1,6 @@
 import { HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
+import type { EquipmentDetail, EquipmentIndex } from "../api/endpoints/equipment";
 import type { MagicItemDetail, MagicItemIndex, Ruleset } from "../api/endpoints/magicItems";
 import { SB_URL, TEST_USER_ID } from "./constants";
 
@@ -67,6 +68,14 @@ export const magicItemDetailHandler = (ruleset: Ruleset, slug: string, body: Mag
     HttpResponse.json(rest),
   );
 };
+
+export const equipmentIndexHandler = (ruleset: Ruleset, body: EquipmentIndex) =>
+  http.get(`https://www.dnd5eapi.co/api/${ruleset}/equipment`, () => HttpResponse.json(body));
+
+export const equipmentDetailHandler = (ruleset: Ruleset, slug: string, body: EquipmentDetail) =>
+  http.get(`https://www.dnd5eapi.co/api/${ruleset}/equipment/${slug}`, () =>
+    HttpResponse.json(body),
+  );
 
 export const apiErrorHandler = (path: string, status: number) =>
   http.get(`https://www.dnd5eapi.co${path}`, () => new HttpResponse(null, { status }));

--- a/src/views/BrowseApiModal.module.css
+++ b/src/views/BrowseApiModal.module.css
@@ -44,6 +44,7 @@
 
 .row:disabled {
   cursor: not-allowed;
+  opacity: 0.5;
 }
 
 .rowName {

--- a/src/views/BrowseApiModal.test.tsx
+++ b/src/views/BrowseApiModal.test.tsx
@@ -261,4 +261,26 @@ describe("<BrowseApiModal>", () => {
     await screen.findByRole("button", { name: "Flame Tongue" });
     expect(screen.queryByRole("button", { name: /skip/i })).not.toBeInTheDocument();
   });
+
+  test("Back from enrichment returns focus to the previously picked row", async () => {
+    const entry = magicItemIndexEntryFactory.build({ name: "Flame Tongue" });
+    const detail = magicItemDetail2024Factory.build({
+      index: entry.index,
+      name: entry.name,
+      equipment_category: { index: "weapons", name: "Weapons", url: "" },
+      desc: "Weapon (Any Melee Weapon)  \n A flaming sword.",
+    });
+    server.use(
+      magicItemIndexHandler("2024", { count: 1, results: [entry] }),
+      magicItemDetailHandler("2024", entry.index, detail),
+      equipmentIndexHandler("2024", { count: 0, results: [] }),
+    );
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "Flame Tongue" }));
+    await userEvent.click(await screen.findByRole("button", { name: /back/i }));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Flame Tongue" })).toHaveFocus());
+  });
 });

--- a/src/views/BrowseApiModal.test.tsx
+++ b/src/views/BrowseApiModal.test.tsx
@@ -174,7 +174,9 @@ describe("<BrowseApiModal>", () => {
 
     await userEvent.click(await screen.findByRole("button", { name: "Sun Blade" }));
 
-    expect(await screen.findByRole("button", { name: /longsword/i })).toBeInTheDocument();
+    const longswordRow = await screen.findByRole("button", { name: /longsword/i });
+    expect(longswordRow).toBeInTheDocument();
+    expect(longswordRow).not.toHaveAttribute("aria-pressed", "true");
     expect(screen.getByRole("button", { name: /skip/i })).toBeInTheDocument();
   });
 

--- a/src/views/BrowseApiModal.test.tsx
+++ b/src/views/BrowseApiModal.test.tsx
@@ -8,6 +8,7 @@ import { magicItemDetail2024Factory, magicItemIndexEntryFactory } from "../api/f
 import { makeCardRow } from "../test/factories";
 import {
   apiErrorHandler,
+  equipmentIndexHandler,
   magicItemDetailHandler,
   magicItemIndexHandler,
   SB_URL,
@@ -65,7 +66,15 @@ describe("<BrowseApiModal>", () => {
 
   test("clicking a row POSTs the card to the persistence layer and calls onSelected", async () => {
     const entry = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
-    const detail = magicItemDetail2024Factory.build({ index: entry.index, name: entry.name });
+    const detail = magicItemDetail2024Factory.build({
+      index: entry.index,
+      name: entry.name,
+      equipment_category: {
+        index: "wondrous-items",
+        name: "Wondrous Items",
+        url: "",
+      },
+    });
     server.use(
       magicItemIndexHandler("2024", { count: 1, results: [entry] }),
       magicItemDetailHandler("2024", entry.index, detail),
@@ -89,7 +98,15 @@ describe("<BrowseApiModal>", () => {
 
   test("clicking the same row only POSTs once even under StrictMode double-render", async () => {
     const entry = magicItemIndexEntryFactory.build({ name: "Flame Tongue" });
-    const detail = magicItemDetail2024Factory.build({ index: entry.index, name: entry.name });
+    const detail = magicItemDetail2024Factory.build({
+      index: entry.index,
+      name: entry.name,
+      equipment_category: {
+        index: "wondrous-items",
+        name: "Wondrous Items",
+        url: "",
+      },
+    });
     server.use(
       magicItemIndexHandler("2024", { count: 1, results: [entry] }),
       magicItemDetailHandler("2024", entry.index, detail),
@@ -134,5 +151,115 @@ describe("<BrowseApiModal>", () => {
     wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />);
 
     expect(await screen.findByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  test("specific weapon advances to enrichment with auto-select", async () => {
+    const entry = magicItemIndexEntryFactory.build({ name: "Sun Blade" });
+    const detail = magicItemDetail2024Factory.build({
+      index: entry.index,
+      name: entry.name,
+      equipment_category: { index: "weapons", name: "Weapons", url: "" },
+      rarity: { name: "Rare" },
+      attunement: true,
+      desc: "Weapon (Longsword)  \n A glowing sword.",
+    });
+    server.use(
+      magicItemIndexHandler("2024", { count: 1, results: [entry] }),
+      magicItemDetailHandler("2024", entry.index, detail),
+      equipmentIndexHandler("2024", {
+        count: 1,
+        results: [{ index: "longsword", name: "Longsword", url: "/api/2024/equipment/longsword" }],
+      }),
+    );
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "Sun Blade" }));
+
+    const longswordRow = await screen.findByRole("button", { name: /longsword/i });
+    await waitFor(() => expect(longswordRow).toHaveAttribute("aria-pressed", "true"));
+    expect(screen.getByRole("button", { name: /skip/i })).toBeInTheDocument();
+  });
+
+  test("'any X' template advances to enrichment with no auto-select", async () => {
+    const entry = magicItemIndexEntryFactory.build({ name: "Flame Tongue" });
+    const detail = magicItemDetail2024Factory.build({
+      index: entry.index,
+      name: entry.name,
+      equipment_category: { index: "weapons", name: "Weapons", url: "" },
+      desc: "Weapon (Any Melee Weapon)  \n A flaming sword.",
+    });
+    server.use(
+      magicItemIndexHandler("2024", { count: 1, results: [entry] }),
+      magicItemDetailHandler("2024", entry.index, detail),
+      equipmentIndexHandler("2024", {
+        count: 2,
+        results: [
+          { index: "longsword", name: "Longsword", url: "" },
+          { index: "warhammer", name: "Warhammer", url: "" },
+        ],
+      }),
+    );
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "Flame Tongue" }));
+
+    await screen.findByRole("button", { name: /skip/i });
+    expect(screen.getByRole("button", { name: /confirm/i })).toBeDisabled();
+  });
+
+  test("Skip from enrichment saves the card without enrichment", async () => {
+    const entry = magicItemIndexEntryFactory.build({ name: "Flame Tongue" });
+    const detail = magicItemDetail2024Factory.build({
+      index: entry.index,
+      name: entry.name,
+      equipment_category: { index: "weapons", name: "Weapons", url: "" },
+      desc: "Weapon (Any Melee Weapon)  \n A flaming sword.",
+    });
+    server.use(
+      magicItemIndexHandler("2024", { count: 1, results: [entry] }),
+      magicItemDetailHandler("2024", entry.index, detail),
+      equipmentIndexHandler("2024", { count: 0, results: [] }),
+    );
+    const onPost = vi.fn();
+    server.use(
+      http.post(`${SB_URL}/rest/v1/cards`, async ({ request }) => {
+        onPost(await request.json());
+        return HttpResponse.json([makeCardRow.build()], { status: 201 });
+      }),
+    );
+    const onSelected = vi.fn();
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={onSelected} />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "Flame Tongue" }));
+    await userEvent.click(await screen.findByRole("button", { name: /skip/i }));
+
+    await waitFor(() => expect(onPost).toHaveBeenCalled());
+    expect(onSelected).toHaveBeenCalled();
+  });
+
+  test("Back from enrichment returns to picker", async () => {
+    const entry = magicItemIndexEntryFactory.build({ name: "Flame Tongue" });
+    const detail = magicItemDetail2024Factory.build({
+      index: entry.index,
+      name: entry.name,
+      equipment_category: { index: "weapons", name: "Weapons", url: "" },
+      desc: "Weapon (Any Melee Weapon)  \n A flaming sword.",
+    });
+    server.use(
+      magicItemIndexHandler("2024", { count: 1, results: [entry] }),
+      magicItemDetailHandler("2024", entry.index, detail),
+      equipmentIndexHandler("2024", { count: 0, results: [] }),
+    );
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "Flame Tongue" }));
+    await userEvent.click(await screen.findByRole("button", { name: /back/i }));
+
+    await screen.findByRole("button", { name: "Flame Tongue" });
+    expect(screen.queryByRole("button", { name: /skip/i })).not.toBeInTheDocument();
   });
 });

--- a/src/views/BrowseApiModal.test.tsx
+++ b/src/views/BrowseApiModal.test.tsx
@@ -159,8 +159,6 @@ describe("<BrowseApiModal>", () => {
       index: entry.index,
       name: entry.name,
       equipment_category: { index: "weapons", name: "Weapons", url: "" },
-      rarity: { name: "Rare" },
-      attunement: true,
       desc: "Weapon (Longsword)  \n A glowing sword.",
     });
     server.use(

--- a/src/views/BrowseApiModal.test.tsx
+++ b/src/views/BrowseApiModal.test.tsx
@@ -153,7 +153,7 @@ describe("<BrowseApiModal>", () => {
     expect(await screen.findByRole("button", { name: /retry/i })).toBeInTheDocument();
   });
 
-  test("specific weapon advances to enrichment with auto-select", async () => {
+  test("specific weapon advances to enrichment", async () => {
     const entry = magicItemIndexEntryFactory.build({ name: "Sun Blade" });
     const detail = magicItemDetail2024Factory.build({
       index: entry.index,
@@ -174,8 +174,7 @@ describe("<BrowseApiModal>", () => {
 
     await userEvent.click(await screen.findByRole("button", { name: "Sun Blade" }));
 
-    const longswordRow = await screen.findByRole("button", { name: /longsword/i });
-    await waitFor(() => expect(longswordRow).toHaveAttribute("aria-pressed", "true"));
+    expect(await screen.findByRole("button", { name: /longsword/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /skip/i })).toBeInTheDocument();
   });
 
@@ -204,7 +203,7 @@ describe("<BrowseApiModal>", () => {
     await userEvent.click(await screen.findByRole("button", { name: "Flame Tongue" }));
 
     await screen.findByRole("button", { name: /skip/i });
-    expect(screen.getByRole("button", { name: /confirm/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /back/i })).toBeInTheDocument();
   });
 
   test("Skip from enrichment saves the card without enrichment", async () => {

--- a/src/views/BrowseApiModal.tsx
+++ b/src/views/BrowseApiModal.tsx
@@ -10,6 +10,7 @@ import {
 import { useMagicItemIndex } from "../api/hooks";
 import { type BaseHint, parseBaseHint } from "../api/mappers/baseHint";
 import { magicItemDetailToCard } from "../api/mappers/magicItems";
+import { DAY_MS } from "../api/timing";
 import { useSaveCard } from "../decks/mutations";
 import { Button } from "../lib/ui/Button";
 import { DialogHeader } from "../lib/ui/DialogHeader";
@@ -28,8 +29,6 @@ type Props = {
 };
 
 type Step = { step: "pick" } | { step: "enrich"; magicDetail: MagicItemDetail; hint: BaseHint };
-
-const DAY_MS = 24 * 60 * 60 * 1000;
 
 const isEnrichable = (k: string): boolean => {
   const lo = k.toLowerCase();
@@ -74,7 +73,6 @@ export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
         onSelected(card.id);
       }
     } catch (err) {
-      console.error("Failed to add magic-item to deck", err);
       setPickError(
         err instanceof Error ? err.message : "Couldn't add this card. Please try again.",
       );
@@ -144,7 +142,7 @@ export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
               <div className={styles.results}>
                 {index.isLoading && <LoadingState />}
                 {index.isError && (
-                  <div className={styles.state}>
+                  <div className={styles.state} role="alert">
                     Couldn't load the magic-items list.
                     <div className={styles.errorActions}>
                       <Button variant="secondary" size="sm" onPress={() => index.refetch()}>

--- a/src/views/BrowseApiModal.tsx
+++ b/src/views/BrowseApiModal.tsx
@@ -1,8 +1,14 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { TextField } from "react-aria-components";
-import { fetchMagicItemDetail, type Ruleset } from "../api/endpoints/magicItems";
+import type { EquipmentDetail } from "../api/endpoints/equipment";
+import {
+  fetchMagicItemDetail,
+  type MagicItemDetail,
+  type Ruleset,
+} from "../api/endpoints/magicItems";
 import { useMagicItemIndex } from "../api/hooks";
+import { type BaseHint, parseBaseHint } from "../api/mappers/baseHint";
 import { magicItemDetailToCard } from "../api/mappers/magicItems";
 import { useSaveCard } from "../decks/mutations";
 import { Button } from "../lib/ui/Button";
@@ -13,6 +19,7 @@ import { LoadingState } from "../lib/ui/LoadingState";
 import { ToggleButton } from "../lib/ui/ToggleButton";
 import { ToggleButtonGroup } from "../lib/ui/ToggleButtonGroup";
 import styles from "./BrowseApiModal.module.css";
+import { EnrichmentStep } from "./EnrichmentStep";
 
 type Props = {
   deckId: string;
@@ -20,13 +27,21 @@ type Props = {
   onSelected: (cardId: string) => void;
 };
 
+type Step = { step: "pick" } | { step: "enrich"; magicDetail: MagicItemDetail; hint: BaseHint };
+
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+const isEnrichable = (k: string): boolean => {
+  const lo = k.toLowerCase();
+  return lo === "weapon" || lo === "weapons" || lo === "armor";
+};
 
 export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
   const [ruleset, setRuleset] = useState<Ruleset>("2024");
   const [query, setQuery] = useState("");
   const [pickingSlug, setPickingSlug] = useState<string | null>(null);
   const [pickError, setPickError] = useState<string | null>(null);
+  const [step, setStep] = useState<Step>({ step: "pick" });
 
   const index = useMagicItemIndex(ruleset);
   const queryClient = useQueryClient();
@@ -49,9 +64,15 @@ export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
         queryFn: () => fetchMagicItemDetail(ruleset, slug),
         staleTime: DAY_MS,
       });
-      const card = magicItemDetailToCard(detail);
-      await saveCard.mutateAsync({ card, deckId, isNew: true });
-      onSelected(card.id);
+      if (isEnrichable(detail.equipment_category.index)) {
+        const desc0 = detail.ruleset === "2024" ? detail.desc : detail.desc[0];
+        const hint = parseBaseHint(desc0);
+        setStep({ step: "enrich", magicDetail: detail, hint });
+      } else {
+        const card = magicItemDetailToCard(detail);
+        await saveCard.mutateAsync({ card, deckId, isNew: true });
+        onSelected(card.id);
+      }
     } catch (err) {
       console.error("Failed to add magic-item to deck", err);
       setPickError(
@@ -61,6 +82,19 @@ export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
       setPickingSlug(null);
     }
   };
+
+  const handleEnrichmentConfirm = async (enrichment: EquipmentDetail | null) => {
+    if (step.step !== "enrich") return;
+    const card = magicItemDetailToCard(step.magicDetail, enrichment ?? undefined);
+    await saveCard.mutateAsync({ card, deckId, isNew: true });
+    onSelected(card.id);
+  };
+
+  const handleEnrichmentCancel = () => {
+    setStep({ step: "pick" });
+  };
+
+  const title = step.step === "enrich" ? step.magicDetail.name : "Browse magic items";
 
   return (
     <DialogShell
@@ -75,68 +109,83 @@ export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
     >
       {() => (
         <>
-          <DialogHeader title="Browse magic items" onClose={onClose}>
-            <ToggleButtonGroup
-              aria-label="Magic items ruleset"
-              selectionMode="single"
-              disallowEmptySelection
-              selectedKeys={[ruleset]}
-              onSelectionChange={(keys) => {
-                const next = Array.from(keys)[0];
-                if (next === "2014" || next === "2024") setRuleset(next);
-              }}
-            >
-              <ToggleButton id="2014">2014</ToggleButton>
-              <ToggleButton id="2024">2024</ToggleButton>
-            </ToggleButtonGroup>
+          <DialogHeader title={title} onClose={onClose}>
+            {step.step === "pick" && (
+              <ToggleButtonGroup
+                aria-label="Magic items ruleset"
+                selectionMode="single"
+                disallowEmptySelection
+                selectedKeys={[ruleset]}
+                onSelectionChange={(keys) => {
+                  const next = Array.from(keys)[0];
+                  if (next === "2014" || next === "2024") setRuleset(next);
+                }}
+              >
+                <ToggleButton id="2014">2014</ToggleButton>
+                <ToggleButton id="2024">2024</ToggleButton>
+              </ToggleButtonGroup>
+            )}
           </DialogHeader>
 
-          <div className={styles.searchRow}>
-            <TextField aria-label="Search magic items" className={styles.searchField}>
-              <Input
-                type="search"
-                placeholder="Search magic items…"
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                autoFocus
-              />
-            </TextField>
-          </div>
+          {step.step === "pick" ? (
+            <>
+              <div className={styles.searchRow}>
+                <TextField aria-label="Search magic items" className={styles.searchField}>
+                  <Input
+                    type="search"
+                    placeholder="Search magic items…"
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    autoFocus
+                  />
+                </TextField>
+              </div>
 
-          <div className={styles.results}>
-            {index.isLoading && <LoadingState />}
-            {index.isError && (
-              <div className={styles.state}>
-                Couldn't load the magic-items list.
-                <div className={styles.errorActions}>
-                  <Button variant="secondary" size="sm" onPress={() => index.refetch()}>
-                    Retry
-                  </Button>
-                </div>
+              <div className={styles.results}>
+                {index.isLoading && <LoadingState />}
+                {index.isError && (
+                  <div className={styles.state}>
+                    Couldn't load the magic-items list.
+                    <div className={styles.errorActions}>
+                      <Button variant="secondary" size="sm" onPress={() => index.refetch()}>
+                        Retry
+                      </Button>
+                    </div>
+                  </div>
+                )}
+                {index.isSuccess && filtered.length === 0 && (
+                  <div className={styles.state}>No items match your search.</div>
+                )}
+                {pickError && (
+                  <div className={styles.state} role="alert">
+                    {pickError}
+                  </div>
+                )}
+                {index.isSuccess &&
+                  filtered.map((entry) => (
+                    <button
+                      key={entry.index}
+                      type="button"
+                      className={styles.row}
+                      onClick={() => handlePick(entry.index)}
+                      disabled={pickingSlug !== null}
+                    >
+                      <span className={styles.rowName}>{entry.name}</span>
+                      {pickingSlug === entry.index && (
+                        <span className={styles.rowMeta}>Loading…</span>
+                      )}
+                    </button>
+                  ))}
               </div>
-            )}
-            {index.isSuccess && filtered.length === 0 && (
-              <div className={styles.state}>No items match your search.</div>
-            )}
-            {pickError && (
-              <div className={styles.state} role="alert">
-                {pickError}
-              </div>
-            )}
-            {index.isSuccess &&
-              filtered.map((entry) => (
-                <button
-                  key={entry.index}
-                  type="button"
-                  className={styles.row}
-                  onClick={() => handlePick(entry.index)}
-                  disabled={pickingSlug !== null}
-                >
-                  <span className={styles.rowName}>{entry.name}</span>
-                  {pickingSlug === entry.index && <span className={styles.rowMeta}>Loading…</span>}
-                </button>
-              ))}
-          </div>
+            </>
+          ) : (
+            <EnrichmentStep
+              ruleset={ruleset}
+              hint={step.hint}
+              onConfirm={handleEnrichmentConfirm}
+              onCancel={handleEnrichmentCancel}
+            />
+          )}
         </>
       )}
     </DialogShell>

--- a/src/views/BrowseApiModal.tsx
+++ b/src/views/BrowseApiModal.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { TextField } from "react-aria-components";
 import type { EquipmentDetail } from "../api/endpoints/equipment";
 import {
@@ -41,6 +41,7 @@ export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
   const [pickingSlug, setPickingSlug] = useState<string | null>(null);
   const [pickError, setPickError] = useState<string | null>(null);
   const [step, setStep] = useState<Step>({ step: "pick" });
+  const lastPickedSlugRef = useRef<string | null>(null);
 
   const index = useMagicItemIndex(ruleset);
   const queryClient = useQueryClient();
@@ -53,8 +54,17 @@ export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
     return all.filter((e) => e.name.toLowerCase().includes(q));
   }, [index.data, query]);
 
+  useEffect(() => {
+    if (step.step !== "pick") return;
+    const slug = lastPickedSlugRef.current;
+    if (!slug) return;
+    const row = document.querySelector(`[data-slug="${CSS.escape(slug)}"]`);
+    if (row instanceof HTMLElement) row.focus();
+  }, [step.step]);
+
   const handlePick = async (slug: string) => {
     if (pickingSlug !== null) return;
+    lastPickedSlugRef.current = slug;
     setPickingSlug(slug);
     setPickError(null);
     try {
@@ -92,7 +102,10 @@ export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
     setStep({ step: "pick" });
   };
 
-  const title = step.step === "enrich" ? step.magicDetail.name : "Browse magic items";
+  const title =
+    step.step === "enrich"
+      ? `${step.magicDetail.name} — pick base equipment`
+      : "Browse magic items";
 
   return (
     <DialogShell
@@ -165,6 +178,7 @@ export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
                       key={entry.index}
                       type="button"
                       className={styles.row}
+                      data-slug={entry.index}
                       onClick={() => handlePick(entry.index)}
                       disabled={pickingSlug !== null}
                     >

--- a/src/views/EditorView.test.tsx
+++ b/src/views/EditorView.test.tsx
@@ -119,7 +119,11 @@ describe("EditorView", () => {
 
   it("navigates to the imported card's editor after picking from the modal", async () => {
     const entry = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
-    const detail = magicItemDetail2024Factory.build({ index: entry.index, name: entry.name });
+    const detail = magicItemDetail2024Factory.build({
+      index: entry.index,
+      name: entry.name,
+      equipment_category: { index: "wondrous-items", name: "Wondrous Items", url: "" },
+    });
     server.use(
       magicItemIndexHandler("2024", { count: 1, results: [entry] }),
       magicItemDetailHandler("2024", entry.index, detail),

--- a/src/views/EnrichmentStep.module.css
+++ b/src/views/EnrichmentStep.module.css
@@ -1,3 +1,18 @@
+.intro {
+  padding: var(--space-3) var(--space-4) 0;
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.source {
+  padding: var(--space-1) var(--space-4) 0;
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+  font-style: italic;
+  margin: 0;
+}
+
 .searchRow {
   padding: var(--space-3) var(--space-4);
   border-bottom: 1px solid var(--color-border);

--- a/src/views/EnrichmentStep.module.css
+++ b/src/views/EnrichmentStep.module.css
@@ -66,6 +66,16 @@
   color: var(--color-text-muted);
 }
 
+.suggestedChip {
+  font-size: var(--fs-xs);
+  font-weight: 500;
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-2);
+  color: var(--color-text-muted);
+  margin-left: var(--space-2);
+}
+
 .state {
   padding: var(--space-5);
   text-align: center;

--- a/src/views/EnrichmentStep.module.css
+++ b/src/views/EnrichmentStep.module.css
@@ -33,7 +33,7 @@
   border-bottom: 0;
 }
 
-.row:hover {
+.row:hover:not(:disabled) {
   background: var(--color-surface-2);
 }
 
@@ -44,6 +44,8 @@
 
 .row[aria-pressed="true"] {
   background: var(--color-surface-2);
+  border-left: 3px solid var(--color-accent);
+  padding-left: calc(var(--space-4) - 3px);
 }
 
 .rowName {

--- a/src/views/EnrichmentStep.module.css
+++ b/src/views/EnrichmentStep.module.css
@@ -57,14 +57,13 @@
   outline-offset: -2px;
 }
 
-.row[aria-pressed="true"] {
-  background: var(--color-surface-2);
-  border-left: 3px solid var(--color-accent);
-  padding-left: calc(var(--space-4) - 3px);
-}
-
 .rowName {
   font-weight: 600;
+}
+
+.rowMeta {
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
 }
 
 .state {

--- a/src/views/EnrichmentStep.module.css
+++ b/src/views/EnrichmentStep.module.css
@@ -1,0 +1,65 @@
+.searchRow {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.searchField {
+  display: block;
+}
+
+.results {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--space-1) 0;
+}
+
+.row {
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-2) var(--space-4);
+  border: 0;
+  background: transparent;
+  text-align: left;
+  font: inherit;
+  font-family: var(--font-body);
+  cursor: pointer;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.row:last-child {
+  border-bottom: 0;
+}
+
+.row:hover {
+  background: var(--color-surface-2);
+}
+
+.row:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: -2px;
+}
+
+.row[aria-pressed="true"] {
+  background: var(--color-surface-2);
+}
+
+.rowName {
+  font-weight: 600;
+}
+
+.state {
+  padding: var(--space-5);
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+.actions {
+  display: flex;
+  gap: var(--space-2);
+  justify-content: flex-end;
+  padding: var(--space-3) var(--space-4);
+  border-top: 1px solid var(--color-border);
+}

--- a/src/views/EnrichmentStep.module.css
+++ b/src/views/EnrichmentStep.module.css
@@ -57,6 +57,11 @@
   outline-offset: -2px;
 }
 
+.row:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 .rowName {
   font-weight: 600;
 }

--- a/src/views/EnrichmentStep.test.tsx
+++ b/src/views/EnrichmentStep.test.tsx
@@ -24,7 +24,7 @@ beforeEach(() => {
 });
 
 describe("EnrichmentStep", () => {
-  it("auto-selects the single match for a specific hint", async () => {
+  it("clicking a row saves with that equipment as enrichment", async () => {
     server.use(
       equipmentDetailHandler("2014", "longsword", {
         index: "longsword",
@@ -42,14 +42,12 @@ describe("EnrichmentStep", () => {
         onCancel={vi.fn()}
       />,
     );
-    const longswordButton = await screen.findByRole("button", { name: /longsword/i });
-    await waitFor(() => expect(longswordButton).toHaveAttribute("aria-pressed", "true"));
-    await userEvent.click(screen.getByRole("button", { name: /confirm/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /longsword/i }));
     await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
     expect(onConfirm.mock.calls[0]![0]).toMatchObject({ index: "longsword" });
   });
 
-  it("does not auto-select for an 'any X' template; allows skip", async () => {
+  it("clicking Skip saves without enrichment", async () => {
     const onConfirm = vi.fn();
     renderWithClient(
       <EnrichmentStep
@@ -59,37 +57,8 @@ describe("EnrichmentStep", () => {
         onCancel={vi.fn()}
       />,
     );
-    await screen.findByRole("button", { name: /skip/i });
-    expect(screen.getByRole("button", { name: /confirm/i })).toBeDisabled();
-    await userEvent.click(screen.getByRole("button", { name: /skip/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /skip/i }));
     expect(onConfirm).toHaveBeenCalledWith(null);
-  });
-
-  it("lets the user override the auto-selection", async () => {
-    server.use(
-      equipmentDetailHandler("2014", "plate-armor", {
-        index: "plate-armor",
-        name: "Plate Armor",
-        armor_class: { base: 18 },
-        weight: 65,
-      }),
-    );
-    const onConfirm = vi.fn();
-    renderWithClient(
-      <EnrichmentStep
-        ruleset="2014"
-        hint={{ kind: "specific", hint: "longsword", source: "Weapon (longsword)" }}
-        onConfirm={onConfirm}
-        onCancel={vi.fn()}
-      />,
-    );
-    await screen.findByRole("button", { name: /longsword/i });
-    await userEvent.clear(screen.getByRole("searchbox"));
-    await screen.findByRole("button", { name: /plate armor/i });
-    await userEvent.click(screen.getByRole("button", { name: /plate armor/i }));
-    await userEvent.click(screen.getByRole("button", { name: /confirm/i }));
-    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
-    expect(onConfirm.mock.calls[0]![0]).toMatchObject({ index: "plate-armor" });
   });
 
   it("calls onCancel when Back is pressed", async () => {

--- a/src/views/EnrichmentStep.test.tsx
+++ b/src/views/EnrichmentStep.test.tsx
@@ -1,0 +1,109 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { equipmentDetailHandler, equipmentIndexHandler, server } from "../test/msw";
+import { EnrichmentStep } from "./EnrichmentStep";
+
+const renderWithClient = (ui: ReactNode) => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+};
+
+const equipmentIndex = {
+  count: 2,
+  results: [
+    { index: "longsword", name: "Longsword", url: "/api/2014/equipment/longsword" },
+    { index: "plate-armor", name: "Plate Armor", url: "/api/2014/equipment/plate-armor" },
+  ],
+};
+
+beforeEach(() => {
+  server.use(equipmentIndexHandler("2014", equipmentIndex));
+});
+
+describe("EnrichmentStep", () => {
+  it("auto-selects the single match for a specific hint", async () => {
+    server.use(
+      equipmentDetailHandler("2014", "longsword", {
+        index: "longsword",
+        name: "Longsword",
+        damage: { damage_dice: "1d8", damage_type: { name: "Slashing" } },
+        weight: 3,
+      }),
+    );
+    const onConfirm = vi.fn();
+    renderWithClient(
+      <EnrichmentStep
+        ruleset="2014"
+        hint={{ kind: "specific", hint: "longsword" }}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+    const longswordButton = await screen.findByRole("button", { name: /longsword/i });
+    await waitFor(() => expect(longswordButton).toHaveAttribute("aria-pressed", "true"));
+    await userEvent.click(screen.getByRole("button", { name: /confirm/i }));
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+    expect(onConfirm.mock.calls[0]![0]).toMatchObject({ index: "longsword" });
+  });
+
+  it("does not auto-select for an 'any X' template; allows skip", async () => {
+    const onConfirm = vi.fn();
+    renderWithClient(
+      <EnrichmentStep
+        ruleset="2014"
+        hint={{ kind: "any", hint: "sword" }}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+    await screen.findByRole("button", { name: /skip/i });
+    expect(screen.getByRole("button", { name: /confirm/i })).toBeDisabled();
+    await userEvent.click(screen.getByRole("button", { name: /skip/i }));
+    expect(onConfirm).toHaveBeenCalledWith(null);
+  });
+
+  it("lets the user override the auto-selection", async () => {
+    server.use(
+      equipmentDetailHandler("2014", "plate-armor", {
+        index: "plate-armor",
+        name: "Plate Armor",
+        armor_class: { base: 18 },
+        weight: 65,
+      }),
+    );
+    const onConfirm = vi.fn();
+    renderWithClient(
+      <EnrichmentStep
+        ruleset="2014"
+        hint={{ kind: "specific", hint: "longsword" }}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />,
+    );
+    await screen.findByRole("button", { name: /longsword/i });
+    await userEvent.clear(screen.getByRole("searchbox"));
+    await screen.findByRole("button", { name: /plate armor/i });
+    await userEvent.click(screen.getByRole("button", { name: /plate armor/i }));
+    await userEvent.click(screen.getByRole("button", { name: /confirm/i }));
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+    expect(onConfirm.mock.calls[0]![0]).toMatchObject({ index: "plate-armor" });
+  });
+
+  it("calls onCancel when Back is pressed", async () => {
+    const onCancel = vi.fn();
+    renderWithClient(
+      <EnrichmentStep
+        ruleset="2014"
+        hint={{ kind: "any", hint: "sword" }}
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+    await screen.findByRole("button", { name: /back/i });
+    await userEvent.click(screen.getByRole("button", { name: /back/i }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/views/EnrichmentStep.test.tsx
+++ b/src/views/EnrichmentStep.test.tsx
@@ -37,7 +37,7 @@ describe("EnrichmentStep", () => {
     renderWithClient(
       <EnrichmentStep
         ruleset="2014"
-        hint={{ kind: "specific", hint: "longsword" }}
+        hint={{ kind: "specific", hint: "longsword", source: "Weapon (longsword)" }}
         onConfirm={onConfirm}
         onCancel={vi.fn()}
       />,
@@ -54,7 +54,7 @@ describe("EnrichmentStep", () => {
     renderWithClient(
       <EnrichmentStep
         ruleset="2014"
-        hint={{ kind: "any", hint: "sword" }}
+        hint={{ kind: "any", hint: "sword", source: "Weapon (any sword)" }}
         onConfirm={onConfirm}
         onCancel={vi.fn()}
       />,
@@ -78,7 +78,7 @@ describe("EnrichmentStep", () => {
     renderWithClient(
       <EnrichmentStep
         ruleset="2014"
-        hint={{ kind: "specific", hint: "longsword" }}
+        hint={{ kind: "specific", hint: "longsword", source: "Weapon (longsword)" }}
         onConfirm={onConfirm}
         onCancel={vi.fn()}
       />,
@@ -97,7 +97,7 @@ describe("EnrichmentStep", () => {
     renderWithClient(
       <EnrichmentStep
         ruleset="2014"
-        hint={{ kind: "any", hint: "sword" }}
+        hint={{ kind: "any", hint: "sword", source: "Weapon (any sword)" }}
         onConfirm={vi.fn()}
         onCancel={onCancel}
       />,
@@ -105,5 +105,42 @@ describe("EnrichmentStep", () => {
     await screen.findByRole("button", { name: /back/i });
     await userEvent.click(screen.getByRole("button", { name: /back/i }));
     expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not pre-fill the search when the hint matches nothing", async () => {
+    renderWithClient(
+      <EnrichmentStep
+        ruleset="2014"
+        hint={{ kind: "any", hint: "melee weapon", source: "Weapon (Any Melee Weapon)" }}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    await screen.findByRole("button", { name: /longsword/i });
+    expect(screen.getByRole("searchbox")).toHaveValue("");
+  });
+
+  it("renders the description source line", async () => {
+    renderWithClient(
+      <EnrichmentStep
+        ruleset="2014"
+        hint={{ kind: "specific", hint: "longsword", source: "Weapon (longsword)" }}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(await screen.findByText(/Weapon \(longsword\)/i)).toBeInTheDocument();
+  });
+
+  it("renders the intro instructions", () => {
+    renderWithClient(
+      <EnrichmentStep
+        ruleset="2014"
+        hint={{ kind: "any", hint: "sword", source: "Weapon (any sword)" }}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/auto-fill damage\/AC and weight/i)).toBeInTheDocument();
   });
 });

--- a/src/views/EnrichmentStep.test.tsx
+++ b/src/views/EnrichmentStep.test.tsx
@@ -131,4 +131,30 @@ describe("EnrichmentStep", () => {
     await userEvent.click(await screen.findByRole("button", { name: /longsword/i }));
     expect(await screen.findByRole("alert")).toBeInTheDocument();
   });
+
+  it("shows a 'Suggested' chip on the single prefilled match", async () => {
+    renderWithClient(
+      <EnrichmentStep
+        ruleset="2014"
+        hint={{ kind: "specific", hint: "longsword", source: "Weapon (longsword)" }}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    await screen.findByRole("button", { name: /longsword/i });
+    expect(await screen.findByText(/suggested/i)).toBeInTheDocument();
+  });
+
+  it("does not show a 'Suggested' chip for 'any' hints", async () => {
+    renderWithClient(
+      <EnrichmentStep
+        ruleset="2014"
+        hint={{ kind: "any", hint: "sword", source: "Weapon (any sword)" }}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    await screen.findByRole("button", { name: /longsword/i });
+    expect(screen.queryByText(/suggested/i)).not.toBeInTheDocument();
+  });
 });

--- a/src/views/EnrichmentStep.test.tsx
+++ b/src/views/EnrichmentStep.test.tsx
@@ -3,7 +3,12 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { equipmentDetailHandler, equipmentIndexHandler, server } from "../test/msw";
+import {
+  apiErrorHandler,
+  equipmentDetailHandler,
+  equipmentIndexHandler,
+  server,
+} from "../test/msw";
 import { EnrichmentStep } from "./EnrichmentStep";
 
 const renderWithClient = (ui: ReactNode) => {
@@ -111,5 +116,19 @@ describe("EnrichmentStep", () => {
       />,
     );
     expect(screen.getByText(/auto-fill damage\/AC and weight/i)).toBeInTheDocument();
+  });
+
+  it("shows an alert when the equipment detail fetch fails", async () => {
+    server.use(apiErrorHandler("/api/2014/equipment/longsword", 500));
+    renderWithClient(
+      <EnrichmentStep
+        ruleset="2014"
+        hint={{ kind: "specific", hint: "longsword", source: "Weapon (longsword)" }}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    await userEvent.click(await screen.findByRole("button", { name: /longsword/i }));
+    expect(await screen.findByRole("alert")).toBeInTheDocument();
   });
 });

--- a/src/views/EnrichmentStep.tsx
+++ b/src/views/EnrichmentStep.tsx
@@ -40,8 +40,8 @@ export function EnrichmentStep({ ruleset, hint, onConfirm, onCancel }: Props) {
   useEffect(() => {
     if (initRef.current) return;
     if (!index.data) return;
-    if (query !== "") return;
     initRef.current = true;
+    if (query !== "") return;
     if (hint.hint === "") return;
     const wouldMatch = index.data.results.some((e) => e.name.toLowerCase().includes(hint.hint));
     if (wouldMatch) setQuery(hint.hint);

--- a/src/views/EnrichmentStep.tsx
+++ b/src/views/EnrichmentStep.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { TextField } from "react-aria-components";
 import { type EquipmentDetail, fetchEquipmentDetail } from "../api/endpoints/equipment";
 import type { Ruleset } from "../api/endpoints/magicItems";
@@ -22,7 +22,8 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 export function EnrichmentStep({ ruleset, hint, onConfirm, onCancel }: Props) {
   const index = useEquipmentIndex(ruleset);
   const queryClient = useQueryClient();
-  const [query, setQuery] = useState(hint.hint);
+  const [query, setQuery] = useState("");
+  const initRef = useRef(false);
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
   const [resolving, setResolving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -33,6 +34,15 @@ export function EnrichmentStep({ ruleset, hint, onConfirm, onCancel }: Props) {
     if (q === "") return all;
     return all.filter((e) => e.name.toLowerCase().includes(q));
   }, [index.data, query]);
+
+  useEffect(() => {
+    if (initRef.current) return;
+    if (!index.data) return;
+    initRef.current = true;
+    if (hint.hint === "") return;
+    const wouldMatch = index.data.results.some((e) => e.name.toLowerCase().includes(hint.hint));
+    if (wouldMatch) setQuery(hint.hint);
+  }, [index.data, hint.hint]);
 
   useEffect(() => {
     if (selectedSlug !== null) return;
@@ -73,6 +83,10 @@ export function EnrichmentStep({ ruleset, hint, onConfirm, onCancel }: Props) {
 
   return (
     <>
+      <p className={styles.intro}>
+        Pick the base equipment to auto-fill damage/AC and weight, or skip.
+      </p>
+      {hint.source && <p className={styles.source}>Described as: {hint.source}</p>}
       <div className={styles.searchRow}>
         <TextField aria-label="Search equipment" className={styles.searchField}>
           <Input

--- a/src/views/EnrichmentStep.tsx
+++ b/src/views/EnrichmentStep.tsx
@@ -1,11 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { TextField } from "react-aria-components";
-import {
-  type EquipmentDetail,
-  type EquipmentIndexEntry,
-  fetchEquipmentDetail,
-} from "../api/endpoints/equipment";
+import { type EquipmentDetail, fetchEquipmentDetail } from "../api/endpoints/equipment";
 import type { Ruleset } from "../api/endpoints/magicItems";
 import { useEquipmentIndex } from "../api/hooks";
 import type { BaseHint } from "../api/mappers/baseHint";
@@ -31,7 +27,7 @@ export function EnrichmentStep({ ruleset, hint, onConfirm, onCancel }: Props) {
   const [resolving, setResolving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const filtered: EquipmentIndexEntry[] = useMemo(() => {
+  const filtered = useMemo(() => {
     const all = index.data?.results ?? [];
     const q = query.trim().toLowerCase();
     if (q === "") return all;

--- a/src/views/EnrichmentStep.tsx
+++ b/src/views/EnrichmentStep.tsx
@@ -24,8 +24,8 @@ export function EnrichmentStep({ ruleset, hint, onConfirm, onCancel }: Props) {
   const queryClient = useQueryClient();
   const [query, setQuery] = useState("");
   const initRef = useRef(false);
-  const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
-  const [resolving, setResolving] = useState(false);
+  const [pickingSlug, setPickingSlug] = useState<string | null>(null);
+  const [skipping, setSkipping] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const filtered = useMemo(() => {
@@ -44,40 +44,32 @@ export function EnrichmentStep({ ruleset, hint, onConfirm, onCancel }: Props) {
     if (wouldMatch) setQuery(hint.hint);
   }, [index.data, hint.hint]);
 
-  useEffect(() => {
-    if (selectedSlug !== null) return;
-    if (hint.kind !== "specific") return;
-    if (filtered.length !== 1) return;
-    setSelectedSlug(filtered[0]!.index);
-  }, [filtered, hint.kind, selectedSlug]);
-
-  const handleConfirm = async () => {
-    if (selectedSlug === null) return;
-    setResolving(true);
+  const handlePick = async (slug: string) => {
+    if (pickingSlug !== null) return;
+    setPickingSlug(slug);
     setError(null);
     try {
       const detail = await queryClient.fetchQuery({
-        queryKey: ["equipment", ruleset, "detail", selectedSlug],
-        queryFn: () => fetchEquipmentDetail(ruleset, selectedSlug),
+        queryKey: ["equipment", ruleset, "detail", slug],
+        queryFn: () => fetchEquipmentDetail(ruleset, slug),
         staleTime: DAY_MS,
       });
       await onConfirm(detail);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Couldn't load this item.");
-    } finally {
-      setResolving(false);
+      setPickingSlug(null);
     }
   };
 
   const handleSkip = async () => {
-    setResolving(true);
+    if (pickingSlug !== null || skipping) return;
+    setSkipping(true);
     setError(null);
     try {
       await onConfirm(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Couldn't save this card.");
-    } finally {
-      setResolving(false);
+      setSkipping(false);
     }
   };
 
@@ -116,23 +108,29 @@ export function EnrichmentStep({ ruleset, hint, onConfirm, onCancel }: Props) {
               key={entry.index}
               type="button"
               className={styles.row}
-              aria-pressed={selectedSlug === entry.index}
-              onClick={() => setSelectedSlug(entry.index)}
+              onClick={() => handlePick(entry.index)}
+              disabled={pickingSlug !== null || skipping}
             >
               <span className={styles.rowName}>{entry.name}</span>
+              {pickingSlug === entry.index && <span className={styles.rowMeta}>Loading…</span>}
             </button>
           ))}
       </div>
 
       <div className={styles.actions}>
-        <Button variant="secondary" onPress={onCancel}>
+        <Button
+          variant="secondary"
+          onPress={onCancel}
+          isDisabled={pickingSlug !== null || skipping}
+        >
           Back
         </Button>
-        <Button variant="secondary" onPress={handleSkip} isDisabled={resolving}>
+        <Button
+          variant="secondary"
+          onPress={handleSkip}
+          isDisabled={pickingSlug !== null || skipping}
+        >
           Skip
-        </Button>
-        <Button onPress={handleConfirm} isDisabled={selectedSlug === null || resolving}>
-          {resolving ? "Loading…" : "Confirm"}
         </Button>
       </div>
     </>

--- a/src/views/EnrichmentStep.tsx
+++ b/src/views/EnrichmentStep.tsx
@@ -34,6 +34,9 @@ export function EnrichmentStep({ ruleset, hint, onConfirm, onCancel }: Props) {
     return all.filter((e) => e.name.toLowerCase().includes(q));
   }, [index.data, query]);
 
+  const showSuggestedChip =
+    hint.kind === "specific" && hint.hint !== "" && query === hint.hint && filtered.length === 1;
+
   useEffect(() => {
     if (initRef.current) return;
     if (!index.data) return;
@@ -116,6 +119,7 @@ export function EnrichmentStep({ ruleset, hint, onConfirm, onCancel }: Props) {
               disabled={pickingSlug !== null || skipping}
             >
               <span className={styles.rowName}>{entry.name}</span>
+              {showSuggestedChip && <span className={styles.suggestedChip}>Suggested</span>}
               {pickingSlug === entry.index && <span className={styles.rowMeta}>Loading…</span>}
             </button>
           ))}

--- a/src/views/EnrichmentStep.tsx
+++ b/src/views/EnrichmentStep.tsx
@@ -1,0 +1,118 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { TextField } from "react-aria-components";
+import {
+  type EquipmentDetail,
+  type EquipmentIndexEntry,
+  fetchEquipmentDetail,
+} from "../api/endpoints/equipment";
+import type { Ruleset } from "../api/endpoints/magicItems";
+import { useEquipmentIndex } from "../api/hooks";
+import type { BaseHint } from "../api/mappers/baseHint";
+import { Button } from "../lib/ui/Button";
+import { Input } from "../lib/ui/Input";
+import { LoadingState } from "../lib/ui/LoadingState";
+import styles from "./EnrichmentStep.module.css";
+
+type Props = {
+  ruleset: Ruleset;
+  hint: BaseHint;
+  onConfirm: (enrichment: EquipmentDetail | null) => void;
+  onCancel: () => void;
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function EnrichmentStep({ ruleset, hint, onConfirm, onCancel }: Props) {
+  const index = useEquipmentIndex(ruleset);
+  const queryClient = useQueryClient();
+  const [query, setQuery] = useState(hint.hint);
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
+  const [resolving, setResolving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const filtered: EquipmentIndexEntry[] = useMemo(() => {
+    const all = index.data?.results ?? [];
+    const q = query.trim().toLowerCase();
+    if (q === "") return all;
+    return all.filter((e) => e.name.toLowerCase().includes(q));
+  }, [index.data, query]);
+
+  useEffect(() => {
+    if (selectedSlug !== null) return;
+    if (hint.kind !== "specific") return;
+    if (filtered.length !== 1) return;
+    setSelectedSlug(filtered[0]!.index);
+  }, [filtered, hint.kind, selectedSlug]);
+
+  const handleConfirm = async () => {
+    if (selectedSlug === null) return;
+    setResolving(true);
+    setError(null);
+    try {
+      const detail = await queryClient.fetchQuery({
+        queryKey: ["equipment", ruleset, "detail", selectedSlug],
+        queryFn: () => fetchEquipmentDetail(ruleset, selectedSlug),
+        staleTime: DAY_MS,
+      });
+      onConfirm(detail);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Couldn't load this item.");
+    } finally {
+      setResolving(false);
+    }
+  };
+
+  return (
+    <>
+      <div className={styles.searchRow}>
+        <TextField aria-label="Search equipment" className={styles.searchField}>
+          <Input
+            type="search"
+            placeholder="Search equipment…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            autoFocus
+          />
+        </TextField>
+      </div>
+
+      <div className={styles.results}>
+        {index.isLoading && <LoadingState />}
+        {index.isError && <div className={styles.state}>Couldn't load equipment.</div>}
+        {index.isSuccess && filtered.length === 0 && (
+          <div className={styles.state}>No equipment matches your search.</div>
+        )}
+        {error && (
+          <div className={styles.state} role="alert">
+            {error}
+          </div>
+        )}
+        {index.isSuccess &&
+          filtered.map((entry) => (
+            <button
+              key={entry.index}
+              type="button"
+              className={styles.row}
+              aria-pressed={selectedSlug === entry.index}
+              onClick={() => setSelectedSlug(entry.index)}
+            >
+              <span className={styles.rowName}>{entry.name}</span>
+            </button>
+          ))}
+      </div>
+
+      <div className={styles.actions}>
+        <Button variant="secondary" onPress={onCancel}>
+          Back
+        </Button>
+        <Button variant="secondary" onPress={() => onConfirm(null)}>
+          Skip
+        </Button>
+        <Button onPress={handleConfirm} isDisabled={selectedSlug === null || resolving}>
+          {resolving ? "Loading…" : "Confirm"}
+        </Button>
+      </div>
+    </>
+  );
+}

--- a/src/views/EnrichmentStep.tsx
+++ b/src/views/EnrichmentStep.tsx
@@ -59,6 +59,18 @@ export function EnrichmentStep({ ruleset, hint, onConfirm, onCancel }: Props) {
     }
   };
 
+  const handleSkip = async () => {
+    setResolving(true);
+    setError(null);
+    try {
+      await onConfirm(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Couldn't save this card.");
+    } finally {
+      setResolving(false);
+    }
+  };
+
   return (
     <>
       <div className={styles.searchRow}>
@@ -102,7 +114,7 @@ export function EnrichmentStep({ ruleset, hint, onConfirm, onCancel }: Props) {
         <Button variant="secondary" onPress={onCancel}>
           Back
         </Button>
-        <Button variant="secondary" onPress={() => onConfirm(null)}>
+        <Button variant="secondary" onPress={handleSkip} isDisabled={resolving}>
           Skip
         </Button>
         <Button onPress={handleConfirm} isDisabled={selectedSlug === null || resolving}>

--- a/src/views/EnrichmentStep.tsx
+++ b/src/views/EnrichmentStep.tsx
@@ -13,7 +13,7 @@ import styles from "./EnrichmentStep.module.css";
 type Props = {
   ruleset: Ruleset;
   hint: BaseHint;
-  onConfirm: (enrichment: EquipmentDetail | null) => void;
+  onConfirm: (enrichment: EquipmentDetail | null) => Promise<void>;
   onCancel: () => void;
 };
 
@@ -51,7 +51,7 @@ export function EnrichmentStep({ ruleset, hint, onConfirm, onCancel }: Props) {
         queryFn: () => fetchEquipmentDetail(ruleset, selectedSlug),
         staleTime: DAY_MS,
       });
-      onConfirm(detail);
+      await onConfirm(detail);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Couldn't load this item.");
     } finally {

--- a/src/views/EnrichmentStep.tsx
+++ b/src/views/EnrichmentStep.tsx
@@ -5,6 +5,7 @@ import { type EquipmentDetail, fetchEquipmentDetail } from "../api/endpoints/equ
 import type { Ruleset } from "../api/endpoints/magicItems";
 import { useEquipmentIndex } from "../api/hooks";
 import type { BaseHint } from "../api/mappers/baseHint";
+import { DAY_MS } from "../api/timing";
 import { Button } from "../lib/ui/Button";
 import { Input } from "../lib/ui/Input";
 import { LoadingState } from "../lib/ui/LoadingState";
@@ -16,8 +17,6 @@ type Props = {
   onConfirm: (enrichment: EquipmentDetail | null) => Promise<void>;
   onCancel: () => void;
 };
-
-const DAY_MS = 24 * 60 * 60 * 1000;
 
 export function EnrichmentStep({ ruleset, hint, onConfirm, onCancel }: Props) {
   const index = useEquipmentIndex(ruleset);
@@ -38,11 +37,12 @@ export function EnrichmentStep({ ruleset, hint, onConfirm, onCancel }: Props) {
   useEffect(() => {
     if (initRef.current) return;
     if (!index.data) return;
+    if (query !== "") return;
     initRef.current = true;
     if (hint.hint === "") return;
     const wouldMatch = index.data.results.some((e) => e.name.toLowerCase().includes(hint.hint));
     if (wouldMatch) setQuery(hint.hint);
-  }, [index.data, hint.hint]);
+  }, [index.data, hint.hint, query]);
 
   const handlePick = async (slug: string) => {
     if (pickingSlug !== null) return;
@@ -56,7 +56,7 @@ export function EnrichmentStep({ ruleset, hint, onConfirm, onCancel }: Props) {
       });
       await onConfirm(detail);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Couldn't load this item.");
+      setError(err instanceof Error ? err.message : "Couldn't import this card. Please try again.");
       setPickingSlug(null);
     }
   };
@@ -68,7 +68,7 @@ export function EnrichmentStep({ ruleset, hint, onConfirm, onCancel }: Props) {
     try {
       await onConfirm(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Couldn't save this card.");
+      setError(err instanceof Error ? err.message : "Couldn't import this card. Please try again.");
       setSkipping(false);
     }
   };
@@ -93,7 +93,11 @@ export function EnrichmentStep({ ruleset, hint, onConfirm, onCancel }: Props) {
 
       <div className={styles.results}>
         {index.isLoading && <LoadingState />}
-        {index.isError && <div className={styles.state}>Couldn't load equipment.</div>}
+        {index.isError && (
+          <div className={styles.state} role="alert">
+            Couldn't load equipment.
+          </div>
+        )}
         {index.isSuccess && filtered.length === 0 && (
           <div className={styles.state}>No equipment matches your search.</div>
         )}
@@ -130,7 +134,7 @@ export function EnrichmentStep({ ruleset, hint, onConfirm, onCancel }: Props) {
           onPress={handleSkip}
           isDisabled={pickingSlug !== null || skipping}
         >
-          Skip
+          {skipping ? "Saving…" : "Skip"}
         </Button>
       </div>
     </>


### PR DESCRIPTION
### What are the relevant tickets?

N/A — feature work tracked in the conversation; spec committed at `docs/superpowers/plans/2026-05-03-import-enrichment-wizard.md`.

### Description (What does it do?)

Replaces the single-click magic-item importer with a two-step wizard that pulls structured damage/AC/weight from the corresponding mundane equipment record on dnd5eapi and splices them into the imported card. The result is fewer manual edits per card and a more consistent on-card layout.

#### What changed

- **Canonical tag order.** Header is `[type, damage/AC, attunement]`; footer is `[rarity, cost, weight]`. Rarity moves from header to footer for fresh imports. (Existing user-edited cards keep whatever order they had — no migration.)
- **Two-step import wizard.** Step 1 is the existing picker. For weapons/armor, step 2 lets the user pick a base equipment item:
  - **Specific items** (Sun Blade → "Weapon (Longsword)"): step 2 search prefills with the parsed hint; the single matching row gets a small "Suggested" chip. Click commits.
  - **"Any X" templates** (Flame Tongue 2024 → "Weapon (Any Melee Weapon)"): step 2 shows the full equipment list (or filtered if the hint substring-matches). User picks; the title becomes "Flame Tongue (Trident)" since the API name alone is incomplete.
  - **Non-enrichable items** (wand, ring, potion, wondrous item, …): no step 2; saves immediately.
- **Body strip.** The dnd5eapi metadata line ("Weapon (Any Melee Weapon)" etc.) is removed from imported card bodies — that information is now redundant with the tag display.
- **Form help text.** ItemEditor shows "Suggested order: …" under each TagInput field as a non-binding convention. Linked via `aria-describedby`.
- **Wizard a11y.** `role="alert"` on error states; focus returns to the previously-clicked row when pressing Back; opacity on disabled rows during in-flight saves; Skip shows "Saving…" while in flight.
- **Upstream API feedback** drafted at `docs/dnd5eapi-feedback.md` — proposed structured-data improvements that would let consumers stop hand-parsing prose.

#### Architecture

- New `src/api/endpoints/equipment.ts` (fetch + types) and `useEquipmentIndex` hook.
- New pure helpers: `parseBaseHint` (parses `desc[0]` parenthetical), `equipmentToHeaderInsert` / `equipmentToFooterInsert` (string formatters).
- `magicItemDetailToCard(detail, enrichment?)` accepts optional equipment detail and splices damage/AC into header position 1, weight into footer position 1. Title appends base name only when `parseBaseHint(...).kind === "any"`.
- New `EnrichmentStep` component (content-only; the parent owns the dialog shell).
- `BrowseApiModal` is now a `pick | enrich` state machine.

API assumptions about dnd5eapi response shape (desc structure, type prefix, attunement detection) are documented inline in `src/api/mappers/magicItems.ts`.

### Screenshots (if appropriate):
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?

**Manual smoke** (Browse SRD modal in the new-card editor):

1. **Non-enrichable** — search "Bag of Holding" or "Wand of Wonder". Click. Imports immediately, no second step. Header shows just the type; footer shows rarity.
2. **Specific weapon** — search "Sun Blade". Click. Step 2 opens; search prefilled with "longsword"; Longsword row has a "Suggested" chip. Click Longsword → card saved with `1d8 slashing` in header and `3 lb` in footer.
3. **Specific armor** — search "Dwarven Plate". Click. Step 2 auto-prefills "plate"; Plate Armor row has the chip. Click → AC 18 in header, 65 lb in footer.
4. **"Any X" template** — search "Flame Tongue". Click. Step 2 shows full list (2024 hint "melee weapon" doesn't substring-match anything; smart prefill correctly leaves the search empty rather than producing zero results). Pick a Trident → title becomes "Flame Tongue (Trident)".
5. **Skip** — click Skip on any step-2 view. Card saved without enrichment; magic item's API name is preserved.
6. **Back** — click Back on any step-2 view. Returns to step 1 with focus restored to the magic-item row you came from.
7. **Help text** — open the editor for any card; the help line under each tag-input field describes the canonical order.

**Automated coverage:** new tests for `parseBaseHint`, equipment endpoint, equipment tag mappers, mapper enrichment splicing + title rule + body strip for both rulesets, `EnrichmentStep` (auto-prefill, commit-on-click, error states, focus return on Back, "Suggested" chip predicate), and `BrowseApiModal` step-machine branching across the four import paths (non-enrichable / specific / "any X" / Skip / Back).

### Additional Context

**Known limitation:** the equipment index endpoint doesn't expose category, so step 2 doesn't filter to weapons-only when invoked from a magic weapon. A user can pick "Plate Armor" while importing a magic weapon — that produces an AC tag instead of damage, which is sensible-but-weird. Hand-rolling a category filter would require pre-fetching every detail, which is too expensive. Left as-is; the "Described as:" line communicates the intended constraint.

**Cost is intentionally never auto-filled.** Mundane equipment cost (e.g. 15 gp for a longsword) doesn't reflect a magic item's value; auto-filling would mislead. Cost stays user-entered.

**`desc[0]` parsing assumptions** are documented inline in `src/api/mappers/magicItems.ts`. They were verified against 12+ items spanning all observed types in both rulesets at time of writing — see `docs/dnd5eapi-feedback.md` for the upstream-suggestions companion.

**Companion docs in this branch:**

- https://github.com/ChristopherChudzicki/dnd-cards/blob/import-enrichment-wizard/docs/superpowers/plans/2026-05-03-import-enrichment-wizard.md
- https://github.com/ChristopherChudzicki/dnd-cards/blob/import-enrichment-wizard/docs/dnd5eapi-feedback.md