### PR TITLE
Remove card title autoscaling

### DIFF
--- a/src/cards/Card.test.tsx
+++ b/src/cards/Card.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
 import { Card } from "./Card";
 import { itemCardFactory, spellCardFactory } from "./factories";
 
@@ -159,91 +159,5 @@ describe("<Card> with markdown body", () => {
     expect(screen.getByRole("table")).toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "a" })).toBeInTheDocument();
     expect(screen.getByRole("cell", { name: "1" })).toBeInTheDocument();
-  });
-});
-
-describe("<Card> with title autofit", () => {
-  const LINE_HEIGHT_PX = 20;
-  let titleHeights: Record<string, number> = {};
-  let measuredScales: string[] = [];
-  let originalOffsetHeight: PropertyDescriptor | undefined;
-  let originalGetComputedStyle: typeof window.getComputedStyle;
-
-  beforeEach(() => {
-    originalOffsetHeight = Object.getOwnPropertyDescriptor(
-      HTMLHeadingElement.prototype,
-      "offsetHeight",
-    );
-    Object.defineProperty(HTMLHeadingElement.prototype, "offsetHeight", {
-      configurable: true,
-      get(this: HTMLHeadingElement) {
-        const fontSize = this.style.fontSize;
-        const key = fontSize === "" ? "1" : fontSize.replace("em", "");
-        measuredScales.push(key);
-        return titleHeights[key] ?? 0;
-      },
-    });
-
-    originalGetComputedStyle = window.getComputedStyle;
-    window.getComputedStyle = ((el: Element, pseudo?: string | null) => {
-      const real = originalGetComputedStyle.call(window, el, pseudo);
-      if (el instanceof HTMLHeadingElement) {
-        return new Proxy(real, {
-          get(target, prop, receiver) {
-            if (prop === "lineHeight") return `${LINE_HEIGHT_PX}px`;
-            const value = Reflect.get(target, prop, receiver);
-            return typeof value === "function" ? value.bind(target) : value;
-          },
-        });
-      }
-      return real;
-    }) as typeof window.getComputedStyle;
-  });
-
-  afterEach(() => {
-    if (originalOffsetHeight) {
-      Object.defineProperty(HTMLHeadingElement.prototype, "offsetHeight", originalOffsetHeight);
-    } else {
-      delete (HTMLHeadingElement.prototype as { offsetHeight?: number }).offsetHeight;
-    }
-    window.getComputedStyle = originalGetComputedStyle;
-    titleHeights = {};
-    measuredScales = [];
-  });
-
-  test("title that fits on one line gets no inline font-size", async () => {
-    titleHeights = { "1": LINE_HEIGHT_PX };
-    const card = itemCardFactory.build();
-    render(<Card card={card} cardsPerPage={4} />);
-    const heading = screen.getByRole("heading", { name: card.name });
-    await waitFor(() => {
-      expect(heading.style.fontSize).toBe("");
-    });
-  });
-
-  test("title that wraps at 1.0 but fits at 0.9 shrinks to 0.9em", async () => {
-    titleHeights = { "1": LINE_HEIGHT_PX * 2, "0.9": LINE_HEIGHT_PX };
-    const card = itemCardFactory.build();
-    render(<Card card={card} cardsPerPage={4} />);
-    const heading = screen.getByRole("heading", { name: card.name });
-    await waitFor(() => {
-      expect(heading.style.fontSize).toBe("0.9em");
-    });
-  });
-
-  test("title that wraps at every scale walks through 0.9 and 0.8 then gives up", async () => {
-    titleHeights = {
-      "1": LINE_HEIGHT_PX * 2,
-      "0.9": LINE_HEIGHT_PX * 2,
-      "0.8": LINE_HEIGHT_PX * 2,
-    };
-    const card = itemCardFactory.build();
-    render(<Card card={card} cardsPerPage={4} />);
-    const heading = screen.getByRole("heading", { name: card.name });
-    await waitFor(() => {
-      expect(measuredScales).toContain("0.8");
-    });
-    expect(measuredScales).toEqual(expect.arrayContaining(["1", "0.9", "0.8"]));
-    expect(heading.style.fontSize).toBe("");
   });
 });

--- a/src/cards/Card.tsx
+++ b/src/cards/Card.tsx
@@ -1,4 +1,3 @@
-import { useLayoutEffect, useRef, useState } from "react";
 import styles from "./Card.module.css";
 import { pickIconKey } from "./iconRules";
 import { renderBody } from "./renderBody";
