### PR TITLE
feat: add favicon, OG image, and SEO meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,26 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>D&D Cards</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <title>Readable D&amp;D Cards</title>
+    <meta
+      name="description"
+      content="Build, browse, and print readable D&amp;D 5e item and spell cards. Search the SRD (2014 + 2024), customize, and print 2 or 4 per page."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Readable D&amp;D Cards" />
+    <meta
+      property="og:description"
+      content="Build, browse, and print readable D&amp;D 5e item and spell cards. Search the SRD (2014 + 2024), customize, and print 2 or 4 per page."
+    />
+    <meta property="og:image" content="/og.svg" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Readable D&amp;D Cards" />
+    <meta
+      name="twitter:description"
+      content="Build, browse, and print readable D&amp;D 5e item and spell cards. Search the SRD (2014 + 2024), customize, and print 2 or 4 per page."
+    />
+    <meta name="twitter:image" content="/og.svg" />
   </head>
   <body>
     <div id="root"></div>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect x="4" y="4" width="56" height="56" rx="6" fill="#fffdf8" stroke="#7a3530" stroke-width="2.5" />
+  <g transform="translate(32 32)" stroke="#fffdf8" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round" fill="none">
+    <polygon points="0,-15 13,-7.5 13,7.5 0,15 -13,7.5 -13,-7.5" fill="#7a3530" stroke="#7a3530" />
+    <polygon points="0,-15 13,7.5 -13,7.5" />
+    <polygon points="13,-7.5 -13,-7.5 0,15" />
+  </g>
+</svg>

--- a/public/og.svg
+++ b/public/og.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <defs>
+    <pattern id="dots" x="0" y="0" width="24" height="24" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1" fill="#e8dcc4" />
+    </pattern>
+  </defs>
+  <rect width="1200" height="630" fill="#fffdf8" />
+  <rect width="1200" height="630" fill="url(#dots)" />
+
+  <g transform="translate(110 110)">
+    <rect x="0" y="0" width="140" height="140" rx="14" fill="#fffdf8" stroke="#7a3530" stroke-width="6" />
+    <g transform="translate(70 72)" stroke="#fffdf8" stroke-width="4" stroke-linejoin="round" stroke-linecap="round" fill="none">
+      <polygon points="0,-44 38,-22 38,22 0,44 -38,22 -38,-22" fill="#7a3530" stroke="#7a3530" />
+      <polygon points="0,-44 38,22 -38,22" />
+      <polygon points="38,-22 -38,-22 0,44" />
+    </g>
+  </g>
+
+  <text x="110" y="340" font-family="Georgia, serif" font-size="92" font-weight="700" fill="#1a1410">Readable D&amp;D Cards</text>
+  <text x="110" y="410" font-family="Georgia, serif" font-size="40" font-style="italic" fill="#6a5a45">Browse the SRD. Print clean cards for your table.</text>
+
+  <g transform="translate(110 490)" font-family="Georgia, serif" font-size="28" fill="#1a1410">
+    <text x="0" y="0">• Magic items + spells from the 5.1 / 5.2 SRD</text>
+    <text x="0" y="44">• Edit, paginate, and print 2 or 4 per page</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

Basic SEO + share-preview metadata for the SPA — title, description, Open Graph, and Twitter card tags — plus a favicon and OG image.

- **Favicon** (`public/favicon.svg`): a filled d20 (hexagon with the classic Star-of-David facet pattern) inside a rounded card frame. Uses the existing accent maroon (`#7a3530`) and surface cream (`#fffdf8`).
- **OG image** (`public/og.svg`, 1200×630): same d20-on-card mark plus a tagline emphasizing SRD browsing and clean printable cards.
- **`index.html`**: title (`Readable D&D Cards`), meta description, og:title/description/image/type, twitter:card, twitter:title/description/image. Description emphasizes browsing the SRD and printing readable cards.

## Test plan

- Build (`npm run build`) emits `dist/favicon.svg`, `dist/og.svg`, and the meta tags in `dist/index.html`.
- Open the dev server and confirm the favicon renders as a d20-on-card in the browser tab.
- After deploy: paste the URL into an OG debugger (e.g. opengraph.xyz, Discord/Slack share preview) to confirm unfurl.

## Caveats / follow-ups

- **og:image is SVG.** Modern crawlers (Slack, Discord, recent Twitter/X) preview SVG fine, but older Facebook crawlers historically prefer raster. If wider compatibility matters, export `og.svg` → `og.png` (1200×630) and swap the meta tag — happy to do that as a follow-up if needed.
- **og:image / twitter:image use a relative path.** Most crawlers resolve relative to the served page, but absolute URLs are more reliable. If a deploy domain is set, we can switch to absolute.