### PR TITLE
Drop imageUrl field from cards

### DIFF
--- a/src/api/mappers/magicItems.test.ts
+++ b/src/api/mappers/magicItems.test.ts
@@ -60,11 +60,10 @@ describe("magicItemDetailToCard", () => {
     });
   });
 
-  test("source is 'api' and imageUrl is undefined (Open5e magicitems has no image field)", () => {
+  test("source is 'api'", () => {
     const detail = magicItemDetailFactory.build();
     const card = magicItemDetailToCard(detail);
     expect(card.source).toBe("api");
-    expect(card.imageUrl).toBeUndefined();
   });
 
   test("weapon non-null → header includes damage tag with lowercased damage type", () => {

--- a/src/cards/Card.module.css
+++ b/src/cards/Card.module.css
@@ -29,18 +29,6 @@
   --card-height: 7.5in;
 }
 
-.image {
-  float: right;
-  margin: 0 0 -0.1em 0.4em;
-  width: 3em;
-  height: 3em;
-  background: var(--print-color-image-bg);
-  border: 1px solid var(--print-color-image-frame);
-  border-radius: 0.2em;
-  object-fit: cover;
-  display: block;
-}
-
 .icon {
   float: right;
   margin: 0 0 -0.1em 0.4em;

--- a/src/cards/Card.test.tsx
+++ b/src/cards/Card.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { Card } from "./Card";
 import { itemCardFactory, spellCardFactory } from "./factories";
@@ -28,13 +28,6 @@ describe("<Card>", () => {
     expect(screen.queryByTestId("card-footer")).not.toBeInTheDocument();
   });
 
-  test("renders image when imageUrl is set", () => {
-    const card = itemCardFactory.build({ imageUrl: "https://example.com/pic.png" });
-    render(<Card card={card} cardsPerPage={4} />);
-    const img = screen.getByTestId("card-image");
-    expect(img).toHaveAttribute("src", card.imageUrl!);
-  });
-
   test("splits body on blank lines into paragraphs", () => {
     const card = itemCardFactory.build({ body: "First paragraph.\n\nSecond paragraph." });
     render(<Card card={card} cardsPerPage={4} />);
@@ -42,34 +35,9 @@ describe("<Card>", () => {
     expect(screen.getByText("Second paragraph.")).toBeInTheDocument();
   });
 
-  test("replaces the image with a fallback icon when the src fails to load", () => {
-    const card = itemCardFactory.build({ imageUrl: "https://example.com/broken.png" });
-    render(<Card card={card} cardsPerPage={4} />);
-    const img = screen.getByTestId("card-image");
-    expect(img).toHaveAttribute("src", card.imageUrl!);
-    fireEvent.error(img);
-    expect(screen.queryByTestId("card-image")).not.toBeInTheDocument();
-    expect(screen.getByTestId("card-icon")).toBeInTheDocument();
-  });
-
-  test("treats an empty-string imageUrl as no image and shows the fallback icon", () => {
-    const card = itemCardFactory.build({ imageUrl: "" });
-    render(<Card card={card} cardsPerPage={4} />);
-    expect(screen.queryByTestId("card-image")).not.toBeInTheDocument();
-    expect(screen.getByTestId("card-icon")).toBeInTheDocument();
-  });
-
-  test("shows a fallback icon when the card has no imageUrl", () => {
-    const card = itemCardFactory.build({ imageUrl: undefined });
-    render(<Card card={card} cardsPerPage={4} />);
-    expect(screen.queryByTestId("card-image")).not.toBeInTheDocument();
-    expect(screen.getByTestId("card-icon")).toBeInTheDocument();
-  });
-
   test("renders the heuristic-picked icon when iconKey is unset", () => {
     const card = itemCardFactory.build({
       name: "Flame Tongue Trident",
-      imageUrl: undefined,
       iconKey: undefined,
     });
     render(<Card card={card} cardsPerPage={4} />);
@@ -80,7 +48,6 @@ describe("<Card>", () => {
   test("renders the explicit override icon when iconKey is set", () => {
     const card = itemCardFactory.build({
       name: "Anything",
-      imageUrl: undefined,
       iconKey: "trident",
     });
     render(<Card card={card} cardsPerPage={4} />);
@@ -91,7 +58,6 @@ describe("<Card>", () => {
   test("does not crash for a stale or unknown iconKey", () => {
     const card = itemCardFactory.build({
       name: "X",
-      imageUrl: undefined,
       iconKey: "definitely-removed-icon",
     });
     expect(() => render(<Card card={card} cardsPerPage={4} />)).not.toThrow();
@@ -101,7 +67,6 @@ describe("<Card>", () => {
     const card = spellCardFactory.build({
       name: "Fireball",
       headerTags: ["3rd-level evocation"],
-      imageUrl: undefined,
       iconKey: undefined,
     });
     render(<Card card={card} cardsPerPage={4} />);

--- a/src/cards/Card.tsx
+++ b/src/cards/Card.tsx
@@ -23,7 +23,6 @@ type AutofitState =
 
 export function Card({ card, cardsPerPage, pagination, bodyOverride }: Props) {
   const layoutClass = cardsPerPage === 4 ? styles.perPage4 : styles.perPage2;
-  const [brokenUrl, setBrokenUrl] = useState<string | null>(null);
 
   const titleRef = useRef<HTMLHeadingElement>(null);
   const [autofit, setAutofit] = useState<AutofitState>({ kind: "unmeasured" });
@@ -60,10 +59,6 @@ export function Card({ card, cardsPerPage, pagination, bodyOverride }: Props) {
       ? { fontSize: `${autofit.scale}em` }
       : undefined;
 
-  // Treat empty string the same as undefined: rendering <img src=""> makes the
-  // browser refetch the document URL, which doesn't fire onError reliably and
-  // leaves the styled-but-empty image element visible instead of falling back.
-  const showImage = !!card.imageUrl && brokenUrl !== card.imageUrl;
   const iconKey = card.iconKey ?? pickIconKey(card);
 
   const isFirstPage = !pagination || pagination.page === 1;
@@ -74,19 +69,9 @@ export function Card({ card, cardsPerPage, pagination, bodyOverride }: Props) {
   return (
     <div className={`${styles.card} ${layoutClass}`} data-role="card-root">
       <div className={styles.header}>
-        {showImage ? (
-          <img
-            className={styles.image}
-            src={card.imageUrl}
-            alt=""
-            data-testid="card-image"
-            onError={() => setBrokenUrl(card.imageUrl ?? null)}
-          />
-        ) : (
-          <div className={styles.icon} data-testid="card-icon" aria-hidden="true">
-            <ResolvedIcon iconKey={iconKey} />
-          </div>
-        )}
+        <div className={styles.icon} data-testid="card-icon" aria-hidden="true">
+          <ResolvedIcon iconKey={iconKey} />
+        </div>
         <h3 className={styles.title} ref={titleRef} style={titleStyle}>
           {card.name}
         </h3>

--- a/src/cards/CardEditor.tsx
+++ b/src/cards/CardEditor.tsx
@@ -15,7 +15,7 @@ type Props = {
   onChange: (next: RenderableCard) => void;
 };
 
-type EditableField = "name" | "body" | "imageUrl";
+type EditableField = "name" | "body";
 
 export function CardEditor({ card, onChange }: Props) {
   const handle =
@@ -50,7 +50,6 @@ export function CardEditor({ card, onChange }: Props) {
     footerTags: `${idBase}-footerTags`,
     footerTagsLabel: `${idBase}-footerTagsLabel`,
     footerTagsHelp: `${idBase}-footerTagsHelp`,
-    imageUrl: `${idBase}-imageUrl`,
   };
 
   return (
@@ -127,15 +126,6 @@ export function CardEditor({ card, onChange }: Props) {
           Suggested order: rarity, cost, weight.
         </span>
       </div>
-      <label className={styles.field} htmlFor={ids.imageUrl}>
-        <span className={styles.label}>Image URL (optional)</span>
-        <Input
-          id={ids.imageUrl}
-          value={card.imageUrl ?? ""}
-          onChange={handle("imageUrl")}
-          placeholder="https://…"
-        />
-      </label>
     </form>
   );
 }

--- a/src/cards/types.ts
+++ b/src/cards/types.ts
@@ -4,7 +4,6 @@ export type BaseCard = {
   id: CardId;
   name: string;
   body: string;
-  imageUrl?: string;
   source: "custom" | "api";
   apiRef?: { system: "open5e"; slug: string; ruleset: "2014" | "2024" };
   createdAt: string;

--- a/src/decks/schema.ts
+++ b/src/decks/schema.ts
@@ -10,7 +10,6 @@ const baseCardSchema = z.object({
   id: z.string(),
   name: z.string(),
   body: z.string(),
-  imageUrl: z.string().optional(),
   source: z.enum(["custom", "api"]),
   apiRef: apiRefSchema.optional(),
   createdAt: z.string(),

--- a/src/index.css
+++ b/src/index.css
@@ -83,8 +83,6 @@ body,
   --print-color-ink-faint: #666;
   --print-color-border-strong: #222;
   --print-color-border: #ddd;
-  --print-color-image-bg: #f0f0f0;
-  --print-color-image-frame: #d0d0d0;
   --print-shadow-card: 0 4px 14px rgba(0, 0, 0, 0.15);
   --print-shadow-page: 0 4px 12px rgba(0, 0, 0, 0.1);
 }

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -19,7 +19,6 @@ const isPristineNewCard = (card: ItemCard): boolean =>
   card.headerTags.length === 0 &&
   card.body === "" &&
   card.footerTags.length === 0 &&
-  card.imageUrl === undefined &&
   card.createdAt === card.updatedAt;
 
 type Bucket = { perPage: number; count: number };

--- a/supabase/migrations/20260506000000_drop_imageurl.sql
+++ b/supabase/migrations/20260506000000_drop_imageurl.sql
@@ -1,3 +1,26 @@
+-- 20260506000000_drop_imageurl.sql
+-- Drop the imageUrl field from card payloads. The editor's image-URL input was
+-- never a great experience; icons are the canonical visual for cards. Strip
+-- imageUrl from any existing rows so they pass the new additionalProperties:
+-- false check, then re-add the constraint with the regenerated schema.
+--
+-- The embedded JSON Schema below is generated from src/decks/schema.ts via
+-- `npm run gen:schema`. To update it, regenerate the JSON file and write a
+-- NEW migration that follows the same drop-then-add pattern below — never
+-- edit this file in place.
+
+create extension if not exists pg_jsonschema;
+
+alter table public.cards drop constraint if exists cards_payload_valid;
+
+update public.cards
+set payload = payload - 'imageUrl'
+where payload ? 'imageUrl';
+
+alter table public.cards
+  add constraint cards_payload_valid
+  check (jsonb_matches_schema(
+    $cardpayload$
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "oneOf": [
@@ -246,3 +269,9 @@
     }
   ]
 }
+    $cardpayload$::json,
+    payload
+  ));
+
+comment on constraint cards_payload_valid on public.cards is
+  'JSON Schema validation generated from src/decks/schema.ts via npm run gen:schema. Regen requires a new migration that drops + re-adds this constraint.';


### PR DESCRIPTION
### Description

The card editor's "Image URL (optional)" input was awkward in practice — most users never used it, and when they did, the resulting card layout was inconsistent with the icon-driven aesthetic. Icons (auto-picked or explicitly chosen) are now the only visual path for cards.

This drops `imageUrl` end-to-end:

- **Type / schema** — removed from `BaseCard` (`src/cards/types.ts`) and `baseCardSchema` (`src/decks/schema.ts`).
- **Editor** — removed the form field, label, id entry, and `EditableField` member from `CardEditor.tsx`. Removed the `imageUrl === undefined` clause from `isPristineNewCard` in `EditorView.tsx`.
- **Card rendering** — `Card.tsx` no longer branches on `imageUrl`; always renders the icon. Dropped the `brokenUrl` state, `<img>` element, error-fallback logic, and the `.image` CSS rule. Also removed the now-unused `--print-color-image-bg` / `--print-color-image-frame` print tokens.
- **Tests** — removed four `imageUrl`-specific tests from `Card.test.tsx` and the unused `fireEvent` import; dropped redundant `imageUrl: undefined` overrides from icon-rendering tests; collapsed the magicItems mapper test that asserted `imageUrl` was undefined.
- **Database** — new migration `20260506000000_drop_imageurl.sql` strips `imageUrl` from existing rows and re-adds the `cards_payload_valid` JSON Schema check constraint via the standard regenerated-schema flow.

### Data migration

We don't care about preserving existing `imageUrl` values — the app isn't public and there's no concern about data loss. The migration unconditionally drops the key from any rows that have it.

### How can this be tested?

- Open the card editor — the "Image URL (optional)" input should be gone.
- Existing cards (or freshly created ones) render with their icon in the header; print preview is unchanged for cards that never had an image set.
- New tests cover the icon-only render path; existing autofit / pagination / markdown tests are untouched.

### Additional Context

- The editor field had been there since the initial card model, but never had a strong UX rationale. Removing it is more aligned with the icon-first direction the project has taken (spell-icon heuristic in #40, curated icon set, etc.).
- The migration follows the same drop-then-add pattern as `20260504120000_hoist_tags_to_base.sql` — the embedded JSON Schema is regenerated from `src/decks/schema.ts` via `npm run gen:schema`.