### PR TITLE
fix(print): improve card border + shadow on paper

### DIFF
--- a/src/cards/Card.module.css
+++ b/src/cards/Card.module.css
@@ -179,3 +179,9 @@
 .body th {
   font-weight: 600;
 }
+
+@media print {
+  .card {
+    box-shadow: none;
+  }
+}

--- a/src/cards/Card.module.css
+++ b/src/cards/Card.module.css
@@ -7,7 +7,7 @@
   padding: 1.15em;
   background: var(--print-color-paper);
   color: var(--print-color-ink);
-  border: 1px solid var(--print-color-border-strong);
+  border: 2px solid var(--print-color-border-strong);
   border-radius: 0.5em;
   display: flex;
   flex-direction: column;

--- a/src/index.css
+++ b/src/index.css
@@ -85,7 +85,7 @@ body,
   --print-color-border: #ddd;
   --print-color-image-bg: #f0f0f0;
   --print-color-image-frame: #d0d0d0;
-  --print-shadow-card: 0 2px 10px rgba(0, 0, 0, 0.08);
+  --print-shadow-card: 0 4px 14px rgba(0, 0, 0, 0.15);
   --print-shadow-page: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
 


### PR DESCRIPTION
### What are the relevant tickets?

N/A — found while printing a sheet of cards.

### Description (What does it do?)

Three small print-output tweaks to `src/cards/Card.module.css` and the `--print-shadow-card` token in `src/index.css`:

1. **Null the per-card `box-shadow` under `@media print`.** The screen sheet preview uses the shadow to give cards a sense of elevation, but printers were rendering it as a faint gray halo around each card.
2. **Bump `--print-shadow-card` from `0 2px 10px / 0.08` to `0 4px 14px / 0.15`.** Now that the shadow is screen-only, it can be more pronounced without bleeding to paper.
3. **Thicken the card border from 1px to 2px.** Reads better on paper alongside the stronger preview shadow.

### Screenshots (if appropriate):
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?

1. Open the print view (`/print`) and confirm the on-screen sheet preview cards look elevated with a slightly stronger shadow and thicker border.
2. Print to PDF (or paper) and confirm: no gray halo around each card, borders are crisper, 4-per-sheet and 2-per-sheet layouts still fit (cards use `box-sizing: border-box`, so outer dimensions are unchanged).

### Additional Context

The `--print-*` token namespace in `src/index.css` means "owned by the printable card stack," not "appears on physical paper" — `--print-shadow-card` is screen-preview-only by design, which is why nulling it under `@media print` is correct rather than a workaround.