### PR TITLE
fix(print): remove trailing blank page in print preview

### DIFF
--- a/src/views/PrintView.module.css
+++ b/src/views/PrintView.module.css
@@ -104,6 +104,9 @@
   box-sizing: border-box;
   display: grid;
   box-shadow: var(--print-shadow-page);
+}
+
+.page:not(:last-child) {
   page-break-after: always;
   break-after: page;
 }
@@ -147,6 +150,8 @@
   .page {
     box-shadow: none;
     padding: 0;
+  }
+  .page:not(:last-child) {
     break-after: page;
   }
   @page perPage2 {


### PR DESCRIPTION
### Description

Chrome's print preview was rendering an extra blank page after the last card sheet. Root cause: every `.page` element had `break-after: page`, including the last one — Chrome obeys that trailing break and emits an empty sheet after it.

Fix: scope the page-break rule to `.page:not(:last-child)` (in both the screen and `@media print` rules). The last sheet no longer forces a break after itself.

### How can this be tested?

- Open the print view for a deck (any `cardsPerPage` setting; with or without "Print backs"), hit Print, and confirm the preview ends on the last card sheet with no trailing blank page.
- On-screen preview should look unchanged.
- Existing `PrintView.test.tsx` suite still passes.