@@ -16,48 +15,8 @@ type Props = {
   bodyOverride?: string;
 };
 
-type AutofitState =
-  | { kind: "unmeasured" }
-  | { kind: "fitted"; scale: 1 | 0.9 | 0.8 }
-  | { kind: "gave-up" };
-
 export function Card({ card, cardsPerPage, pagination, bodyOverride }: Props) {
   const layoutClass = cardsPerPage === 4 ? styles.perPage4 : styles.perPage2;
-
-  const titleRef = useRef<HTMLHeadingElement>(null);
-  const [autofit, setAutofit] = useState<AutofitState>({ kind: "unmeasured" });
-  const lastInputKeyRef = useRef<string | null>(null);
-
-  useLayoutEffect(() => {
-    const inputKey = `${card.id}:${card.name}:${cardsPerPage}`;
-    if (lastInputKeyRef.current !== inputKey) {
-      lastInputKeyRef.current = inputKey;
-      if (autofit.kind !== "unmeasured") {
-        setAutofit({ kind: "unmeasured" });
-        return;
-      }
-    }
-    if (autofit.kind === "gave-up") return;
-    if (autofit.kind === "fitted" && autofit.scale === 1) return;
-    const el = titleRef.current;
-    if (!el) return;
-    const lineHeightPx = Number.parseFloat(getComputedStyle(el).lineHeight);
-    if (!Number.isFinite(lineHeightPx) || lineHeightPx <= 0) return;
-    const wraps = Math.round(el.offsetHeight / lineHeightPx) > 1;
-
-    if (autofit.kind === "unmeasured") {
-      setAutofit(wraps ? { kind: "fitted", scale: 0.9 } : { kind: "fitted", scale: 1 });
-      return;
-    }
-    if (!wraps) return;
-    if (autofit.scale === 0.9) setAutofit({ kind: "fitted", scale: 0.8 });
-    else setAutofit({ kind: "gave-up" });
-  }, [autofit, card.id, card.name, cardsPerPage]);
-
-  const titleStyle =
-    autofit.kind === "fitted" && autofit.scale !== 1
-      ? { fontSize: `${autofit.scale}em` }
-      : undefined;
 
   const iconKey = card.iconKey ?? pickIconKey(card);
 
@@ -72,9 +31,7 @@ export function Card({ card, cardsPerPage, pagination, bodyOverride }: Props) {
         <div className={styles.icon} data-testid="card-icon" aria-hidden="true">
           <ResolvedIcon iconKey={iconKey} />
         </div>
-        <h3 className={styles.title} ref={titleRef} style={titleStyle}>
-          {card.name}
-        </h3>
+        <h3 className={styles.title}>{card.name}</h3>
         {isFirstPage && card.headerTags.length > 0 && (
           <span className={styles.headerTags}>
             {card.headerTags.map((tag) => (


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Removes the auto-shrink behavior that previously stepped a card title's font size down (1.0em → 0.9em → 0.8em → give up) when it would wrap to a second line. Titles now render at the base CSS size and wrap normally if they don't fit.

Deleted from `src/cards/Card.tsx`:
- `AutofitState` type
- `titleRef`, `lastInputKeyRef`, the `autofit` `useState`, and the measuring `useLayoutEffect`
- The inline `titleStyle` and the `ref` / `style` props on the `<h3>`
- The `useLayoutEffect` / `useRef` / `useState` imports (no longer used)

Deleted from `src/cards/Card.test.tsx`:
- The `<Card> with title autofit` describe block (DOM measurement stubs + 3 tests)
- `waitFor`, `beforeEach`, `afterEach` imports (only the autofit block used them)

The historical design spec at `docs/superpowers/specs/2026-05-03-title-autofit-design.md` is intentionally left in place as a record of the removed feature.

### How can this be tested?

- Open a card with a long title (e.g., a name long enough that it would previously have triggered the 0.9em / 0.8em scale step) and confirm it now renders at the normal size and wraps to a second line.
- Existing `<Card>` tests still cover heading rendering, pagination, and markdown body. The autofit-specific tests are removed because the behavior they pinned is gone.

### Additional Context

- The offscreen pagination `measurer.ts` is unaffected — it always measured titles at scale 1.0, so its conservative pagination decisions are unchanged.
- `Card.module.css` is unchanged. The `.title` class still owns the title's size (`font-size: 1.2em`) and `line-height: 1.15`.
- No callers anywhere else read the title's inline `font-size` (verified via grep for `autofit`, `AutofitState`, `titleStyle`, `titleRef`).