### PR TITLE
feat(auth): anonymous Supabase users with deck import on sign-in

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,3 @@
+# Loaded only when running `vite dev` (mode=development). Production
+# builds and tests are unaffected. Override in .env.local if needed.
+VITE_ANON_USERS_ENABLED=true

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
-# Enable anonymous Supabase users on app boot.
+# Enable anonymous Supabase users on app boot. Already on by default in
+# dev (see .env.development); set explicitly here for production envs.
 VITE_ANON_USERS_ENABLED=true

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-# Enable anonymous Supabase users on app boot. Default off.
-VITE_ANON_USERS_ENABLED=false
+# Enable anonymous Supabase users on app boot.
+VITE_ANON_USERS_ENABLED=true

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Enable anonymous Supabase users on app boot. Default off.
+VITE_ANON_USERS_ENABLED=false

--- a/docs/superpowers/handoffs/2026-05-08-anon-user-cleanup-notes.md
+++ b/docs/superpowers/handoffs/2026-05-08-anon-user-cleanup-notes.md
@@ -11,13 +11,13 @@ Decision: ship anonymous users without cleanup. Keep this doc so that whoever re
 
 ## Why cleanup is not urgent
 
-Three potential reasons to clean up; none of them currently bind:
+Three potential reasons to clean up; none currently bind, but the MAU one tightens once traffic is real:
 
-1. **Database row count.** `auth.users` rows are tiny. 100k abandoned anon rows consume well under the free-tier 500MB limit. Decks/cards belonging to abandoned users live under `on delete cascade`, so they'd vanish if/when the user does — but they're not large either.
-2. **MAU billing.** Supabase counts MAU only when a user signs in or refreshes a token. Truly abandoned anon users don't bill. There's no cost pressure.
+1. **Database row count.** `auth.users` rows are small (~30 mostly-tiny columns). 100k abandoned anon rows consume well under the free-tier 500MB limit. Decks/cards belonging to abandoned users live under `on delete cascade`, so they'd vanish if/when the user does — but they're not large either.
+2. **MAU billing.** This is the one to watch. Supabase counts MAU on sign-in *or* token refresh ([Manage MAU](https://supabase.com/docs/guides/platform/manage-your-usage/monthly-active-users)). The supabase-js client refreshes tokens automatically with `persistSession: true` (the default), so an anon user who comes back to the app — even silently, even without doing anything — is generating a refresh and **counts toward MAU** ([discussion #35933](https://github.com/orgs/supabase/discussions/35933)). Only *truly* abandoned anon users (never returning, no JWT in any browser still hitting the app) are free. Once the app has real recurring traffic, returning-but-uncommitted visitors will quietly inflate MAU.
 3. **Operator hygiene.** When poking around `auth.users` for debugging, anon users clutter. A `where is_anonymous = false` filter solves it.
 
-If MAU starts climbing, or if `auth.users` ever crosses some operationally annoying threshold, revisit. Until then the table can grow.
+**Suggested revisit threshold:** when either (a) MAU exceeds ~5,000 (free tier is 50,000, but headroom matters), or (b) `auth.users` row count exceeds ~10,000 — whichever comes first. Both are observable from the Supabase dashboard.
 
 ## Patterns we considered
 
@@ -42,13 +42,13 @@ These all bit the spec and would bite a re-attempt. Address each before shipping
 
 ### Activity-signal pitfalls
 
-- **`auth.users.last_sign_in_at` does not update on token refresh.** A returning anon user whose tokens auto-refresh in the background still has the same `last_sign_in_at` from the day they first arrived. Gating cleanup on this column reaps actively-used accounts at 30 days.
+- **`auth.users.last_sign_in_at` does not update on token refresh** (verified empirically and reported by community contributors; not formally documented as far as we found). A returning anon user whose tokens auto-refresh in the background still has the same `last_sign_in_at` from the day they first arrived. Gating cleanup on this column reaps actively-used accounts at 30 days.
 - **`auth.sessions.updated_at` looks like the right signal but isn't on its own.** Supabase prunes `auth.sessions` rows about 24 hours after the session expires. A user who was active 25 days ago and closed the tab will have *no* session row by the time the cleanup runs — and would be reaped despite being a "30-day-old" user. The activity predicate must combine session presence with a fallback like `users.created_at > now() - interval '30 days'` so freshly-created anons aren't reaped before they get a chance to come back. ([Sessions docs](https://supabase.com/docs/guides/auth/sessions))
 
 ### Edge Function pitfalls
 
 - **`Authorization: Bearer <service_role_key>` is wrong on new API keys.** Supabase's new `sb_secret_*` keys are not JWTs; `verify_jwt = true` (the default) rejects them. Two ways forward: (a) set `verify_jwt = false` for the cleanup function in `supabase/config.toml` and gate inside the function with a shared secret read from `Deno.env`, or (b) keep `verify_jwt = true` and pass legacy HS256 service-role JWT explicitly. (a) is cleaner and forward-compatible. ([Securing Edge Functions](https://supabase.com/docs/guides/functions/auth), [API keys](https://supabase.com/docs/guides/api/api-keys))
-- **`pg_net.http_post` defaults to a 2-second timeout.** Iterating `auth.admin.deleteUser()` over even 100 stale users on a cold-started Edge Function easily exceeds 2 seconds. Pass `timeout_milliseconds := 60000` explicitly; failures land in `net._http_response` (kept for 6 hours) and don't auto-retry.
+- **`pg_net.http_post` defaults to a 1-second (1000 ms) timeout** ([pg_net API reference](https://supabase.github.io/pg_net/api/)). Iterating `auth.admin.deleteUser()` over even a handful of stale users on a cold-started Edge Function easily exceeds 1 second. Pass `timeout_milliseconds := 60000` explicitly; failures land in `net._http_response` (kept for 6 hours) and don't auto-retry.
 - **Free-tier Edge Function limits matter.** 150 s wall clock, 2 s CPU, 256 MB memory. Deleting 1000 users serially via the admin API can approach the CPU budget. Either parallelize with `Promise.allSettled`, or cap the per-run `LIMIT` to ~200 and let weekly runs catch up.
 
 ## Recommended approach when revisiting
@@ -57,7 +57,19 @@ If/when cleanup becomes worth doing:
 
 1. **Pattern:** `pg_cron` + `pg_net` → Edge Function (Supabase's recommended pattern for scheduled admin work).
 2. **Auth model:** `verify_jwt = false` on the cleanup function; the function reads a `CLEANUP_SHARED_SECRET` env var and rejects requests that don't carry it. The cron job sends the secret. Sidesteps the legacy-vs-new key ambiguity.
-3. **Activity predicate:** `is_anonymous = true AND no recent session AND created_at < now() - interval '30 days'`. Both conditions are required so newly-created anons with no session yet aren't reaped.
+3. **Activity predicate:** `is_anonymous = true AND no recent session AND created_at < now() - interval '30 days'`. Both conditions are required so newly-created anons with no session yet aren't reaped. Concrete shape:
+    ```sql
+    select u.id
+    from auth.users u
+    where u.is_anonymous is true
+      and u.created_at < now() - interval '30 days'
+      and not exists (
+        select 1 from auth.sessions s
+        where s.user_id = u.id
+          and s.not_after > now() - interval '30 days'
+      )
+    ```
+    The `s.not_after` check tolerates the 24-hour-after-expiry pruning window: a session that's still listed and hasn't yet been pruned, but expired more than 30 days ago, doesn't count as "recent."
 4. **Permission grants** in the cleanup migration:
    - `grant delete on public.decks, public.cards to supabase_auth_admin;` (cascade path)
    - `grant select on vault.decrypted_secrets to postgres;` if Vault is used (or skip Vault)
@@ -65,17 +77,21 @@ If/when cleanup becomes worth doing:
 6. **Concurrency:** parallelize the per-user `auth.admin.deleteUser()` calls with `Promise.allSettled`, capped at ~10 concurrent.
 7. **Limits:** `LIMIT 200` per run on the helper. Schedule weekly. If volume ever justifies more, raise the LIMIT or the frequency.
 8. **Observability:** the Edge Function returns a JSON summary of `{ deleted, failures }`. Check `cron.job_run_details` and `net._http_response` for the first run; subsequent runs are visible in the Edge Function logs panel.
-9. **Rollout pre-flight:** verify the cascade grants by manually deleting one anon user in dev and confirming the cascade succeeds; verify the activity predicate against a known-active anon user.
+9. **Soft-delete vs hard-delete.** `auth.admin.deleteUser(id, shouldSoftDelete)` defaults to hard-delete (the FK cascade fires). Soft-delete preserves the row with `deleted_at` set and may not cascade. For our case (no audit retention requirement, deleted = irrelevant) the hard-delete default is correct; just confirm we're not flipping it accidentally.
+10. **Rollout pre-flight.** Verify the cascade grants by manually deleting one anon user in dev and confirming the cascade succeeds; verify the activity predicate against a known-active anon user.
+    - **Caveat:** the local Supabase stack (via `supabase start`) sometimes has different default role memberships than the hosted environment. Cascade-grant or ownership-transfer bugs can pass locally and fail in staging. Always smoke-test on a hosted project before assuming the migration is solid.
 
 ## References
 
 - [Supabase Anonymous Sign-Ins](https://supabase.com/docs/guides/auth/auth-anonymous)
+- [Manage MAU](https://supabase.com/docs/guides/platform/manage-your-usage/monthly-active-users) — what counts as MAU; relevant for anon billing
+- [Anon sign-ins MAU discussion #35933](https://github.com/orgs/supabase/discussions/35933)
 - [Supabase Cron + Edge Functions](https://supabase.com/docs/guides/functions/schedule-functions)
 - [pg_cron extension](https://supabase.com/docs/guides/database/extensions/pg_cron)
-- [pg_net extension](https://supabase.com/docs/guides/database/extensions/pg_net)
+- [pg_net extension docs](https://supabase.com/docs/guides/database/extensions/pg_net) and [pg_net API reference](https://supabase.github.io/pg_net/api/) — the API ref is where the 1-second default timeout is documented.
 - [Supabase Vault](https://supabase.com/docs/guides/database/vault)
 - [Edge Function limits (free tier)](https://supabase.com/docs/guides/functions/limits)
-- [Securing Edge Functions](https://supabase.com/docs/guides/functions/auth)
-- [Sessions docs (retention)](https://supabase.com/docs/guides/auth/sessions)
-- [Cascade-vs-supabase_auth_admin discussion](https://github.com/orgs/supabase/discussions/28776)
+- [Securing Edge Functions](https://supabase.com/docs/guides/functions/auth) and [Understanding API keys](https://supabase.com/docs/guides/api/api-keys) — relevant for the legacy-vs-`sb_secret_*` distinction
+- [Sessions docs (retention: 24h after expiry)](https://supabase.com/docs/guides/auth/sessions)
+- [Cascade-vs-supabase_auth_admin discussion #28776](https://github.com/orgs/supabase/discussions/28776) and [auth.users ownership #38887](https://github.com/orgs/supabase/discussions/38887)
 - [pg_cron → Edge Function CLI issue tracking the official pattern](https://github.com/supabase/cli/issues/4287)

--- a/docs/superpowers/handoffs/2026-05-08-anon-user-cleanup-notes.md
+++ b/docs/superpowers/handoffs/2026-05-08-anon-user-cleanup-notes.md
@@ -1,0 +1,81 @@
+# Anonymous user cleanup — research notes
+
+**Date:** 2026-05-08
+**Status:** deferred from the [Anonymous Supabase Users spec](../specs/2026-05-07-anon-supabase-users-design.md)
+
+## Why this doc exists
+
+The original anonymous-users spec included a weekly `pg_cron` job to delete stale anon `auth.users` rows. Two consecutive review rounds turned up a long tail of correctness and operational issues that, taken together, cost more design and implementation budget than the cleanup is actually worth for a hobby project.
+
+Decision: ship anonymous users without cleanup. Keep this doc so that whoever revisits the cleanup question later doesn't have to rediscover everything.
+
+## Why cleanup is not urgent
+
+Three potential reasons to clean up; none of them currently bind:
+
+1. **Database row count.** `auth.users` rows are tiny. 100k abandoned anon rows consume well under the free-tier 500MB limit. Decks/cards belonging to abandoned users live under `on delete cascade`, so they'd vanish if/when the user does — but they're not large either.
+2. **MAU billing.** Supabase counts MAU only when a user signs in or refreshes a token. Truly abandoned anon users don't bill. There's no cost pressure.
+3. **Operator hygiene.** When poking around `auth.users` for debugging, anon users clutter. A `where is_anonymous = false` filter solves it.
+
+If MAU starts climbing, or if `auth.users` ever crosses some operationally annoying threshold, revisit. Until then the table can grow.
+
+## Patterns we considered
+
+| Pattern | Status |
+|---|---|
+| Do nothing | What we shipped |
+| `pg_cron` direct DELETE on `auth.users` | Rejected — `postgres` role lacks DELETE permission |
+| `pg_cron` + `SECURITY DEFINER` function that does DELETE | Rejected — works in principle but stacks several Supabase pitfalls (see below); two review rounds turned up new problems |
+| `pg_cron` + `pg_net` → Edge Function calling `auth.admin.deleteUser()` | The right pattern when revisited; still needs all the fixes below |
+| External cron (GitHub Actions / Vercel cron) → Edge Function | Same Edge Function as above; only differs in scheduler. Useful if the Postgres-side complexity feels worse than CI complexity |
+
+## Pitfalls we found (and the fixes)
+
+These all bit the spec and would bite a re-attempt. Address each before shipping cleanup.
+
+### Permission and role pitfalls
+
+- **`postgres` cannot DELETE from `auth.users` directly.** That table is owned by `supabase_auth_admin`. The bare `delete from auth.users where ...` from a `pg_cron` job will fail with a permission error. Standard workarounds: a `SECURITY DEFINER` function owned by `supabase_auth_admin`, an explicit `grant delete on auth.users to postgres` (broader privilege than necessary), or call `auth.admin.deleteUser()` from an Edge Function (which uses `service_role`).
+- **`alter function ... owner to supabase_auth_admin` from a standard migration often fails with 42501.** `postgres` is sometimes — not always — a member of `supabase_auth_admin`'s role group, and ownership transfer also requires CREATE on the function's schema. If we go the SECURITY DEFINER route, ownership transfer should not be load-bearing; default `postgres` ownership is enough for read-only operations on `auth.sessions` (which `postgres` can already SELECT).
+- **Cascading deletes from `auth.users` run as `supabase_auth_admin`, not as the caller.** Calling `auth.admin.deleteUser(id)` triggers the FK cascade to `public.decks` (and transitively `public.cards`), but that cascade executes under `supabase_auth_admin`, which doesn't have default `DELETE` permission on `public` tables. Expect cascades to fail unless you `grant delete on public.decks, public.cards to supabase_auth_admin;` in a migration. ([Discussion #28776](https://github.com/orgs/supabase/discussions/28776))
+- **`vault.decrypted_secrets` reads from a cron job often hit `permission denied`.** If the cron schedule embeds Vault reads (for project URL or service-role key), grant SELECT on the view to `postgres`, or move the secrets out of Vault and into Edge Function env vars (which Supabase auto-injects).
+
+### Activity-signal pitfalls
+
+- **`auth.users.last_sign_in_at` does not update on token refresh.** A returning anon user whose tokens auto-refresh in the background still has the same `last_sign_in_at` from the day they first arrived. Gating cleanup on this column reaps actively-used accounts at 30 days.
+- **`auth.sessions.updated_at` looks like the right signal but isn't on its own.** Supabase prunes `auth.sessions` rows about 24 hours after the session expires. A user who was active 25 days ago and closed the tab will have *no* session row by the time the cleanup runs — and would be reaped despite being a "30-day-old" user. The activity predicate must combine session presence with a fallback like `users.created_at > now() - interval '30 days'` so freshly-created anons aren't reaped before they get a chance to come back. ([Sessions docs](https://supabase.com/docs/guides/auth/sessions))
+
+### Edge Function pitfalls
+
+- **`Authorization: Bearer <service_role_key>` is wrong on new API keys.** Supabase's new `sb_secret_*` keys are not JWTs; `verify_jwt = true` (the default) rejects them. Two ways forward: (a) set `verify_jwt = false` for the cleanup function in `supabase/config.toml` and gate inside the function with a shared secret read from `Deno.env`, or (b) keep `verify_jwt = true` and pass legacy HS256 service-role JWT explicitly. (a) is cleaner and forward-compatible. ([Securing Edge Functions](https://supabase.com/docs/guides/functions/auth), [API keys](https://supabase.com/docs/guides/api/api-keys))
+- **`pg_net.http_post` defaults to a 2-second timeout.** Iterating `auth.admin.deleteUser()` over even 100 stale users on a cold-started Edge Function easily exceeds 2 seconds. Pass `timeout_milliseconds := 60000` explicitly; failures land in `net._http_response` (kept for 6 hours) and don't auto-retry.
+- **Free-tier Edge Function limits matter.** 150 s wall clock, 2 s CPU, 256 MB memory. Deleting 1000 users serially via the admin API can approach the CPU budget. Either parallelize with `Promise.allSettled`, or cap the per-run `LIMIT` to ~200 and let weekly runs catch up.
+
+## Recommended approach when revisiting
+
+If/when cleanup becomes worth doing:
+
+1. **Pattern:** `pg_cron` + `pg_net` → Edge Function (Supabase's recommended pattern for scheduled admin work).
+2. **Auth model:** `verify_jwt = false` on the cleanup function; the function reads a `CLEANUP_SHARED_SECRET` env var and rejects requests that don't carry it. The cron job sends the secret. Sidesteps the legacy-vs-new key ambiguity.
+3. **Activity predicate:** `is_anonymous = true AND no recent session AND created_at < now() - interval '30 days'`. Both conditions are required so newly-created anons with no session yet aren't reaped.
+4. **Permission grants** in the cleanup migration:
+   - `grant delete on public.decks, public.cards to supabase_auth_admin;` (cascade path)
+   - `grant select on vault.decrypted_secrets to postgres;` if Vault is used (or skip Vault)
+5. **Helper function:** `public.stale_anon_user_ids()` — read-only, `SECURITY DEFINER`, default `postgres` owner, `set search_path = ''`. Returns IDs only; deletion happens in the Edge Function via `auth.admin.deleteUser()`.
+6. **Concurrency:** parallelize the per-user `auth.admin.deleteUser()` calls with `Promise.allSettled`, capped at ~10 concurrent.
+7. **Limits:** `LIMIT 200` per run on the helper. Schedule weekly. If volume ever justifies more, raise the LIMIT or the frequency.
+8. **Observability:** the Edge Function returns a JSON summary of `{ deleted, failures }`. Check `cron.job_run_details` and `net._http_response` for the first run; subsequent runs are visible in the Edge Function logs panel.
+9. **Rollout pre-flight:** verify the cascade grants by manually deleting one anon user in dev and confirming the cascade succeeds; verify the activity predicate against a known-active anon user.
+
+## References
+
+- [Supabase Anonymous Sign-Ins](https://supabase.com/docs/guides/auth/auth-anonymous)
+- [Supabase Cron + Edge Functions](https://supabase.com/docs/guides/functions/schedule-functions)
+- [pg_cron extension](https://supabase.com/docs/guides/database/extensions/pg_cron)
+- [pg_net extension](https://supabase.com/docs/guides/database/extensions/pg_net)
+- [Supabase Vault](https://supabase.com/docs/guides/database/vault)
+- [Edge Function limits (free tier)](https://supabase.com/docs/guides/functions/limits)
+- [Securing Edge Functions](https://supabase.com/docs/guides/functions/auth)
+- [Sessions docs (retention)](https://supabase.com/docs/guides/auth/sessions)
+- [Cascade-vs-supabase_auth_admin discussion](https://github.com/orgs/supabase/discussions/28776)
+- [pg_cron → Edge Function CLI issue tracking the official pattern](https://github.com/supabase/cli/issues/4287)

--- a/docs/superpowers/plans/2026-05-08-anon-supabase-users.md
+++ b/docs/superpowers/plans/2026-05-08-anon-supabase-users.md
@@ -1,0 +1,2164 @@
+# Anonymous Supabase Users Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let visitors use the full app without signing in. Their work persists under a real `auth.users` row created via Supabase's anonymous sign-in. Sign-in via OAuth converts the anon account in place (same UUID); if the OAuth identity is already linked elsewhere, offer a resumable client-side clone into the existing account.
+
+**Architecture:** Gated behind `VITE_ANON_USERS_ENABLED`. `AuthProvider` calls `signInAnonymously()` on boot when no session exists; `LoginView` branches on the anon's deck count to choose `linkIdentity` vs `signInWithOAuth`; `AuthCallback` parses the URL for `error_code=identity_already_exists` and runs the resumable import via `localStorage.dndCards.pendingAnonImport`; a small `Announcement` primitive replaces the toasts referenced in early drafts of the spec.
+
+**Tech Stack:** React 18 + TypeScript + Vite, TanStack Router + TanStack Query, `@supabase/supabase-js`, react-aria-components, CSS modules, Vitest + RTL + `@testing-library/user-event`, MSW for HTTP mocks, Fishery + faker for factories.
+
+**Spec:** [`docs/superpowers/specs/2026-05-07-anon-supabase-users-design.md`](../specs/2026-05-07-anon-supabase-users-design.md). The spec is the source of truth for any decision not spelled out here.
+
+---
+
+## File structure
+
+**Files to create:**
+- `src/lib/ui/Announcement.tsx` — `<AnnouncementProvider>`, `useSetNextAnnouncement()`, `<Announcement />`
+- `src/lib/ui/Announcement.module.css`
+- `src/lib/ui/Announcement.test.tsx`
+- `src/auth/anonImport.ts` — `stash`, `tryResume`, `clear`, `PendingAnonImport` type
+- `src/auth/anonImport.test.ts`
+- `src/views/FirstDeckDialog.tsx` — modal explainer (uses `DialogShell` + `DialogHeader`)
+- `src/views/FirstDeckDialog.test.tsx`
+- `src/auth/ImportAccountDialog.tsx` — "you already have an account" dialog
+- `src/auth/ImportAccountDialog.test.tsx`
+
+**Files to modify:**
+- `src/auth/AuthProvider.tsx` — call `signInAnonymously()` when no session and flag on
+- `src/auth/AuthProvider.test.tsx` — flag-on path test
+- `src/lib/ui/UserMenu.tsx` — render pill CTA when anon
+- `src/lib/ui/UserMenu.module.css` — `.pillCta` class
+- `src/lib/ui/UserMenu.test.tsx` — anon-CTA case
+- `src/auth/LoginView.tsx` — anon-aware OAuth click handlers; two-step `updateUser` for dev path
+- `src/auth/LoginView.test.tsx` — anon paths
+- `src/auth/AuthCallback.tsx` — URL parsing, import progress, `tryResume()`, set Announcement on success
+- `src/auth/AuthCallback.test.tsx` — failure-URL → dialog; success → announcement
+- `src/views/HomeView.tsx` — trigger `FirstDeckDialog` after first anon deck create
+- `src/views/HomeView.test.tsx` — dialog trigger; anon-create flow
+- `src/app/Root.tsx` — wrap children with `AnnouncementProvider`; render `<Announcement />` near top of main
+- `src/test/msw.ts` — handlers for `signInAnonymously`, `linkIdentity`, `updateUser`, public-read SELECTs by `owner_id`
+- `supabase/config.toml` — `enable_anonymous_sign_ins = true`
+- `.env.example` (or README env section) — document `VITE_ANON_USERS_ENABLED`
+
+**Tests run with:** `npm test -- --run path/to/file` (Vitest). Pre-approved per CLAUDE.md.
+
+---
+
+## Task 1: Foundation — env var helper and supabase local config
+
+**Files:**
+- Create: `src/lib/anonEnabled.ts`
+- Create: `src/lib/anonEnabled.test.ts`
+- Modify: `supabase/config.toml`
+- Modify: `.env.example` (create if missing)
+
+The flag is read in three call sites (`AuthProvider`, `UserMenu`, `LoginView`); centralize via a tiny helper so tests can stub one place.
+
+- [ ] **Step 1: Write the failing test for the helper**
+
+```ts
+// src/lib/anonEnabled.test.ts
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isAnonUsersEnabled } from "./anonEnabled";
+
+describe("isAnonUsersEnabled", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns true when VITE_ANON_USERS_ENABLED === "true"', () => {
+    vi.stubEnv("VITE_ANON_USERS_ENABLED", "true");
+    expect(isAnonUsersEnabled()).toBe(true);
+  });
+
+  it("returns false when the env var is unset", () => {
+    vi.stubEnv("VITE_ANON_USERS_ENABLED", "");
+    expect(isAnonUsersEnabled()).toBe(false);
+  });
+
+  it('returns false for any non-"true" value', () => {
+    vi.stubEnv("VITE_ANON_USERS_ENABLED", "1");
+    expect(isAnonUsersEnabled()).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+Run: `npm test -- --run src/lib/anonEnabled.test.ts`
+Expected: fails with "Cannot find module './anonEnabled'".
+
+- [ ] **Step 3: Implement the helper**
+
+```ts
+// src/lib/anonEnabled.ts
+export function isAnonUsersEnabled(): boolean {
+  return import.meta.env.VITE_ANON_USERS_ENABLED === "true";
+}
+```
+
+- [ ] **Step 4: Run the test, confirm pass**
+
+Run: `npm test -- --run src/lib/anonEnabled.test.ts`
+Expected: 3/3 pass.
+
+- [ ] **Step 5: Update local Supabase config**
+
+In `supabase/config.toml`, find `enable_anonymous_sign_ins = false` and change to `true`.
+
+- [ ] **Step 6: Document the env var**
+
+Add to `.env.example` (create if missing):
+
+```
+# Enable anonymous Supabase users on app boot. Default off.
+VITE_ANON_USERS_ENABLED=false
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/anonEnabled.ts src/lib/anonEnabled.test.ts supabase/config.toml .env.example
+git commit -m "feat: add VITE_ANON_USERS_ENABLED flag and helper"
+```
+
+---
+
+## Task 2: Announcement primitive
+
+**Files:**
+- Create: `src/lib/ui/Announcement.tsx`
+- Create: `src/lib/ui/Announcement.module.css`
+- Create: `src/lib/ui/Announcement.test.tsx`
+
+A small primitive: provider holds the next announcement in a ref-backed slot; `<Announcement />` reads on mount, displays it, auto-dismisses after 5s. `useSetNextAnnouncement()` writes the slot.
+
+- [ ] **Step 1: Write a failing test for the basic render-then-dismiss flow**
+
+```tsx
+// src/lib/ui/Announcement.test.tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Announcement, AnnouncementProvider, useSetNextAnnouncement } from "./Announcement";
+
+function Setter({ message }: { message: string | null }) {
+  const setNext = useSetNextAnnouncement();
+  return (
+    <button type="button" onClick={() => setNext(message)}>
+      set
+    </button>
+  );
+}
+
+describe("<Announcement>", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders nothing when no announcement is queued", () => {
+    const { container } = render(
+      <AnnouncementProvider>
+        <Announcement />
+      </AnnouncementProvider>,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the queued message when mounted after the setter ran", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    function Harness() {
+      return (
+        <AnnouncementProvider>
+          <Setter message="Signed in" />
+          <Announcement />
+        </AnnouncementProvider>
+      );
+    }
+    render(<Harness />);
+    await user.click(screen.getByText("set"));
+    // The setter writes the slot; the existing <Announcement /> picks it up
+    // on its next render. We trigger that by advancing the dismiss timer.
+    expect(screen.getByRole("status")).toHaveTextContent("Signed in");
+  });
+
+  it("auto-dismisses after 5 seconds", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(
+      <AnnouncementProvider>
+        <Setter message="Imported 3 decks" />
+        <Announcement />
+      </AnnouncementProvider>,
+    );
+    await user.click(screen.getByText("set"));
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    vi.advanceTimersByTime(5000);
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("dismisses on user click of the close button", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(
+      <AnnouncementProvider>
+        <Setter message="Imported 3 decks" />
+        <Announcement />
+      </AnnouncementProvider>,
+    );
+    await user.click(screen.getByText("set"));
+    await user.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it('marks the message with role="status" and aria-live="polite"', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(
+      <AnnouncementProvider>
+        <Setter message="Hello" />
+        <Announcement />
+      </AnnouncementProvider>,
+    );
+    await user.click(screen.getByText("set"));
+    const status = screen.getByRole("status");
+    expect(status).toHaveAttribute("aria-live", "polite");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests, confirm they fail**
+
+Run: `npm test -- --run src/lib/ui/Announcement.test.tsx`
+Expected: fails with "Cannot find module './Announcement'".
+
+- [ ] **Step 3: Create the CSS module**
+
+```css
+/* src/lib/ui/Announcement.module.css */
+.root {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  margin-bottom: var(--space-3);
+  color: var(--color-text);
+  font-size: var(--fs-sm);
+}
+
+.message {
+  flex: 1;
+}
+
+.dismiss {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  font-size: var(--fs-md);
+  color: var(--color-text-muted);
+  padding: 0 var(--space-1);
+}
+
+.dismiss:hover {
+  color: var(--color-text);
+}
+```
+
+- [ ] **Step 4: Implement the primitive**
+
+```tsx
+// src/lib/ui/Announcement.tsx
+import {
+  type ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import styles from "./Announcement.module.css";
+
+const AUTO_DISMISS_MS = 5000;
+
+type Slot = { message: string | null };
+
+const AnnouncementContext = createContext<{ slotRef: { current: Slot } } | null>(null);
+
+export function AnnouncementProvider({ children }: { children: ReactNode }) {
+  const slotRef = useRef<Slot>({ message: null });
+  return (
+    <AnnouncementContext.Provider value={{ slotRef }}>{children}</AnnouncementContext.Provider>
+  );
+}
+
+export function useSetNextAnnouncement() {
+  const ctx = useContext(AnnouncementContext);
+  if (!ctx) {
+    throw new Error("useSetNextAnnouncement must be used inside <AnnouncementProvider>");
+  }
+  return useCallback(
+    (message: string | null) => {
+      ctx.slotRef.current.message = message;
+    },
+    [ctx],
+  );
+}
+
+export function Announcement() {
+  const ctx = useContext(AnnouncementContext);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!ctx) return;
+    const queued = ctx.slotRef.current.message;
+    if (queued) {
+      setMessage(queued);
+      ctx.slotRef.current.message = null;
+    }
+  });
+
+  useEffect(() => {
+    if (!message) return;
+    const id = window.setTimeout(() => setMessage(null), AUTO_DISMISS_MS);
+    return () => window.clearTimeout(id);
+  }, [message]);
+
+  if (!message) return null;
+  return (
+    <div className={styles.root} role="status" aria-live="polite">
+      <span className={styles.message}>{message}</span>
+      <button
+        type="button"
+        className={styles.dismiss}
+        aria-label="Dismiss announcement"
+        onClick={() => setMessage(null)}
+      >
+        ✕
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Run the tests, confirm pass**
+
+Run: `npm test -- --run src/lib/ui/Announcement.test.tsx`
+Expected: 5/5 pass.
+
+- [ ] **Step 6: Wire into Root**
+
+In `src/app/Root.tsx`, import and wrap children, render `<Announcement />` near the top of `<main>`:
+
+```tsx
+// src/app/Root.tsx
+import { Link, Outlet } from "@tanstack/react-router";
+import { Announcement, AnnouncementProvider } from "../lib/ui/Announcement";
+import { GitHubLogo } from "../lib/ui/icons/GitHubLogo";
+import { UserMenu } from "../lib/ui/UserMenu";
+import { DeckBreadcrumb } from "./DeckBreadcrumb";
+import styles from "./root.module.css";
+
+const REPO_URL = "https://github.com/ChristopherChudzicki/dnd-cards";
+
+export function Root() {
+  return (
+    <AnnouncementProvider>
+      <div className={styles.shell}>
+        <header className={styles.header}>
+          <Link to="/" className={styles.brand}>
+            D&amp;D Cards
+          </Link>
+          <DeckBreadcrumb />
+          <a
+            href={REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.iconLink}
+            aria-label="View source on GitHub"
+          >
+            <GitHubLogo size={20} />
+          </a>
+          <UserMenu />
+        </header>
+        <main className={styles.main}>
+          <Announcement />
+          <Outlet />
+        </main>
+      </div>
+    </AnnouncementProvider>
+  );
+}
+```
+
+- [ ] **Step 7: Run the full test suite to confirm no regressions**
+
+Run: `npm test -- --run`
+Expected: all green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/ui/Announcement.tsx src/lib/ui/Announcement.module.css src/lib/ui/Announcement.test.tsx src/app/Root.tsx
+git commit -m "feat(ui): add Announcement primitive and wire into Root"
+```
+
+---
+
+## Task 3: anonImport pure module
+
+**Files:**
+- Create: `src/auth/anonImport.ts`
+- Create: `src/auth/anonImport.test.ts`
+
+Pure module: stash/tryResume/clear of `localStorage.dndCards.pendingAnonImport`. The shape carries a `version: 1` field so a future shape change can be ignored gracefully.
+
+- [ ] **Step 1: Write failing tests for stash/clear/read**
+
+```ts
+// src/auth/anonImport.test.ts
+import { beforeEach, describe, expect, it } from "vitest";
+import { clear, readPending, stash, type PendingAnonImport } from "./anonImport";
+
+describe("anonImport storage", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns null when nothing is stashed", () => {
+    expect(readPending()).toBeNull();
+  });
+
+  it("round-trips a stashed payload", () => {
+    const payload: PendingAnonImport = {
+      version: 1,
+      anonUuid: "00000000-0000-0000-0000-000000000001",
+      importedDeckIds: [],
+    };
+    stash(payload);
+    expect(readPending()).toEqual(payload);
+  });
+
+  it("clears the stashed payload", () => {
+    stash({ version: 1, anonUuid: "x", importedDeckIds: [] });
+    clear();
+    expect(readPending()).toBeNull();
+  });
+
+  it("returns null and does not throw on a malformed value", () => {
+    window.localStorage.setItem("dndCards.pendingAnonImport", "not json");
+    expect(readPending()).toBeNull();
+  });
+
+  it("returns null on a stashed value with an unknown version", () => {
+    window.localStorage.setItem(
+      "dndCards.pendingAnonImport",
+      JSON.stringify({ version: 999, anonUuid: "x", importedDeckIds: [] }),
+    );
+    expect(readPending()).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failing**
+
+Run: `npm test -- --run src/auth/anonImport.test.ts`
+Expected: fails with "Cannot find module './anonImport'".
+
+- [ ] **Step 3: Implement the module skeleton (storage helpers)**
+
+```ts
+// src/auth/anonImport.ts
+const STORAGE_KEY = "dndCards.pendingAnonImport";
+
+export type PendingAnonImport = {
+  version: 1;
+  anonUuid: string;
+  importedDeckIds: string[];
+};
+
+export function stash(payload: PendingAnonImport): void {
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+}
+
+export function clear(): void {
+  window.localStorage.removeItem(STORAGE_KEY);
+}
+
+export function readPending(): PendingAnonImport | null {
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as { version?: number };
+    if (parsed.version !== 1) return null;
+    return parsed as PendingAnonImport;
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 4: Run, confirm pass**
+
+Run: `npm test -- --run src/auth/anonImport.test.ts`
+Expected: 5/5 pass.
+
+- [ ] **Step 5: Add a failing test for `tryResume` happy path**
+
+Append to `src/auth/anonImport.test.ts`:
+
+```ts
+import { tryResume } from "./anonImport";
+// (existing imports already cover stash/clear/readPending/PendingAnonImport)
+
+type FakeSupabase = {
+  decks: { ownerId: string; id: string; name: string }[];
+  cards: { id: string; deck_id: string; position: number; payload: unknown }[];
+  inserts: { decks: unknown[]; cards: unknown[] };
+};
+
+function makeFakeSupabase(initial: FakeSupabase) {
+  return {
+    state: initial,
+    from(table: string) {
+      const state = initial;
+      return {
+        select() {
+          return {
+            eq(_col: string, val: string) {
+              if (table === "decks") {
+                return Promise.resolve({
+                  data: state.decks.filter((d) => d.ownerId === val).map((d) => ({
+                    id: d.id,
+                    owner_id: d.ownerId,
+                    name: d.name,
+                  })),
+                  error: null,
+                });
+              }
+              if (table === "cards") {
+                return Promise.resolve({
+                  data: state.cards.filter((c) => c.deck_id === val),
+                  error: null,
+                });
+              }
+              return Promise.resolve({ data: [], error: null });
+            },
+          };
+        },
+        insert(rows: unknown) {
+          state.inserts[table as "decks" | "cards"].push(rows);
+          return {
+            select() {
+              return {
+                single() {
+                  // Pretend the DB minted an id and timestamps.
+                  return Promise.resolve({
+                    data: { id: "new-deck-id", ...(Array.isArray(rows) ? rows[0] : rows) },
+                    error: null,
+                  });
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe("tryResume", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("clones each anon-owned deck and its cards under the new user, then clears the key", async () => {
+    stash({
+      version: 1,
+      anonUuid: "anon-1",
+      importedDeckIds: [],
+    });
+    const fake = makeFakeSupabase({
+      decks: [{ ownerId: "anon-1", id: "d1", name: "Goblins" }],
+      cards: [{ id: "c1", deck_id: "d1", position: 0, payload: { kind: "item", name: "Sword" } }],
+      inserts: { decks: [], cards: [] },
+    });
+    await tryResume({ supabase: fake as never, currentUserId: "real-1" });
+    expect(fake.state.inserts.decks).toHaveLength(1);
+    expect(fake.state.inserts.cards).toHaveLength(1);
+    expect(readPending()).toBeNull();
+  });
+
+  it("skips decks already in importedDeckIds (resumable)", async () => {
+    stash({
+      version: 1,
+      anonUuid: "anon-1",
+      importedDeckIds: ["d1"],
+    });
+    const fake = makeFakeSupabase({
+      decks: [
+        { ownerId: "anon-1", id: "d1", name: "Done" },
+        { ownerId: "anon-1", id: "d2", name: "Pending" },
+      ],
+      cards: [{ id: "c2", deck_id: "d2", position: 0, payload: {} }],
+      inserts: { decks: [], cards: [] },
+    });
+    await tryResume({ supabase: fake as never, currentUserId: "real-1" });
+    expect(fake.state.inserts.decks).toHaveLength(1);
+  });
+
+  it("treats zero-rows as already-imported and clears the key without inserting", async () => {
+    stash({
+      version: 1,
+      anonUuid: "missing-anon",
+      importedDeckIds: [],
+    });
+    const fake = makeFakeSupabase({
+      decks: [],
+      cards: [],
+      inserts: { decks: [], cards: [] },
+    });
+    await tryResume({ supabase: fake as never, currentUserId: "real-1" });
+    expect(fake.state.inserts.decks).toHaveLength(0);
+    expect(readPending()).toBeNull();
+  });
+
+  it("is a no-op when there is no pending import", async () => {
+    const fake = makeFakeSupabase({ decks: [], cards: [], inserts: { decks: [], cards: [] } });
+    const result = await tryResume({ supabase: fake as never, currentUserId: "real-1" });
+    expect(result).toEqual({ kind: "noop" });
+  });
+});
+```
+
+- [ ] **Step 6: Run, confirm failing**
+
+Run: `npm test -- --run src/auth/anonImport.test.ts`
+Expected: tryResume tests fail with "tryResume is not exported".
+
+- [ ] **Step 7: Implement tryResume**
+
+Append to `src/auth/anonImport.ts`:
+
+```ts
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export type ResumeResult =
+  | { kind: "noop" }
+  | { kind: "completed"; importedCount: number }
+  | { kind: "partial"; importedCount: number; total: number };
+
+export async function tryResume(args: {
+  supabase: SupabaseClient;
+  currentUserId: string;
+  onProgress?: (imported: number, total: number) => void;
+}): Promise<ResumeResult> {
+  const pending = readPending();
+  if (!pending) return { kind: "noop" };
+
+  const { data: anonDecks, error: deckError } = await args.supabase
+    .from("decks")
+    .select("id, name")
+    .eq("owner_id", pending.anonUuid);
+  if (deckError) throw deckError;
+  if (!anonDecks || anonDecks.length === 0) {
+    clear();
+    return { kind: "completed", importedCount: 0 };
+  }
+
+  const total = anonDecks.length;
+  let imported = pending.importedDeckIds.length;
+  args.onProgress?.(imported, total);
+
+  for (const deck of anonDecks as Array<{ id: string; name: string }>) {
+    if (pending.importedDeckIds.includes(deck.id)) continue;
+
+    const { data: newDeck, error: insertDeckError } = await args.supabase
+      .from("decks")
+      .insert({ owner_id: args.currentUserId, name: deck.name })
+      .select()
+      .single();
+    if (insertDeckError) {
+      stash(pending);
+      return { kind: "partial", importedCount: imported, total };
+    }
+
+    const { data: cards, error: cardsError } = await args.supabase
+      .from("cards")
+      .select("position, payload")
+      .eq("deck_id", deck.id);
+    if (cardsError) {
+      stash(pending);
+      return { kind: "partial", importedCount: imported, total };
+    }
+
+    if (cards && cards.length > 0) {
+      const rows = (cards as Array<{ position: number; payload: unknown }>).map((c) => ({
+        deck_id: (newDeck as { id: string }).id,
+        position: c.position,
+        payload: c.payload,
+      }));
+      const { error: insertCardsError } = await args.supabase.from("cards").insert(rows);
+      if (insertCardsError) {
+        stash(pending);
+        return { kind: "partial", importedCount: imported, total };
+      }
+    }
+
+    pending.importedDeckIds.push(deck.id);
+    imported += 1;
+    stash(pending);
+    args.onProgress?.(imported, total);
+  }
+
+  clear();
+  return { kind: "completed", importedCount: imported };
+}
+```
+
+- [ ] **Step 8: Run, confirm pass**
+
+Run: `npm test -- --run src/auth/anonImport.test.ts`
+Expected: 9/9 pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/auth/anonImport.ts src/auth/anonImport.test.ts
+git commit -m "feat(auth): add anonImport module for resumable cross-account clone"
+```
+
+---
+
+## Task 4: AuthProvider boot path — anonymous sign-in
+
+**Files:**
+- Modify: `src/auth/AuthProvider.tsx`
+- Modify: `src/auth/AuthProvider.test.tsx`
+- Modify: `src/test/msw.ts` (add handler for `/auth/v1/signup`)
+
+When the flag is on and INITIAL_SESSION fires with no session, call `signInAnonymously()` and stay in `loading` until the next auth event resolves. Never transition through `unauthenticated`.
+
+- [ ] **Step 1: Add MSW handler for the anonymous signup endpoint**
+
+Read `src/test/msw.ts` first to find where the auth handlers are registered. Add this handler inside the `supabaseDefaultHandlers` array (next to the existing `/auth/v1/user` handler):
+
+```ts
+http.post(`${SB_URL}/auth/v1/signup`, async ({ request }) => {
+  const body = (await request.json()) as { is_anonymous?: boolean };
+  if (!body.is_anonymous) {
+    return new HttpResponse("only anon signup mocked", { status: 400 });
+  }
+  return HttpResponse.json({
+    access_token: "fake-anon-jwt",
+    refresh_token: "fake-anon-refresh",
+    token_type: "bearer",
+    expires_in: 3600,
+    user: { id: "anon-test-id", is_anonymous: true, email: null },
+  });
+}),
+```
+
+- [ ] **Step 2: Write a failing test for the flag-on path**
+
+Append to `src/auth/AuthProvider.test.tsx`:
+
+```tsx
+import { vi } from "vitest";
+
+describe("AuthProvider with anon flag on", () => {
+  beforeEach(async () => {
+    await supabase.auth.signOut();
+    vi.stubEnv("VITE_ANON_USERS_ENABLED", "true");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("calls signInAnonymously and transitions to authenticated, never unauthenticated", async () => {
+    const spy = vi.spyOn(supabase.auth, "signInAnonymously");
+    render(
+      <AuthProvider>
+        <ShowSession />
+      </AuthProvider>,
+    );
+    expect(screen.getByTestId("status").textContent).toBe("loading");
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    // Status should not transition to "unauthenticated" while we wait.
+    // We assert by observing it goes from "loading" directly to "authenticated"
+    // after the SIGNED_IN event resolves through the listener.
+    await waitFor(() => {
+      expect(screen.getByTestId("status").textContent).toBe("authenticated");
+    });
+  });
+});
+```
+
+You'll also need to add `afterEach` to the import list at the top: `import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";`
+
+- [ ] **Step 3: Run, confirm the new test fails**
+
+Run: `npm test -- --run src/auth/AuthProvider.test.tsx`
+Expected: existing test passes; new test fails because nothing currently calls `signInAnonymously()`.
+
+- [ ] **Step 4: Modify AuthProvider to call signInAnonymously on the flag-on no-session path**
+
+Replace the contents of `src/auth/AuthProvider.tsx`:
+
+```tsx
+import { type ReactNode, useEffect, useState } from "react";
+import { supabase } from "../api/supabase";
+import { isAnonUsersEnabled } from "../lib/anonEnabled";
+import { SessionContext, type SessionState } from "./useSession";
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<SessionState>({
+    status: "loading",
+    user: null,
+    session: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    const anonEnabled = isAnonUsersEnabled();
+    const { data: sub } = supabase.auth.onAuthStateChange((event, session) => {
+      if (cancelled) return;
+      if (session) {
+        setState({ status: "authenticated", user: session.user, session });
+        return;
+      }
+      if (event === "INITIAL_SESSION" && anonEnabled) {
+        // Stay "loading"; signInAnonymously will fire SIGNED_IN, which we'll
+        // pick up on the next listener invocation.
+        void supabase.auth.signInAnonymously();
+        return;
+      }
+      setState({ status: "unauthenticated", user: null, session: null });
+    });
+
+    return () => {
+      cancelled = true;
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+
+  return <SessionContext.Provider value={state}>{children}</SessionContext.Provider>;
+}
+```
+
+- [ ] **Step 5: Run the full AuthProvider test suite**
+
+Run: `npm test -- --run src/auth/AuthProvider.test.tsx`
+Expected: both tests pass (the original `unauthenticated` baseline still works because the flag is off in that test by default).
+
+- [ ] **Step 6: Run the full test suite for regressions**
+
+Run: `npm test -- --run`
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/auth/AuthProvider.tsx src/auth/AuthProvider.test.tsx src/test/msw.ts
+git commit -m "feat(auth): sign in anonymously on boot when flag is on"
+```
+
+---
+
+## Task 5: UserMenu — anon CTA pill
+
+**Files:**
+- Modify: `src/lib/ui/UserMenu.tsx`
+- Modify: `src/lib/ui/UserMenu.module.css`
+- Modify: `src/lib/ui/UserMenu.test.tsx`
+
+When `session.user.is_anonymous`, render an accent-pill link to `/login` instead of the avatar/menu.
+
+- [ ] **Step 1: Write a failing test for the anon CTA**
+
+Append to `src/lib/ui/UserMenu.test.tsx`:
+
+```tsx
+it('renders an accent pill linking to /login when the user is anonymous', () => {
+  wrap({
+    status: "authenticated",
+    user: { id: "anon-1", email: null, is_anonymous: true } as never,
+    session: {} as never,
+  });
+  const link = screen.getByRole("link", { name: /sign in to save your work/i });
+  expect(link).toHaveAttribute("href", "/login");
+});
+
+it('does NOT render the avatar/menu when the user is anonymous', () => {
+  wrap({
+    status: "authenticated",
+    user: { id: "anon-1", email: null, is_anonymous: true } as never,
+    session: {} as never,
+  });
+  expect(screen.queryByRole("button", { name: /account menu/i })).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run, confirm failing**
+
+Run: `npm test -- --run src/lib/ui/UserMenu.test.tsx`
+Expected: new tests fail (the avatar still renders for anon users).
+
+- [ ] **Step 3: Add the `.pillCta` styles**
+
+Append to `src/lib/ui/UserMenu.module.css`:
+
+```css
+.pillCta {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-accent);
+  color: var(--color-accent-fg);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: var(--fs-sm);
+  transition:
+    background 0.12s,
+    box-shadow 0.12s,
+    transform 0.05s;
+}
+
+.pillCta:hover {
+  background: var(--color-accent-hover);
+  box-shadow: var(--shadow-accent);
+}
+
+.pillCta:active {
+  background: var(--color-accent-active);
+  transform: translateY(1px);
+}
+```
+
+- [ ] **Step 4: Branch UserMenu on `is_anonymous`**
+
+In `src/lib/ui/UserMenu.tsx`, replace the `if (session.status === "unauthenticated")` block area with the anon-aware version. Full updated file:
+
+```tsx
+import { Link } from "@tanstack/react-router";
+import { Menu, MenuItem, MenuTrigger, Popover, Button as RACButton } from "react-aria-components";
+import { supabase } from "../../api/supabase";
+import { useSession } from "../../auth/useSession";
+import styles from "./UserMenu.module.css";
+
+function initialFor(email: string | null | undefined): string {
+  const trimmed = (email ?? "").trim();
+  if (!trimmed) return "?";
+  return trimmed[0]?.toUpperCase() ?? "?";
+}
+
+export function UserMenu() {
+  const session = useSession();
+
+  if (session.status === "loading") return null;
+
+  if (session.status === "unauthenticated") {
+    return (
+      <Link to="/login" className={styles.signInLink}>
+        Sign in
+      </Link>
+    );
+  }
+
+  if (session.user.is_anonymous) {
+    return (
+      <Link to="/login" className={styles.pillCta}>
+        Sign in to save your work
+      </Link>
+    );
+  }
+
+  const email = session.user.email ?? "";
+
+  return (
+    <MenuTrigger>
+      <RACButton aria-label={`Account menu for ${email}`} className={styles.trigger}>
+        <span aria-hidden="true">{initialFor(email)}</span>
+      </RACButton>
+      <Popover className={styles.popover} placement="bottom end">
+        <div className={styles.email}>{email}</div>
+        <Menu className={styles.menu}>
+          <MenuItem
+            className={styles.menuItem}
+            onAction={() => {
+              void supabase.auth.signOut();
+            }}
+          >
+            Sign out
+          </MenuItem>
+        </Menu>
+      </Popover>
+    </MenuTrigger>
+  );
+}
+```
+
+- [ ] **Step 5: Run, confirm pass**
+
+Run: `npm test -- --run src/lib/ui/UserMenu.test.tsx`
+Expected: all UserMenu tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/ui/UserMenu.tsx src/lib/ui/UserMenu.module.css src/lib/ui/UserMenu.test.tsx
+git commit -m "feat(ui): UserMenu pill CTA for anonymous users"
+```
+
+---
+
+## Task 6: FirstDeckDialog and HomeView trigger
+
+**Files:**
+- Create: `src/views/FirstDeckDialog.tsx`
+- Create: `src/views/FirstDeckDialog.module.css`
+- Create: `src/views/FirstDeckDialog.test.tsx`
+- Modify: `src/views/HomeView.tsx`
+- Modify: `src/views/HomeView.test.tsx`
+
+Modal explainer shown once per browser when an anon user creates their first deck. Gated via `localStorage.dndCards.firstDeckExplainerSeen`.
+
+- [ ] **Step 1: Look up the existing DialogShell API**
+
+Run: `grep -n "DialogShell\|DialogHeader" src/lib/ui/DialogShell.tsx src/lib/ui/DialogHeader.tsx 2>&1 | head -30`
+
+Note the exported props (you'll use them below). Most likely shape: `<DialogShell isOpen onOpenChange={...}><DialogHeader>...</DialogHeader>...</DialogShell>`. Verify before writing the component.
+
+- [ ] **Step 2: Write a failing test for the dialog**
+
+```tsx
+// src/views/FirstDeckDialog.test.tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { FirstDeckDialog } from "./FirstDeckDialog";
+
+describe("<FirstDeckDialog>", () => {
+  it("renders the heading and copy when open", () => {
+    render(<FirstDeckDialog isOpen onOpenChange={() => {}} />);
+    expect(screen.getByRole("heading", { name: /your decks live on this browser/i })).toBeInTheDocument();
+    expect(screen.getByText(/30 days/i)).toBeInTheDocument();
+  });
+
+  it("renders nothing when closed", () => {
+    const { container } = render(<FirstDeckDialog isOpen={false} onOpenChange={() => {}} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('calls onOpenChange(false) when "Not yet" is clicked', async () => {
+    const onOpenChange = vi.fn();
+    render(<FirstDeckDialog isOpen onOpenChange={onOpenChange} />);
+    await userEvent.click(screen.getByRole("button", { name: /not yet/i }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('"Sign in now" is a link to /login', () => {
+    render(<FirstDeckDialog isOpen onOpenChange={() => {}} />);
+    const link = screen.getByRole("link", { name: /sign in now/i });
+    expect(link).toHaveAttribute("href", "/login");
+  });
+});
+```
+
+- [ ] **Step 3: Run, confirm failing**
+
+Run: `npm test -- --run src/views/FirstDeckDialog.test.tsx`
+Expected: fails with "Cannot find module './FirstDeckDialog'".
+
+- [ ] **Step 4: Implement the dialog**
+
+```tsx
+// src/views/FirstDeckDialog.tsx
+import { Link } from "@tanstack/react-router";
+import { DialogHeader } from "../lib/ui/DialogHeader";
+import { DialogShell } from "../lib/ui/DialogShell";
+import { Button } from "../lib/ui/Button";
+import styles from "./FirstDeckDialog.module.css";
+
+type Props = {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function FirstDeckDialog({ isOpen, onOpenChange }: Props) {
+  if (!isOpen) return null;
+  return (
+    <DialogShell isOpen={isOpen} onOpenChange={onOpenChange}>
+      <DialogHeader>Your decks live on this browser</DialogHeader>
+      <div className={styles.body}>
+        <p>
+          You're not signed in, so your new deck only exists here on this device — not on your
+          phone, your other laptop, or anywhere else. Sign in any time to save your decks to your
+          account, where you can access them from any device.
+        </p>
+        <p>
+          Otherwise, your decks may be lost if you clear browsing data, switch browsers, or don't
+          visit for 30 days.
+        </p>
+      </div>
+      <div className={styles.actions}>
+        <Link to="/login" className={styles.primary}>
+          Sign in now
+        </Link>
+        <Button variant="secondary" onPress={() => onOpenChange(false)}>
+          Not yet
+        </Button>
+      </div>
+    </DialogShell>
+  );
+}
+```
+
+If `DialogShell`/`DialogHeader` props differ from what's used here, adjust. The principle: a controlled `isOpen`/`onOpenChange` modal with a heading, copy, primary "Sign in now" link to `/login`, and a secondary "Not yet" dismiss action.
+
+- [ ] **Step 5: Add CSS module**
+
+```css
+/* src/views/FirstDeckDialog.module.css */
+.body {
+  padding: var(--space-3) var(--space-4);
+  color: var(--color-text);
+}
+
+.body p {
+  margin: 0 0 var(--space-3) 0;
+}
+
+.body p:last-child {
+  margin-bottom: 0;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+}
+
+.primary {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-accent);
+  color: var(--color-accent-fg);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.primary:hover {
+  background: var(--color-accent-hover);
+}
+```
+
+- [ ] **Step 6: If button labels differ from the existing Button primitive, adapt — verify**
+
+Run: `cat src/lib/ui/Button.tsx | head -30` to see the props. Adjust the `<Button variant="secondary" onPress={...}>` call if needed.
+
+- [ ] **Step 7: Run the dialog tests**
+
+Run: `npm test -- --run src/views/FirstDeckDialog.test.tsx`
+Expected: 4/4 pass.
+
+- [ ] **Step 8: Write a failing test for HomeView's trigger**
+
+Append to `src/views/HomeView.test.tsx` (after the existing tests, inside the `describe("HomeView")` block):
+
+```tsx
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+// (existing imports already cover most needs)
+
+describe("HomeView with anon flag on", () => {
+  beforeEach(async () => {
+    await supabase.auth.signOut();
+    navigate.mockClear();
+    vi.stubEnv("VITE_ANON_USERS_ENABLED", "true");
+    window.localStorage.clear();
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("opens the FirstDeckDialog after an anonymous user creates their first deck", async () => {
+    // Simulate anon-signed-in by setting the session via signInAnonymously stub
+    // (signInTestUser would create a non-anon user, which is wrong here).
+    vi.spyOn(supabase.auth, "getUser").mockResolvedValue({
+      data: { user: { id: "anon-1", is_anonymous: true } as never },
+      error: null,
+    });
+    // Use the existing AuthProvider in `wrap`; with the flag on, it'll call
+    // signInAnonymously and reach authenticated.
+    const inserted = makeDeckRow.build({ name: "Untitled deck", owner_id: "anon-1" });
+    server.use(
+      http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([])),
+      http.post(`${SB}/rest/v1/decks`, () => HttpResponse.json([inserted], { status: 201 })),
+    );
+    render(wrap(<HomeView />));
+    await userEvent.click(await screen.findByRole("button", { name: /create your first deck/i }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: /your decks live on this browser/i }),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("does NOT open the FirstDeckDialog if it has been seen before", async () => {
+    window.localStorage.setItem("dndCards.firstDeckExplainerSeen", "1");
+    vi.spyOn(supabase.auth, "getUser").mockResolvedValue({
+      data: { user: { id: "anon-1", is_anonymous: true } as never },
+      error: null,
+    });
+    const inserted = makeDeckRow.build({ name: "Untitled deck", owner_id: "anon-1" });
+    server.use(
+      http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([])),
+      http.post(`${SB}/rest/v1/decks`, () => HttpResponse.json([inserted], { status: 201 })),
+    );
+    render(wrap(<HomeView />));
+    await userEvent.click(await screen.findByRole("button", { name: /create your first deck/i }));
+    // navigate is the mocked router; assert it was called instead of waiting on a dialog that won't render.
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith({ to: "/deck/$deckId", params: { deckId: inserted.id } }),
+    );
+    expect(screen.queryByRole("heading", { name: /your decks live on this browser/i })).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 9: Run, confirm failing**
+
+Run: `npm test -- --run src/views/HomeView.test.tsx`
+Expected: existing tests pass; new tests fail (the dialog never shows).
+
+- [ ] **Step 10: Wire the dialog into HomeView**
+
+In `src/views/HomeView.tsx`, add the dialog render and a small `useState` + a `localStorage` check inside `handleCreate` and `handleImport`. Updated handlers and JSX:
+
+```tsx
+// Add to imports
+import { useEffect, useState } from "react";  // useState is the new addition; useEffect already imported in earlier task
+import { FirstDeckDialog } from "./FirstDeckDialog";
+
+// inside HomeView():
+const [showFirstDeckDialog, setShowFirstDeckDialog] = useState(false);
+
+const maybeShowFirstDeckExplainer = () => {
+  if (!session.user.is_anonymous) return false;
+  if (window.localStorage.getItem("dndCards.firstDeckExplainerSeen")) return false;
+  window.localStorage.setItem("dndCards.firstDeckExplainerSeen", "1");
+  setShowFirstDeckDialog(true);
+  return true;
+};
+
+// In handleCreate, after `const deck = await createDeck.mutateAsync(...)`:
+if (maybeShowFirstDeckExplainer()) {
+  // Don't navigate; the dialog primary action goes to /login or the user
+  // dismisses and stays on home with the new deck visible.
+  return;
+}
+navigate({ to: "/deck/$deckId", params: { deckId: deck.id } });
+
+// Same pattern in handleImport before the final navigate({ to: "/deck/$deckId" ...
+```
+
+In the JSX returned by HomeView, render the dialog at the end:
+
+```tsx
+<FirstDeckDialog
+  isOpen={showFirstDeckDialog}
+  onOpenChange={setShowFirstDeckDialog}
+/>
+```
+
+You'll need to refactor the early returns slightly — the simplest is to render the dialog as a sibling of the main `<section>` so it's available regardless of which branch returns. Concretely, restructure HomeView to:
+
+```tsx
+return (
+  <>
+    {decks.isLoading ? <LoadingState /> : (!decks.data || decks.data.length === 0) ? (
+      <>
+        <EmptyHero ... />
+        <input ... />
+      </>
+    ) : (
+      <section>
+        <header className={styles.header}>...</header>
+        <ul className={styles.list}>...</ul>
+      </section>
+    )}
+    <FirstDeckDialog isOpen={showFirstDeckDialog} onOpenChange={setShowFirstDeckDialog} />
+  </>
+);
+```
+
+Read the current HomeView before making the edit so the restructuring preserves all the existing branches and the file input.
+
+- [ ] **Step 11: Run, confirm pass**
+
+Run: `npm test -- --run src/views/HomeView.test.tsx`
+Expected: all HomeView tests pass.
+
+- [ ] **Step 12: Run the full suite**
+
+Run: `npm test -- --run`
+Expected: all green.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add src/views/FirstDeckDialog.tsx src/views/FirstDeckDialog.module.css src/views/FirstDeckDialog.test.tsx src/views/HomeView.tsx src/views/HomeView.test.tsx
+git commit -m "feat(home): show FirstDeckDialog after first anonymous deck create"
+```
+
+---
+
+## Task 7: LoginView — anon-aware OAuth click handlers
+
+**Files:**
+- Modify: `src/auth/LoginView.tsx`
+- Modify: `src/auth/LoginView.test.tsx`
+
+OAuth click branches on the anon user's deck count:
+- 0 decks (or unauthenticated) → `signInWithOAuth`
+- ≥1 decks → `linkIdentity`
+
+Dev sign-in path uses two-step `updateUser` when the user is anon.
+
+- [ ] **Step 1: Add MSW handler for `linkIdentity`**
+
+In `src/test/msw.ts`, add to the `supabaseDefaultHandlers`:
+
+```ts
+http.post(`${SB_URL}/auth/v1/user/identities/authorize`, () =>
+  HttpResponse.json({ url: "https://example.com/oauth", provider: "google" }),
+),
+```
+
+(The exact URL depends on supabase-js's wire format — verify by inspecting the actual request in a manual test if the path differs. Most projects route linkIdentity through `/auth/v1/user/identities/authorize`. If the path differs, adjust.)
+
+- [ ] **Step 2: Write a failing test for the anon-with-decks branch (linkIdentity)**
+
+Append to `src/auth/LoginView.test.tsx`:
+
+```tsx
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { supabase } from "../api/supabase";
+import { SessionContext, type SessionState } from "./useSession";
+import { LoginView } from "./LoginView";
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual =
+    await vi.importActual<typeof import("@tanstack/react-router")>("@tanstack/react-router");
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+  };
+});
+
+function wrap(ui: ReactNode, session: SessionState) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={client}>
+      <SessionContext.Provider value={session}>{ui}</SessionContext.Provider>
+    </QueryClientProvider>
+  );
+}
+
+describe("LoginView OAuth branching", () => {
+  beforeEach(() => {
+    vi.stubEnv("VITE_ANON_USERS_ENABLED", "true");
+    vi.stubEnv("VITE_AUTH_GOOGLE_ENABLED", "true");
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("calls linkIdentity when user is anonymous and has decks", async () => {
+    const linkSpy = vi.spyOn(supabase.auth, "linkIdentity").mockResolvedValue({ data: { provider: "google", url: "https://example.com" }, error: null } as never);
+    const oauthSpy = vi.spyOn(supabase.auth, "signInWithOAuth").mockResolvedValue({ data: { provider: "google", url: "https://example.com" }, error: null } as never);
+    // Stub useDecks-equivalent: pre-populate the query cache with a deck.
+    // Easiest: have the click handler use queryClient.fetchQuery — we mock its return below.
+
+    render(
+      wrap(
+        <LoginView />,
+        {
+          status: "authenticated",
+          user: { id: "anon-1", is_anonymous: true } as never,
+          session: {} as never,
+        },
+      ),
+    );
+    // We need to simulate the deck-count fetch returning >=1.
+    // Easiest: prefill the cache. Wrap re-render with a custom query setup
+    // (see next step's implementation for the cache key).
+    // For now, accept that this test will require the implementation to
+    // expose a clear seam; we'll use a server.use for /rest/v1/decks.
+    server.use(
+      http.get(`${SB_URL}/rest/v1/decks`, () =>
+        HttpResponse.json([{ id: "d1", owner_id: "anon-1", name: "Goblins" }]),
+      ),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /sign in with google/i }));
+    expect(linkSpy).toHaveBeenCalledWith(expect.objectContaining({ provider: "google" }));
+    expect(oauthSpy).not.toHaveBeenCalled();
+  });
+
+  it("calls signInWithOAuth when user is anonymous with zero decks", async () => {
+    const linkSpy = vi.spyOn(supabase.auth, "linkIdentity").mockResolvedValue({ data: {}, error: null } as never);
+    const oauthSpy = vi.spyOn(supabase.auth, "signInWithOAuth").mockResolvedValue({ data: { provider: "google", url: "https://example.com" }, error: null } as never);
+    server.use(http.get(`${SB_URL}/rest/v1/decks`, () => HttpResponse.json([])));
+    render(
+      wrap(<LoginView />, {
+        status: "authenticated",
+        user: { id: "anon-1", is_anonymous: true } as never,
+        session: {} as never,
+      }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /sign in with google/i }));
+    expect(oauthSpy).toHaveBeenCalledWith(expect.objectContaining({ provider: "google" }));
+    expect(linkSpy).not.toHaveBeenCalled();
+  });
+
+  it("calls signInWithOAuth when user is unauthenticated", async () => {
+    const linkSpy = vi.spyOn(supabase.auth, "linkIdentity").mockResolvedValue({ data: {}, error: null } as never);
+    const oauthSpy = vi.spyOn(supabase.auth, "signInWithOAuth").mockResolvedValue({ data: { provider: "google", url: "https://example.com" }, error: null } as never);
+    render(wrap(<LoginView />, { status: "unauthenticated", user: null, session: null }));
+    await userEvent.click(screen.getByRole("button", { name: /sign in with google/i }));
+    expect(oauthSpy).toHaveBeenCalled();
+    expect(linkSpy).not.toHaveBeenCalled();
+  });
+});
+```
+
+You'll need to import `SB_URL`, `server`, `http`, `HttpResponse` at the top:
+
+```tsx
+import { HttpResponse, http } from "msw";
+import { SB_URL } from "../test/msw";
+import { server } from "../test/msw";
+```
+
+(`SB_URL` is already exported from `src/test/msw.ts` per current code.)
+
+- [ ] **Step 3: Run, confirm failing**
+
+Run: `npm test -- --run src/auth/LoginView.test.tsx`
+Expected: new tests fail; existing dev sign-in tests still pass.
+
+- [ ] **Step 4: Implement anon-aware OAuth handlers**
+
+Update `src/auth/LoginView.tsx`:
+
+```tsx
+import { useQueryClient } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { supabase } from "../api/supabase";
+import { useSession } from "./useSession";
+import { OAuthButton } from "../lib/ui/OAuthButton";
+import { decksKey } from "../decks/queries";
+import styles from "./LoginView.module.css";
+
+const DEV_EMAIL = "dev@local";
+const DEV_PASSWORD = "devpass";
+
+export function LoginView() {
+  const navigate = useNavigate();
+  const session = useSession();
+  const queryClient = useQueryClient();
+
+  const isAnon = session.status === "authenticated" && session.user.is_anonymous === true;
+  const userId = session.status === "authenticated" ? session.user.id : null;
+
+  const signIn = async (provider: "google" | "github") => {
+    const next = new URLSearchParams(window.location.search).get("next") ?? "/";
+    const redirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`;
+
+    if (isAnon && userId) {
+      const decks = await queryClient.fetchQuery({
+        queryKey: decksKey(userId),
+        queryFn: async () => {
+          const result = await supabase.from("decks").select("id").eq("owner_id", userId);
+          return result.data ?? [];
+        },
+        staleTime: 0,
+      });
+      const hasDecks = (decks?.length ?? 0) > 0;
+      if (hasDecks) {
+        // Stash the provider so AuthCallback can use it for the second OAuth
+        // round-trip after the user picks an action in the import dialog.
+        window.localStorage.setItem("dndCards.lastProvider", provider);
+        await supabase.auth.linkIdentity({ provider, options: { redirectTo } });
+        return;
+      }
+    }
+    await supabase.auth.signInWithOAuth({ provider, options: { redirectTo } });
+  };
+
+  const devSignIn = async () => {
+    const next = new URLSearchParams(window.location.search).get("next") ?? "/";
+    if (isAnon) {
+      const { error: emailError } = await supabase.auth.updateUser({ email: DEV_EMAIL });
+      if (emailError) {
+        await supabase.auth.signOut();
+        await supabase.auth.signInWithPassword({ email: DEV_EMAIL, password: DEV_PASSWORD });
+        navigate({ to: next });
+        return;
+      }
+      const { error: pwError } = await supabase.auth.updateUser({ password: DEV_PASSWORD });
+      if (pwError) {
+        await supabase.auth.signOut();
+        await supabase.auth.signInWithPassword({ email: DEV_EMAIL, password: DEV_PASSWORD });
+        navigate({ to: next });
+        return;
+      }
+      navigate({ to: next });
+      return;
+    }
+    const { error } = await supabase.auth.signInWithPassword({ email: DEV_EMAIL, password: DEV_PASSWORD });
+    if (error?.message === "Invalid login credentials") {
+      await supabase.auth.signUp({ email: DEV_EMAIL, password: DEV_PASSWORD });
+    }
+    navigate({ to: next });
+  };
+
+  const heading = isAnon ? "Save your work to your account" : "Sign in";
+  const copy = isAnon
+    ? "Sign in to save your decks to your account, where you can access them from any device."
+    : "Sign in to create and edit decks. Anyone can view shared decks via link.";
+
+  return (
+    <section className={styles.login} aria-labelledby="signin-heading">
+      <h1 id="signin-heading">{heading}</h1>
+      <p className={styles.copy}>{copy}</p>
+      {/* biome-ignore lint/a11y/noRedundantRoles: list-style:none strips the implicit role in WebKit */}
+      <ul className={styles.providers} role="list">
+        {import.meta.env.VITE_AUTH_GOOGLE_ENABLED === "true" && (
+          <li>
+            <OAuthButton provider="google" onPress={() => void signIn("google")} />
+          </li>
+        )}
+        {import.meta.env.VITE_AUTH_GITHUB_ENABLED === "true" && (
+          <li>
+            <OAuthButton provider="github" onPress={() => void signIn("github")} />
+          </li>
+        )}
+        {import.meta.env.DEV && (
+          <li>
+            <OAuthButton provider="dev" onPress={() => void devSignIn()} />
+          </li>
+        )}
+      </ul>
+    </section>
+  );
+}
+```
+
+If `decksQueryKey` doesn't exist in `src/decks/queries.ts`, define a small inline replacement: `["decks", userId] as const`. The principle is to use whatever cache key `useDecks(userId)` already uses, so the click-time fetch shares the cache.
+
+- [ ] **Step 5: Run, confirm pass**
+
+Run: `npm test -- --run src/auth/LoginView.test.tsx`
+Expected: all LoginView tests pass.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `npm test -- --run`
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/auth/LoginView.tsx src/auth/LoginView.test.tsx src/test/msw.ts
+git commit -m "feat(auth): anon-aware OAuth in LoginView; two-step dev updateUser"
+```
+
+---
+
+## Task 8: ImportAccountDialog component
+
+**Files:**
+- Create: `src/auth/ImportAccountDialog.tsx`
+- Create: `src/auth/ImportAccountDialog.module.css`
+- Create: `src/auth/ImportAccountDialog.test.tsx`
+
+The "you already have a dnd-cards account" dialog. Two outcomes: import (user accepts) or skip (user declines).
+
+- [ ] **Step 1: Write a failing test**
+
+```tsx
+// src/auth/ImportAccountDialog.test.tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ImportAccountDialog } from "./ImportAccountDialog";
+
+describe("<ImportAccountDialog>", () => {
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <ImportAccountDialog isOpen={false} deckCount={3} onImport={() => {}} onSkip={() => {}} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders heading, deck count, and unrecoverable warning", () => {
+    render(
+      <ImportAccountDialog isOpen deckCount={3} onImport={() => {}} onSkip={() => {}} />,
+    );
+    expect(screen.getByRole("heading", { name: /you already have a dnd-cards account/i })).toBeInTheDocument();
+    expect(screen.getByText(/3 decks/i)).toBeInTheDocument();
+    expect(screen.getByText(/cannot be recovered/i)).toBeInTheDocument();
+  });
+
+  it("calls onImport when the primary action is clicked", async () => {
+    const onImport = vi.fn();
+    render(<ImportAccountDialog isOpen deckCount={2} onImport={onImport} onSkip={() => {}} />);
+    await userEvent.click(screen.getByRole("button", { name: /yes, import 2 decks/i }));
+    expect(onImport).toHaveBeenCalled();
+  });
+
+  it("calls onSkip when the skip text link is clicked", async () => {
+    const onSkip = vi.fn();
+    render(<ImportAccountDialog isOpen deckCount={2} onImport={() => {}} onSkip={onSkip} />);
+    await userEvent.click(screen.getByRole("button", { name: /skip — leave decks behind/i }));
+    expect(onSkip).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failing**
+
+Run: `npm test -- --run src/auth/ImportAccountDialog.test.tsx`
+Expected: fails with "Cannot find module './ImportAccountDialog'".
+
+- [ ] **Step 3: Implement the dialog**
+
+```tsx
+// src/auth/ImportAccountDialog.tsx
+import { Button } from "../lib/ui/Button";
+import { DialogHeader } from "../lib/ui/DialogHeader";
+import { DialogShell } from "../lib/ui/DialogShell";
+import styles from "./ImportAccountDialog.module.css";
+
+type Props = {
+  isOpen: boolean;
+  deckCount: number;
+  onImport: () => void;
+  onSkip: () => void;
+};
+
+export function ImportAccountDialog({ isOpen, deckCount, onImport, onSkip }: Props) {
+  if (!isOpen) return null;
+  return (
+    <DialogShell isOpen={isOpen} onOpenChange={() => {}}>
+      <DialogHeader>You already have a dnd-cards account</DialogHeader>
+      <div className={styles.body}>
+        <p>
+          An account on dnd-cards is already linked to that identity. Want to bring your{" "}
+          {deckCount} decks into that account?
+        </p>
+        <p className={styles.warning}>
+          If you skip, those decks will be left behind. They cannot be recovered.
+        </p>
+      </div>
+      <div className={styles.actions}>
+        <Button variant="primary" onPress={onImport}>
+          Yes, import {deckCount} decks
+        </Button>
+        <button type="button" className={styles.skip} onClick={onSkip}>
+          Skip — leave decks behind
+        </button>
+      </div>
+    </DialogShell>
+  );
+}
+```
+
+- [ ] **Step 4: Add CSS module**
+
+```css
+/* src/auth/ImportAccountDialog.module.css */
+.body {
+  padding: var(--space-3) var(--space-4);
+}
+
+.body p {
+  margin: 0 0 var(--space-3) 0;
+}
+
+.warning {
+  color: var(--color-warning, var(--color-text-muted));
+  font-size: var(--fs-sm);
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+}
+
+.skip {
+  background: transparent;
+  border: 0;
+  color: var(--color-text-muted);
+  font-size: var(--fs-sm);
+  cursor: pointer;
+  padding: var(--space-2) var(--space-3);
+  text-decoration: underline;
+}
+
+.skip:hover {
+  color: var(--color-text);
+}
+```
+
+- [ ] **Step 5: Run, confirm pass**
+
+Run: `npm test -- --run src/auth/ImportAccountDialog.test.tsx`
+Expected: 4/4 pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/auth/ImportAccountDialog.tsx src/auth/ImportAccountDialog.module.css src/auth/ImportAccountDialog.test.tsx
+git commit -m "feat(auth): add ImportAccountDialog for the linkIdentity-conflict path"
+```
+
+---
+
+## Task 9: AuthCallback — URL parsing, dialog wiring, and tryResume
+
+**Files:**
+- Modify: `src/auth/AuthCallback.tsx`
+- Modify: `src/auth/AuthCallback.test.tsx`
+
+AuthCallback now does three things:
+1. Parse the URL hash/query for `error_code=identity_already_exists` → open `ImportAccountDialog`.
+2. If `localStorage.dndCards.pendingAnonImport` exists and the user is non-anon → run `tryResume` with progress UI.
+3. On clean success (no pending import, no error) → set Announcement "Signed in" and navigate.
+
+- [ ] **Step 1: Write a failing test for the link-failure → dialog branch**
+
+Replace `src/auth/AuthCallback.test.tsx` (existing tests preserved, plus new ones):
+
+```tsx
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AnnouncementProvider } from "../lib/ui/Announcement";
+import { supabase } from "../api/supabase";
+import { SessionContext, type SessionState } from "./useSession";
+import { AuthCallback } from "./AuthCallback";
+
+const navigate = vi.fn();
+vi.mock("@tanstack/react-router", async () => {
+  const actual =
+    await vi.importActual<typeof import("@tanstack/react-router")>("@tanstack/react-router");
+  return { ...actual, useNavigate: () => navigate };
+});
+
+function wrap(ui: ReactNode, session: SessionState) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={client}>
+      <AnnouncementProvider>
+        <SessionContext.Provider value={session}>{ui}</SessionContext.Provider>
+      </AnnouncementProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe("AuthCallback", () => {
+  beforeEach(() => {
+    navigate.mockClear();
+    window.localStorage.clear();
+  });
+
+  it("opens ImportAccountDialog when URL has error_code=identity_already_exists and user is anon with decks", async () => {
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: {
+        ...window.location,
+        hash: "#error=invalid_request&error_code=identity_already_exists&error_description=Identity+is+already+linked+to+another+user",
+        search: "",
+      },
+    });
+    const fromSpy = vi.spyOn(supabase, "from").mockReturnValue({
+      select: () => ({ eq: () => Promise.resolve({ data: [{ id: "d1" }, { id: "d2" }], error: null }) }),
+    } as never);
+    render(
+      wrap(<AuthCallback />, {
+        status: "authenticated",
+        user: { id: "anon-1", is_anonymous: true } as never,
+        session: {} as never,
+      }),
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: /you already have a dnd-cards account/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/2 decks/i)).toBeInTheDocument();
+    fromSpy.mockRestore();
+  });
+
+  it("on import click: stashes pendingAnonImport, signs out, and signInWithOAuth", async () => {
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: {
+        ...window.location,
+        origin: "http://localhost:5173",
+        hash: "#error_code=identity_already_exists",
+        search: "?next=/",
+      },
+    });
+    vi.spyOn(supabase, "from").mockReturnValue({
+      select: () => ({ eq: () => Promise.resolve({ data: [{ id: "d1" }], error: null }) }),
+    } as never);
+    const signOutSpy = vi.spyOn(supabase.auth, "signOut").mockResolvedValue({ error: null } as never);
+    const oauthSpy = vi.spyOn(supabase.auth, "signInWithOAuth").mockResolvedValue({ data: {}, error: null } as never);
+
+    render(
+      wrap(<AuthCallback />, {
+        status: "authenticated",
+        user: { id: "anon-1", is_anonymous: true } as never,
+        session: {} as never,
+      }),
+    );
+    await userEvent.click(await screen.findByRole("button", { name: /yes, import 1 decks/i }));
+    const stash = window.localStorage.getItem("dndCards.pendingAnonImport");
+    expect(stash).not.toBeNull();
+    expect(JSON.parse(stash as string)).toMatchObject({ anonUuid: "anon-1", importedDeckIds: [] });
+    expect(signOutSpy).toHaveBeenCalled();
+    expect(oauthSpy).toHaveBeenCalled();
+  });
+
+  it("on skip click: signs out and signInWithOAuth, no stash", async () => {
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: {
+        ...window.location,
+        origin: "http://localhost:5173",
+        hash: "#error_code=identity_already_exists",
+        search: "",
+      },
+    });
+    vi.spyOn(supabase, "from").mockReturnValue({
+      select: () => ({ eq: () => Promise.resolve({ data: [{ id: "d1" }], error: null }) }),
+    } as never);
+    const signOutSpy = vi.spyOn(supabase.auth, "signOut").mockResolvedValue({ error: null } as never);
+    const oauthSpy = vi.spyOn(supabase.auth, "signInWithOAuth").mockResolvedValue({ data: {}, error: null } as never);
+
+    render(
+      wrap(<AuthCallback />, {
+        status: "authenticated",
+        user: { id: "anon-1", is_anonymous: true } as never,
+        session: {} as never,
+      }),
+    );
+    await userEvent.click(await screen.findByRole("button", { name: /skip — leave decks behind/i }));
+    expect(window.localStorage.getItem("dndCards.pendingAnonImport")).toBeNull();
+    expect(signOutSpy).toHaveBeenCalled();
+    expect(oauthSpy).toHaveBeenCalled();
+  });
+
+  it("on clean success (no error, no pendingImport, non-anon authenticated): navigates to next", async () => {
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { ...window.location, hash: "", search: "?next=/some/path" },
+    });
+    render(
+      wrap(<AuthCallback />, {
+        status: "authenticated",
+        user: { id: "real-1", is_anonymous: false, email: "x@y.z" } as never,
+        session: {} as never,
+      }),
+    );
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: "/some/path" }));
+  });
+
+  it("when pendingAnonImport exists and session is non-anon: shows progress, runs import, navigates", async () => {
+    window.localStorage.setItem(
+      "dndCards.pendingAnonImport",
+      JSON.stringify({ version: 1, anonUuid: "anon-1", importedDeckIds: [] }),
+    );
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { ...window.location, hash: "", search: "" },
+    });
+    vi.spyOn(supabase, "from").mockReturnValue({
+      select: () => ({
+        eq: (col: string) =>
+          col === "owner_id"
+            ? Promise.resolve({ data: [{ id: "d1", name: "Goblins" }], error: null })
+            : Promise.resolve({ data: [{ position: 0, payload: {} }], error: null }),
+      }),
+      insert: () => ({
+        select: () => ({ single: () => Promise.resolve({ data: { id: "new-deck" }, error: null }) }),
+      }),
+    } as never);
+    render(
+      wrap(<AuthCallback />, {
+        status: "authenticated",
+        user: { id: "real-1", is_anonymous: false, email: "x@y.z" } as never,
+        session: {} as never,
+      }),
+    );
+    await waitFor(() => expect(navigate).toHaveBeenCalled());
+    expect(window.localStorage.getItem("dndCards.pendingAnonImport")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm failing**
+
+Run: `npm test -- --run src/auth/AuthCallback.test.tsx`
+Expected: new tests fail; existing test (if any) still passes.
+
+- [ ] **Step 3: Implement AuthCallback's new behavior**
+
+Replace `src/auth/AuthCallback.tsx`:
+
+```tsx
+import { useNavigate } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { supabase } from "../api/supabase";
+import { useSetNextAnnouncement } from "../lib/ui/Announcement";
+import { ImportAccountDialog } from "./ImportAccountDialog";
+import { clear, readPending, stash, tryResume } from "./anonImport";
+import { useSession } from "./useSession";
+
+function parseLinkError(): string | null {
+  const hash = new URLSearchParams(window.location.hash.replace(/^#/, ""));
+  const search = new URLSearchParams(window.location.search);
+  return hash.get("error_code") ?? search.get("error_code");
+}
+
+function getNextPath(): string {
+  return new URLSearchParams(window.location.search).get("next") ?? "/";
+}
+
+export function AuthCallback() {
+  const navigate = useNavigate();
+  const session = useSession();
+  const setAnnouncement = useSetNextAnnouncement();
+
+  const [phase, setPhase] = useState<"checking" | "importing" | "dialog" | "error">("checking");
+  const [deckCount, setDeckCount] = useState(0);
+  const [progress, setProgress] = useState({ imported: 0, total: 0 });
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (session.status !== "authenticated") return;
+
+    const linkError = parseLinkError();
+    if (linkError === "identity_already_exists" && session.user.is_anonymous) {
+      // Anon user with conflicting OAuth identity. Fetch the anon's deck count
+      // and surface the dialog.
+      void (async () => {
+        const { data } = await supabase.from("decks").select("id").eq("owner_id", session.user.id);
+        setDeckCount(data?.length ?? 0);
+        setPhase("dialog");
+      })();
+      return;
+    }
+
+    if (linkError) {
+      // Generic OAuth failure. Show a recoverable message and stay on this page.
+      setErrorMessage("Sign-in didn't complete. Please try again.");
+      setPhase("error");
+      return;
+    }
+
+    // No error. If we have a pending import and the user is non-anon, run it.
+    const pending = readPending();
+    if (pending && !session.user.is_anonymous) {
+      setPhase("importing");
+      void (async () => {
+        try {
+          const result = await tryResume({
+            supabase,
+            currentUserId: session.user.id,
+            onProgress: (imported, total) => setProgress({ imported, total }),
+          });
+          if (result.kind === "completed" && result.importedCount > 0) {
+            setAnnouncement(`Imported ${result.importedCount} decks`);
+          } else if (result.kind === "partial") {
+            setAnnouncement(`Imported ${result.importedCount} of ${result.total} decks. We'll try again next time you sign in.`);
+          }
+          navigate({ to: getNextPath() });
+        } catch {
+          setAnnouncement("Couldn't finish importing your decks. We'll try again next time you sign in.");
+          navigate({ to: getNextPath() });
+        }
+      })();
+      return;
+    }
+
+    // Plain successful sign-in.
+    if (!session.user.is_anonymous) {
+      setAnnouncement("Signed in");
+      // Clear the provider stash so it doesn't linger across sessions.
+      window.localStorage.removeItem("dndCards.lastProvider");
+    }
+    navigate({ to: getNextPath() });
+  }, [session, navigate, setAnnouncement]);
+
+  const lastProvider = (): "google" | "github" => {
+    const v = window.localStorage.getItem("dndCards.lastProvider");
+    return v === "github" ? "github" : "google";
+  };
+
+  const onImport = async () => {
+    if (session.status !== "authenticated") return;
+    stash({ version: 1, anonUuid: session.user.id, importedDeckIds: [] });
+    const next = getNextPath();
+    const redirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`;
+    const provider = lastProvider();
+    await supabase.auth.signOut();
+    await supabase.auth.signInWithOAuth({ provider, options: { redirectTo } });
+  };
+
+  const onSkip = async () => {
+    clear();
+    const next = getNextPath();
+    const redirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`;
+    const provider = lastProvider();
+    await supabase.auth.signOut();
+    await supabase.auth.signInWithOAuth({ provider, options: { redirectTo } });
+  };
+
+  if (phase === "dialog") {
+    return <ImportAccountDialog isOpen deckCount={deckCount} onImport={onImport} onSkip={onSkip} />;
+  }
+
+  if (phase === "importing") {
+    return (
+      <section style={{ textAlign: "center", padding: "4rem" }} role="status" aria-live="polite">
+        <h2>Bringing your decks over</h2>
+        <p>
+          Imported {progress.imported} of {progress.total} decks…
+        </p>
+      </section>
+    );
+  }
+
+  if (phase === "error") {
+    return (
+      <section style={{ textAlign: "center", padding: "4rem" }}>
+        <p>{errorMessage}</p>
+      </section>
+    );
+  }
+
+  return (
+    <section style={{ textAlign: "center", padding: "4rem" }}>
+      <p>Signing you in…</p>
+    </section>
+  );
+}
+```
+
+The provider for the second OAuth round-trip is read from `localStorage.dndCards.lastProvider`, which `LoginView`'s click handler stashed before calling `linkIdentity` (see Task 7). Defaults to `"google"` if the key is missing. The key is cleared after a clean signed-in callback completes.
+
+- [ ] **Step 4: Run, confirm pass**
+
+Run: `npm test -- --run src/auth/AuthCallback.test.tsx`
+Expected: all tests pass.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `npm test -- --run`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/auth/AuthCallback.tsx src/auth/AuthCallback.test.tsx
+git commit -m "feat(auth): AuthCallback parses link failures, runs tryResume, and announces"
+```
+
+---
+
+## Task 10: Manual smoke and pre-flight check
+
+This task has no code; it walks through the manual rollout pre-flight from the spec.
+
+- [ ] **Step 1: Run the full test suite one more time**
+
+Run: `npm test -- --run`
+Expected: all green.
+
+- [ ] **Step 2: Run the build**
+
+Run: `npm run build`
+Expected: clean build, no type errors.
+
+- [ ] **Step 3: Local smoke with the flag on**
+
+In a shell:
+
+```bash
+echo "VITE_ANON_USERS_ENABLED=true" >> .env.local
+npm run dev
+```
+
+Open the app in a fresh browser profile (or incognito):
+
+- [ ] App loads, no flash of unauthenticated state, header shows "Sign in to save your work" pill.
+- [ ] Click "Create your first deck" → first-create dialog appears with "Your decks live on this browser" copy.
+- [ ] Dismiss the dialog with "Not yet" → deck is in your list.
+- [ ] Click the header pill → lands on `/login`, heading reads "Save your work to your account".
+- [ ] Sign in with Google → callback runs, you land on `/`, header now shows your avatar.
+- [ ] Sign out, then in another browser profile, repeat with the same Google identity → after the second OAuth round-trip you should see "Imported N decks" announcement (if the first profile had decks).
+
+- [ ] **Step 4: Pre-flight checks against Supabase project (when ready to deploy)**
+
+Per the spec's Rollout section:
+- Confirm Supabase Auth → URL Configuration restricts redirect URLs to the prod origin and `localhost:5173`. No wildcards.
+- Confirm Supabase Auth → Rate Limits has the default `anonymous_users` limit enabled (30/hr/IP).
+- Flip `enable_anonymous_sign_ins = true` in the Supabase dashboard for prod.
+- Set `VITE_ANON_USERS_ENABLED=true` in the prod build env (Vercel).
+
+These steps are out of band from the code; document them in the PR description.
+
+- [ ] **Step 5: Remove `.env.local` if you added it just for smoke**
+
+```bash
+git checkout -- .env.local 2>/dev/null || rm -f .env.local
+```
+
+- [ ] **Step 6: Open the PR**
+
+```bash
+git push -u origin worktree-anon-supabase-users
+gh pr create --title "Anonymous Supabase users" --body-file docs/superpowers/specs/2026-05-07-anon-supabase-users-design.md
+```
+
+(Or write a short PR description that links to the spec instead of pasting the full thing.)
+
+---
+
+## Self-review checklist (run after the plan is written; this is for the plan author, not the implementer)
+
+- [ ] **Spec coverage:** Goals 1–4 (anon users can use the app, OAuth conversion, import-into-existing-account, local-only honesty) are covered by Tasks 4–9. Cleanup goal was deliberately removed; no task is missing for it.
+- [ ] **Placeholder scan:** No "TBD"/"TODO"/"add error handling here". One genuinely-deferred decision is flagged in Task 9 step 3 (provider for the second OAuth round-trip; v1 hardcoded to `google`).
+- [ ] **Type consistency:** `PendingAnonImport` (Task 3) is the same shape used by AuthCallback's stash call (Task 9). `tryResume` signature `({supabase, currentUserId, onProgress})` is the same in both. `useSetNextAnnouncement()` returns `(message: string | null) => void` consistently.
+- [ ] **Test coverage:** AuthProvider flag-on, UserMenu anon-CTA, FirstDeckDialog one-time, LoginView anon-with-decks/no-decks/unauth/dev paths, AuthCallback link-failure-dialog/import/skip/clean-success/pending-import paths all have tests.
+
+If anything's missing, fix inline before handing off.

--- a/docs/superpowers/specs/2026-05-07-anon-supabase-users-design.md
+++ b/docs/superpowers/specs/2026-05-07-anon-supabase-users-design.md
@@ -93,11 +93,20 @@ When the flag is off, behavior is identical to today: no-session boot lands in `
 
 ## Sign-in flow
 
-### Happy path: linkIdentity succeeds
+### Branching logic
 
-User is anon with N decks. Clicks "Sign in to save permanently" in the header CTA. Lands on `/login`. Clicks Google (or GitHub). Because they're already anon, the LoginView calls `linkIdentity({ provider })` instead of `signInWithOAuth({ provider })`. OAuth round-trip; on the callback their session updates: same `user.id`, `is_anonymous` is now `false`. All `decks.owner_id` references stay valid. We toast "Signed in" and navigate to `next ?? "/"`.
+Before picking the API, the LoginView checks how many decks the anon user owns:
 
-### Already-linked branch: linkIdentity fails
+- **0 decks** → call `signInWithOAuth({ provider })` directly. The anon row is abandoned (and reaped by cron); no link, no dialog. This handles the common returning-user-on-new-device case (where a fresh anon row exists from boot but the user hasn't done anything yet) and the brand-new-user-signing-in-immediately case.
+- **≥1 decks** → call `linkIdentity({ provider })`. On the callback we know whether linking succeeded; failure routes to the dialog described below.
+
+The deck count comes from the existing `useDecks(anonUserId)` query. Reading it from the cache or refetching at click time are both fine; for safety we'll refetch (cheap; the user is about to do an OAuth round-trip anyway).
+
+### Happy path: linkIdentity succeeds (anon has decks, first time signing in with this provider)
+
+User is anon with N decks. Clicks "Sign in to save permanently" in the header CTA. Lands on `/login`. Clicks Google (or GitHub). Because they're anon and have decks, LoginView calls `linkIdentity({ provider })`. OAuth round-trip; on the callback their session updates: same `user.id`, `is_anonymous` is now `false`. All `decks.owner_id` references stay valid. We toast "Signed in" and navigate to `next ?? "/"`.
+
+### Already-linked branch: linkIdentity fails (anon has decks, existing account on this provider)
 
 If the user's OAuth identity is already attached to a different account, `linkIdentity` returns an error on the callback. We don't pin to a specific error code — any failure routes to the same dialog. The user is still anon (linking failed; session is unchanged).
 
@@ -110,7 +119,15 @@ Dialog copy (uses existing `DialogShell` / `DialogHeader`):
 - **Import branch:** Persist `{ anonUuid, importedDeckIds: [] }` under `localStorage.dndCards.pendingAnonImport`, then `signOut()` and `signInWithOAuth({ provider })`. After OAuth lands the user as the existing real user, `anonImport.tryResume()` runs (see invocation rules below): SELECT decks where `owner_id = anonUuid` (public read), then SELECT their cards. For each deck not already in `importedDeckIds`: INSERT a new deck owned by the current user with the same name; INSERT clones of its cards under the new deck id; append the original deck id to `importedDeckIds` and persist back to localStorage. When the list is complete, clear the key. Toast "Imported N decks."
 - **Sign in without importing branch:** `signOut()` and `signInWithOAuth({ provider })`. localStorage is not touched. The anon's decks are abandoned.
 
-In both branches the user goes through OAuth twice (once for the failed link, once for the actual sign-in). That's unavoidable: linkIdentity needs a real OAuth round-trip to discover the conflict, and we can't reuse the failed attempt as a sign-in.
+In both branches of this dialog the user goes through OAuth twice (once for the failed link, once for the actual sign-in). That's unavoidable: linkIdentity needs a real OAuth round-trip to discover the conflict, and we can't reuse the failed attempt as a sign-in. The deck-count branch above keeps this 2-round-trip path confined to the case where there's actually data to merge — which is precisely when the user wants the dialog anyway.
+
+### Cost summary
+
+| Scenario | Round-trips | Dialog? |
+|---|---|---|
+| Anon with 0 decks signs in (first time or returning) | 1 | No |
+| Anon with decks, first time signing in with this provider | 1 | No |
+| Anon with decks, existing account already on this provider | 2 | Yes |
 
 ### `tryResume()` invocation rules
 
@@ -219,7 +236,7 @@ No changes. Existing policies (`decks_select_all`, `cards_select_all`, `_insert_
 | `src/lib/ui/UserMenu.tsx` | Branch on `is_anonymous` for the CTA pill |
 | `src/lib/ui/UserMenu.module.css` | Pill button styling (or reuse `Button` accent variant) |
 | `src/lib/ui/UserMenu.test.tsx` | New cases for anon CTA |
-| `src/auth/LoginView.tsx` | OAuth buttons use `linkIdentity` when anon; dev path uses `updateUser` |
+| `src/auth/LoginView.tsx` | OAuth buttons branch on anon deck count: 0 → `signInWithOAuth`; ≥1 → `linkIdentity`. Dev path uses `updateUser` |
 | `src/auth/LoginView.test.tsx` | New cases for the link path |
 | `src/auth/AuthCallback.tsx` | Detect `linkIdentity` failure; open import dialog |
 | `src/auth/AuthCallback.test.tsx` | New cases for the failure path and dialog |
@@ -239,7 +256,7 @@ No changes. Existing policies (`decks_select_all`, `cards_select_all`, `_insert_
 - Coverage:
   - `AuthProvider`: with flag on, no session → calls `signInAnonymously`; status never `unauthenticated`.
   - `UserMenu`: anon → CTA pill; authenticated → avatar/menu; unauthenticated → existing "Sign in" link.
-  - `LoginView`: OAuth click as anon → `linkIdentity`; as unauthenticated → `signInWithOAuth`. Dev click as anon → `updateUser`.
+  - `LoginView`: OAuth click as anon with decks → `linkIdentity`; as anon with no decks → `signInWithOAuth`; as unauthenticated → `signInWithOAuth`. Dev click as anon → `updateUser`.
   - `AuthCallback`: linkIdentity failure → opens import dialog.
   - `anonImport`: happy clone, resumable clone (pre-existing partial state), cleared key on full success.
   - `FirstDeckDialog`: opens on first create; suppressed when flag set.

--- a/docs/superpowers/specs/2026-05-07-anon-supabase-users-design.md
+++ b/docs/superpowers/specs/2026-05-07-anon-supabase-users-design.md
@@ -1,0 +1,270 @@
+# Anonymous Supabase Users — Design Spec
+
+**Date:** 2026-05-07
+**Status:** approved (pending implementation plan)
+
+## Summary
+
+Let visitors use the full app — create, edit, and print decks — without signing in. Persist their work in the same Supabase database under a real `auth.users` row created via Supabase's anonymous sign-in. When they later sign in with OAuth, `linkIdentity` upgrades the same row in place; their decks are preserved without any data movement. If their OAuth identity is already linked to a different existing account, offer to clone their anon decks into it. Stale anon users are auto-reaped after 30 days.
+
+The whole feature is gated behind a `VITE_ANON_USERS_ENABLED` env var so it can be merged dark and rolled out independently.
+
+## Goals
+
+- Anon users can create, edit, import, export, and print decks just like signed-in users.
+- Sign-in via OAuth converts the anon account into a permanent one in place — same UUID, same `decks.owner_id`, no data movement.
+- If the OAuth identity is already on a different account, offer to clone anon decks into it (resumable, survives interruptions).
+- Make the local-only nature of anon work obvious so users don't lose work to a Safari ITP eviction by surprise.
+- Auto-cleanup of unused anon `auth.users` rows after 30 days via `pg_cron`.
+- Fully gated behind `VITE_ANON_USERS_ENABLED`; existing flows unchanged when off.
+
+## Non-goals (v1)
+
+- Multi-device sync of anon work. (Anon decks live on the originating browser only until the user signs in.)
+- Atomic transfer of decks between accounts. The "clone into existing account" flow uses public-read SELECTs + INSERTs and is resumable but not transactional.
+- Server-side Postgres functions to facilitate transfer (`SECURITY DEFINER`). Not needed because cloning is purely client-side.
+- Differentiating anon from real users in RLS (e.g., capping anon to N decks). Existing policies already gate on `owner_id = auth.uid()`; anon users inherit the same constraints naturally.
+- Toast/notification primitive. The first-time explainer uses an existing modal dialog.
+
+## Hard constraints (carried forward)
+
+1. **Existing RLS posture.** `decks_select_all` and `cards_select_all` are public reads (`using (true)`); writes gate on `owner_id = auth.uid()`. The clone flow depends on these policies; we do not change them.
+2. **Existing FK cascade.** `decks.owner_id references auth.users(id) on delete cascade` and `cards.deck_id references decks(id) on delete cascade`. Reaping an anon user cascades correctly without additional FK work.
+3. **Test conventions.** Fishery + faker; no unnecessary factory overrides; `signInTestUser` continues to drive existing tests.
+4. **No emotion/styled-components/Tailwind.** New UI uses CSS modules + react-aria-components like the rest of the codebase.
+
+## Architecture overview
+
+```
+Browser (Vite SPA)                               Supabase
+──────────────────────────────────             ────────────────────────────
+AuthProvider                                   auth.users
+  ├ onAuthStateChange listener                   ├ regular users (is_anonymous = false)
+  └ INITIAL_SESSION + no session + flag on  →   └ anon users   (is_anonymous = true)
+       supabase.auth.signInAnonymously()       Postgres
+       (status stays "loading")                  ├ decks   (RLS unchanged)
+                                                 └ cards   (RLS unchanged)
+UserMenu                                       pg_cron schedule
+  ├ anonymous → "Sign in to save permanently"    └ weekly: delete anon users
+  ├ authenticated → avatar + sign-out                inactive > 30 days
+  └ unauthenticated (flag off) → "Sign in" link
+LoginView
+  ├ anon? → linkIdentity(provider)
+  └ unauthenticated? → signInWithOAuth(provider)
+AuthCallback
+  ├ link succeeded → toast, redirect to next
+  └ link failed (identity already on another account) → import dialog
+anonImport.ts
+  ├ stash {anonUuid, importedDeckIds:[]} in localStorage
+  ├ on next sign-in: SELECT anon decks/cards (public reads), INSERT clones
+  └ resumable: append to importedDeckIds per success, clear when done
+FirstDeckDialog
+  └ shown once per browser via localStorage flag
+```
+
+Boundaries:
+
+- `api/supabase.ts` remains the only module that imports `@supabase/supabase-js`.
+- `auth/AuthProvider.tsx` is the only place that calls `signInAnonymously()`.
+- `auth/anonImport.ts` is the only place that mutates `localStorage.pendingAnonImport`.
+
+## Boot path: anonymous sign-in on app load
+
+When `VITE_ANON_USERS_ENABLED === "true"` and there is no existing session, `AuthProvider` calls `signInAnonymously()` and holds the session state in `loading` until the next auth event resolves. It never transitions through `unauthenticated`.
+
+Sketch (modify the existing `onAuthStateChange` callback):
+
+```ts
+onAuthStateChange((event, session) => {
+  if (cancelled) return;
+  if (session) {
+    setState({ status: "authenticated", user: session.user, session });
+    return;
+  }
+  if (event === "INITIAL_SESSION" && ANON_ENABLED) {
+    void supabase.auth.signInAnonymously();
+    return;  // keep status "loading"
+  }
+  setState({ status: "unauthenticated", user: null, session: null });
+});
+```
+
+When the flag is off, behavior is identical to today: no-session boot lands in `unauthenticated`, the `HomeView` redirect (shipped in PR #47) sends them to `/login`.
+
+## Sign-in flow
+
+### Happy path: linkIdentity succeeds
+
+User is anon with N decks. Clicks "Sign in to save permanently" in the header CTA. Lands on `/login`. Clicks Google (or GitHub). Because they're already anon, the LoginView calls `linkIdentity({ provider })` instead of `signInWithOAuth({ provider })`. OAuth round-trip; on the callback their session updates: same `user.id`, `is_anonymous` is now `false`. All `decks.owner_id` references stay valid. We toast "Signed in" and navigate to `next ?? "/"`.
+
+### Already-linked branch: linkIdentity fails
+
+If the user's OAuth identity is already attached to a different account, `linkIdentity` returns an error on the callback. We don't pin to a specific error code — any failure routes to the same dialog. The user is still anon (linking failed; session is unchanged).
+
+Dialog copy (uses existing `DialogShell` / `DialogHeader`):
+
+> **You already have an account**
+> Looks like that Google account is already signed up. Want to import your N decks into it?
+> [ Import N decks ] [ Sign in without importing ]
+
+- **Import branch:** Persist `{ anonUuid, importedDeckIds: [] }` under `localStorage.dndCards.pendingAnonImport`, then `signOut()` and `signInWithOAuth({ provider })`. After OAuth lands the user as the existing real user, `anonImport.tryResume()` runs (see invocation rules below): SELECT decks where `owner_id = anonUuid` (public read), then SELECT their cards. For each deck not already in `importedDeckIds`: INSERT a new deck owned by the current user with the same name; INSERT clones of its cards under the new deck id; append the original deck id to `importedDeckIds` and persist back to localStorage. When the list is complete, clear the key. Toast "Imported N decks."
+- **Sign in without importing branch:** `signOut()` and `signInWithOAuth({ provider })`. localStorage is not touched. The anon's decks are abandoned.
+
+In both branches the user goes through OAuth twice (once for the failed link, once for the actual sign-in). That's unavoidable: linkIdentity needs a real OAuth round-trip to discover the conflict, and we can't reuse the failed attempt as a sign-in.
+
+### `tryResume()` invocation rules
+
+`anonImport.tryResume()` runs whenever:
+
+1. The session transitions to `authenticated` with `!user.is_anonymous`, **and**
+2. `localStorage.dndCards.pendingAnonImport` exists.
+
+The natural call site is `AuthCallback` (before navigating to `next`), so the import runs in front of the user with a "Importing your decks…" progress UI. For the rare case where the user closes the tab mid-import and returns days later already signed in, a secondary check from `AuthProvider` on the `authenticated` event picks up the resume. The function is idempotent (the `importedDeckIds` list prevents double-cloning) so calling it from both sites is safe.
+
+The new decks have new UUIDs (deck and card IDs change). The original anon rows are abandoned and reaped by `pg_cron`.
+
+Resumability: if the network drops mid-clone, on the next page load `tryResume()` picks up where it left off. Idempotent because we never re-insert deck ids that are already in `importedDeckIds`.
+
+### Dev sign-in path
+
+The existing dev sign-in button does `signInWithPassword(DEV_EMAIL, DEV_PASSWORD)` and on first run does `signUp(...)`. With anon-as-default the user is already anon when they click it. The new path:
+
+1. Try `updateUser({ email: DEV_EMAIL, password: DEV_PASSWORD })` — upgrades the anon user in place, preserving the UUID and decks.
+2. On error (e.g., email already exists from a previous dev session): `signOut()` then `signInWithPassword(...)`. Decks are abandoned, same as today.
+
+`enable_confirmations = false` in `supabase/config.toml` already lets `updateUser` complete without an email round-trip locally.
+
+## UI changes
+
+### Header CTA (`UserMenu.tsx`)
+
+Branch on `session.user.is_anonymous`:
+
+- **Anonymous** → render an accent-colored pill button labeled "Sign in to save permanently" that links to `/login`. This replaces the avatar/menu when anon. No sign-out option; the only way out of anon is to convert.
+- **Authenticated (real)** → existing avatar + sign-out menu, unchanged.
+- **Unauthenticated** (flag off) → existing "Sign in" link, unchanged.
+
+The pill button styling should be visually clearly an action — not a text link. Reuse `Button.module.css` accent variant or extend `UserMenu.module.css`.
+
+### First-create explainer dialog
+
+When an anon user creates their first deck, open a modal explainer once per browser. Subsequent deck creates are silent.
+
+Component: new `src/views/FirstDeckDialog.tsx` (or co-located in `HomeView`) using `DialogShell` + `DialogHeader`.
+
+Trigger: in `HomeView.handleCreate` (and `handleImport`), after the deck is created, check if `session.user.is_anonymous` is true and `localStorage.dndCards.firstDeckExplainerSeen` is unset. If both, open the dialog and set the flag.
+
+Copy:
+
+> **Heads up — your decks live on this browser**
+> You're using the app without an account. Your decks are saved to a temporary account on this browser and can be lost if you clear browsing data or don't visit for a few weeks.
+>
+> Sign in any time to save them permanently to your account.
+> [ Got it ] [ Sign in now ]
+
+"Sign in now" links to `/login`. "Got it" dismisses.
+
+### LoginView copy
+
+When the current user is anon, the page heading and copy shift from "Sign in to create and edit decks" to "Save your work to your account." OAuth buttons stay visually identical; the underlying handler picks `linkIdentity` vs `signInWithOAuth` based on session state.
+
+## Database changes
+
+### `supabase/config.toml`
+
+```toml
+[auth]
+enable_anonymous_sign_ins = true
+```
+
+A corresponding toggle in the Supabase dashboard for prod.
+
+### Migration: anonymous-user cleanup
+
+New migration `supabase/migrations/<timestamp>_anon_user_cleanup.sql`:
+
+```sql
+create extension if not exists pg_cron;
+
+select cron.schedule(
+  'delete-stale-anon-users',
+  '0 3 * * 0',  -- Sundays 03:00 UTC
+  $$
+    delete from auth.users
+    where is_anonymous = true
+      and last_sign_in_at < now() - interval '30 days'
+  $$
+);
+```
+
+`decks.owner_id` already has `on delete cascade`, so deleting the user cascades to decks → cards.
+
+### RLS
+
+No changes. Existing policies (`decks_select_all`, `cards_select_all`, `_insert_owner`/`_update_owner`/`_delete_owner` gated on `owner_id = auth.uid()`) work unchanged for anon users because `auth.uid()` returns the anon's real UUID.
+
+## Env var: `VITE_ANON_USERS_ENABLED`
+
+- Type: `"true"` | unset (treated as off)
+- Default: unset
+- Read by: `AuthProvider` (gates `signInAnonymously()` on boot), `UserMenu` (branches CTA copy on `is_anonymous`), `LoginView` (chooses `linkIdentity` vs `signInWithOAuth`)
+- Tests: unset by default, so existing tests continue to pass; new tests stub `import.meta.env.VITE_ANON_USERS_ENABLED = "true"` per-test.
+
+## Files affected
+
+| File | Change |
+|---|---|
+| `src/auth/AuthProvider.tsx` | Modify `INITIAL_SESSION` handler to call `signInAnonymously()` and stay loading |
+| `src/auth/AuthProvider.test.tsx` | New cases for the flag-on path |
+| `src/lib/ui/UserMenu.tsx` | Branch on `is_anonymous` for the CTA pill |
+| `src/lib/ui/UserMenu.module.css` | Pill button styling (or reuse `Button` accent variant) |
+| `src/lib/ui/UserMenu.test.tsx` | New cases for anon CTA |
+| `src/auth/LoginView.tsx` | OAuth buttons use `linkIdentity` when anon; dev path uses `updateUser` |
+| `src/auth/LoginView.test.tsx` | New cases for the link path |
+| `src/auth/AuthCallback.tsx` | Detect `linkIdentity` failure; open import dialog |
+| `src/auth/AuthCallback.test.tsx` | New cases for the failure path and dialog |
+| `src/auth/anonImport.ts` (new) | Pure module: stash, resume, clear `pendingAnonImport` |
+| `src/auth/anonImport.test.ts` (new) | Unit tests including resumable interruption |
+| `src/views/FirstDeckDialog.tsx` (new) | Modal explainer using `DialogShell` |
+| `src/views/FirstDeckDialog.test.tsx` (new) | First-create-only behavior |
+| `src/views/HomeView.tsx` | Trigger first-create dialog on first deck create as anon |
+| `src/views/HomeView.test.tsx` | New cases for the anon-create dialog and resume |
+| `supabase/config.toml` | `enable_anonymous_sign_ins = true` |
+| `supabase/migrations/<ts>_anon_user_cleanup.sql` (new) | `pg_cron` schedule |
+
+## Testing strategy
+
+- All existing tests remain green with the flag off (the default in test env).
+- New behavior gated by stubbing `import.meta.env.VITE_ANON_USERS_ENABLED = "true"` within the relevant tests.
+- Coverage:
+  - `AuthProvider`: with flag on, no session → calls `signInAnonymously`; status never `unauthenticated`.
+  - `UserMenu`: anon → CTA pill; authenticated → avatar/menu; unauthenticated → existing "Sign in" link.
+  - `LoginView`: OAuth click as anon → `linkIdentity`; as unauthenticated → `signInWithOAuth`. Dev click as anon → `updateUser`.
+  - `AuthCallback`: linkIdentity failure → opens import dialog.
+  - `anonImport`: happy clone, resumable clone (pre-existing partial state), cleared key on full success.
+  - `FirstDeckDialog`: opens on first create; suppressed when flag set.
+  - `HomeView`: integrates the dialog and resume call without breaking existing flows.
+
+## Open verification items (deferred to implementation)
+
+- Exact error code/message returned by `linkIdentity` when the OAuth identity is on a different account. Implementation will catch any error and route to the dialog rather than match a specific code; revisit if the error is also raised in benign cases.
+- `INITIAL_SESSION` event ordering when we synchronously call `signInAnonymously()` from inside the listener. Acceptable fallback: call `signInAnonymously()` from a `useEffect` after subscribe rather than inside the listener body.
+- `updateUser({ email, password })` on an anon user under local config (`enable_confirmations = false`). Expected to complete without email confirmation; verify on first manual run.
+
+## Rollout
+
+1. Land the feature behind the flag (default off). All existing tests pass.
+2. Manual smoke locally with `VITE_ANON_USERS_ENABLED=true`:
+   - Boot fresh: anon sign-in, create deck, see first-create dialog.
+   - Sign in via Google → verify same UUID, decks attached.
+   - Repeat with a Google identity already on another account → verify import dialog and resumable clone.
+3. Flip `enable_anonymous_sign_ins = true` in the Supabase dashboard for prod.
+4. Set `VITE_ANON_USERS_ENABLED=true` in the prod build env (Vercel).
+5. Verify `pg_cron` schedule landed and runs once before relying on it.
+
+## Out of scope follow-ups
+
+- "Clear my work" action for anon users who want to reset (e.g., sharing a device).
+- Per-deck "local only" badge after sign-in if a future feature lets users have a mix of synced and local decks.
+- Captcha / rate limiting on anonymous sign-in if abuse becomes a concern.
+- Telemetry on conversion rate (anon → real user).

--- a/docs/superpowers/specs/2026-05-07-anon-supabase-users-design.md
+++ b/docs/superpowers/specs/2026-05-07-anon-supabase-users-design.md
@@ -45,7 +45,7 @@ AuthProvider                                   auth.users
        (status stays "loading")                  ├ decks   (RLS unchanged)
                                                  └ cards   (RLS unchanged)
 UserMenu                                       pg_cron schedule
-  ├ anonymous → "Sign in to save permanently"    └ weekly: delete anon users
+  ├ anonymous → "Sign in to save your work"      └ weekly: delete anon users
   ├ authenticated → avatar + sign-out                inactive > 30 days
   └ unauthenticated (flag off) → "Sign in" link
 LoginView
@@ -104,17 +104,22 @@ The deck count comes from the existing `useDecks(anonUserId)` query. Reading it 
 
 ### Happy path: linkIdentity succeeds (anon has decks, first time signing in with this provider)
 
-User is anon with N decks. Clicks "Sign in to save permanently" in the header CTA. Lands on `/login`. Clicks Google (or GitHub). Because they're anon and have decks, LoginView calls `linkIdentity({ provider })`. OAuth round-trip; on the callback their session updates: same `user.id`, `is_anonymous` is now `false`. All `decks.owner_id` references stay valid. We toast "Signed in" and navigate to `next ?? "/"`.
+User is anon with N decks. Clicks "Sign in to save your work" in the header CTA. Lands on `/login`. Clicks Google (or GitHub). Because they're anon and have decks, LoginView calls `linkIdentity({ provider })`. OAuth round-trip; on the callback their session updates: same `user.id`, `is_anonymous` is now `false`. All `decks.owner_id` references stay valid. We toast "Signed in" and navigate to `next ?? "/"`.
 
 ### Already-linked branch: linkIdentity fails (anon has decks, existing account on this provider)
 
 If the user's OAuth identity is already attached to a different account, `linkIdentity` returns an error on the callback. We don't pin to a specific error code — any failure routes to the same dialog. The user is still anon (linking failed; session is unchanged).
 
-Dialog copy (uses existing `DialogShell` / `DialogHeader`):
+Dialog copy (uses existing `DialogShell` / `DialogHeader`). The conflicting email is read from the failed-link response (Supabase exposes the OAuth identity's email even on link failure):
 
-> **You already have an account**
-> Looks like that Google account is already signed up. Want to import your N decks into it?
-> [ Import N decks ] [ Sign in without importing ]
+> **You already have a dnd-cards account**
+> Looks like {email} is already signed up here. Want to bring your N decks into that account?
+>
+> If you skip, those decks will be left behind and deleted after 30 days. They cannot be recovered.
+>
+> [ **Yes, import N decks** ]   <small>Skip — leave decks behind</small>
+
+The primary action is the styled button; "Skip" is a tertiary text-link styled to be visually de-emphasized so a hurried user can't equate it with the import action. The destructive consequence is named explicitly above the buttons.
 
 - **Import branch:** Persist `{ anonUuid, importedDeckIds: [] }` under `localStorage.dndCards.pendingAnonImport`, then `signOut()` and `signInWithOAuth({ provider })`. After OAuth lands the user as the existing real user, `anonImport.tryResume()` runs (see invocation rules below): SELECT decks where `owner_id = anonUuid` (public read), then SELECT their cards. For each deck not already in `importedDeckIds`: INSERT a new deck owned by the current user with the same name; INSERT clones of its cards under the new deck id; append the original deck id to `importedDeckIds` and persist back to localStorage. When the list is complete, clear the key. Toast "Imported N decks."
 - **Sign in without importing branch:** `signOut()` and `signInWithOAuth({ provider })`. localStorage is not touched. The anon's decks are abandoned.
@@ -136,11 +141,40 @@ In both branches of this dialog the user goes through OAuth twice (once for the 
 1. The session transitions to `authenticated` with `!user.is_anonymous`, **and**
 2. `localStorage.dndCards.pendingAnonImport` exists.
 
-The natural call site is `AuthCallback` (before navigating to `next`), so the import runs in front of the user with a "Importing your decks…" progress UI. For the rare case where the user closes the tab mid-import and returns days later already signed in, a secondary check from `AuthProvider` on the `authenticated` event picks up the resume. The function is idempotent (the `importedDeckIds` list prevents double-cloning) so calling it from both sites is safe.
+The natural call site is `AuthCallback` (before navigating to `next`), so the import runs in front of the user. For the rare case where the user closes the tab mid-import and returns days later already signed in, a secondary check from `AuthProvider` on the `authenticated` event picks up the resume. The function is idempotent (the `importedDeckIds` list prevents double-cloning) so calling it from both sites is safe.
 
 The new decks have new UUIDs (deck and card IDs change). The original anon rows are abandoned and reaped by `pg_cron`.
 
-Resumability: if the network drops mid-clone, on the next page load `tryResume()` picks up where it left off. Idempotent because we never re-insert deck ids that are already in `importedDeckIds`.
+### Import progress UI
+
+While `tryResume()` is running on the AuthCallback page, the page renders an interstitial in place of its current "Signing you in…" copy:
+
+> **Bringing your decks over**
+> Imported {imported} of {total} decks…
+
+A simple inline counter — no spinner, no progress bar primitive needed. Updates live as `importedDeckIds` grows. Navigation to `next` happens only after the counter reaches `total` and the localStorage key is cleared. The interstitial also doubles as the "Signing you in to import…" cue between the two OAuth round-trips, since the user lands on `AuthCallback` after the second OAuth completes.
+
+If the SELECT or any INSERT fails after retry (a single in-process retry on transient errors), render a recoverable error state:
+
+> **Couldn't finish importing your decks**
+> Imported {imported} of {total}. We'll try again automatically next time you sign in.
+>
+> [ Retry now ]   <small>Continue without retrying</small>
+
+The localStorage key is preserved so the next sign-in resumes from where this one stopped. "Continue" navigates to `next` without clearing the key.
+
+### Toast on full success
+
+`Imported N decks.` Shown once on completion of the import. If the import resumed across multiple sessions (e.g., interrupted at deck 3 of 10, completed on a later visit), the toast still says the total imported, so the user understands the import is fully done.
+
+### OAuth failure modes
+
+Beyond the already-linked branch, `linkIdentity` and `signInWithOAuth` can fail for several reasons. Each is handled by leaving the user in their pre-click state and surfacing a recoverable error:
+
+- **User cancels the OAuth popup / browser back-button.** No callback fires; user is still anon on the LoginView. No state change needed; they can click again.
+- **OAuth provider error (Google/GitHub down, denied consent).** Callback returns with `error_description` query param. We display "Sign-in didn't complete: {message}" on the LoginView and clear any `pendingAnonImport` key set in this attempt — we never started the import, so there's nothing to resume.
+- **Network drops mid-redirect.** Same as cancellation from the user's perspective.
+- **Race: anon row reaped while user is at the OAuth screen.** Possible but extremely unlikely (cron is weekly, OAuth round-trip is seconds). If `tryResume()` SELECTs the anon's decks and gets zero rows, we treat it as already-imported (clear the key, no toast). The user lands signed-in with no anon-decks to import — the same outcome as if they had no anon decks to begin with.
 
 ### Dev sign-in path
 
@@ -157,7 +191,7 @@ The existing dev sign-in button does `signInWithPassword(DEV_EMAIL, DEV_PASSWORD
 
 Branch on `session.user.is_anonymous`:
 
-- **Anonymous** → render an accent-colored pill button labeled "Sign in to save permanently" that links to `/login`. This replaces the avatar/menu when anon. No sign-out option; the only way out of anon is to convert.
+- **Anonymous** → render an accent-colored pill button labeled "Sign in to save your work" that links to `/login`. This replaces the avatar/menu when anon. No sign-out option; the only way out of anon is to convert.
 - **Authenticated (real)** → existing avatar + sign-out menu, unchanged.
 - **Unauthenticated** (flag off) → existing "Sign in" link, unchanged.
 
@@ -173,17 +207,25 @@ Trigger: in `HomeView.handleCreate` (and `handleImport`), after the deck is crea
 
 Copy:
 
-> **Heads up — your decks live on this browser**
-> You're using the app without an account. Your decks are saved to a temporary account on this browser and can be lost if you clear browsing data or don't visit for a few weeks.
+> **Your decks live on this browser**
+> You're not signed in, so your new deck only exists here on this device — not on your phone, your other laptop, or anywhere else. Sign in any time to save your decks to your account, where you can access them from any device.
 >
-> Sign in any time to save them permanently to your account.
-> [ Got it ] [ Sign in now ]
+> Otherwise, your decks may be lost if you clear browsing data, switch browsers, or don't visit for 30 days.
+>
+> [ **Sign in now** ]   <small>Not yet</small>
 
-"Sign in now" links to `/login`. "Got it" dismisses.
+The primary action is "Sign in now" (links to `/login`). "Not yet" is a tertiary text link that dismisses. Visual weight reflects intent: this is a conversion moment, not a 50/50 choice. Once dismissed, the dialog never reappears for that browser; the header CTA is the only ongoing prompt.
 
 ### LoginView copy
 
 When the current user is anon, the page heading and copy shift from "Sign in to create and edit decks" to "Save your work to your account." OAuth buttons stay visually identical; the underlying handler picks `linkIdentity` vs `signInWithOAuth` based on session state.
+
+### Accessibility
+
+- All dialogs (`FirstDeckDialog`, the import dialog) use the existing `DialogShell` + `DialogHeader`, which are built on react-aria-components and handle modal focus trap, escape-to-dismiss, and labelled-by relationships out of the box.
+- The header CTA pill is a `<Link to="/login">` styled as a button. It carries an explicit text label ("Sign in to save your work") so it reads correctly to screen readers without an `aria-label` override.
+- The import progress interstitial on `AuthCallback` uses an `aria-live="polite"` region so the counter updates are announced as the import progresses.
+- After dialog dismissal, focus returns to the originating control (the "Sign in" CTA for the import dialog; the deck list for the first-create dialog). `DialogShell` handles this by default; verify in tests.
 
 ## Database changes
 
@@ -257,7 +299,7 @@ No changes. Existing policies (`decks_select_all`, `cards_select_all`, `_insert_
   - `AuthProvider`: with flag on, no session → calls `signInAnonymously`; status never `unauthenticated`.
   - `UserMenu`: anon → CTA pill; authenticated → avatar/menu; unauthenticated → existing "Sign in" link.
   - `LoginView`: OAuth click as anon with decks → `linkIdentity`; as anon with no decks → `signInWithOAuth`; as unauthenticated → `signInWithOAuth`. Dev click as anon → `updateUser`.
-  - `AuthCallback`: linkIdentity failure → opens import dialog.
+  - `AuthCallback`: linkIdentity failure → opens import dialog; partial-import failure → renders recoverable error state with retry button; OAuth provider error → renders recoverable message.
   - `anonImport`: happy clone, resumable clone (pre-existing partial state), cleared key on full success.
   - `FirstDeckDialog`: opens on first create; suppressed when flag set.
   - `HomeView`: integrates the dialog and resume call without breaking existing flows.

--- a/docs/superpowers/specs/2026-05-07-anon-supabase-users-design.md
+++ b/docs/superpowers/specs/2026-05-07-anon-supabase-users-design.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Let visitors use the full app — create, edit, and print decks — without signing in. Persist their work in the same Supabase database under a real `auth.users` row created via Supabase's anonymous sign-in. When they later sign in with OAuth, `linkIdentity` upgrades the same row in place; their decks are preserved without any data movement. If their OAuth identity is already linked to a different existing account, offer to clone their anon decks into it. Stale anon users are auto-reaped after 30 days.
+Let visitors use the full app — create, edit, and print decks — without signing in. Persist their work in the same Supabase database under a real `auth.users` row created via Supabase's anonymous sign-in. When they later sign in with OAuth, `linkIdentity` upgrades the same row in place; their decks are preserved without any data movement. If their OAuth identity is already linked to a different existing account, offer to clone their anon decks into it.
 
 The whole feature is gated behind a `VITE_ANON_USERS_ENABLED` env var so it can be merged dark and rolled out independently.
 
@@ -15,7 +15,6 @@ The whole feature is gated behind a `VITE_ANON_USERS_ENABLED` env var so it can 
 - Sign-in via OAuth converts the anon account into a permanent one in place — same UUID, same `decks.owner_id`, no data movement.
 - If the OAuth identity is already on a different account, offer to clone anon decks into it (resumable, survives interruptions).
 - Make the local-only nature of anon work obvious so users don't lose work to a Safari ITP eviction by surprise.
-- Auto-cleanup of unused anon `auth.users` rows after 30 days via `pg_cron`.
 - Fully gated behind `VITE_ANON_USERS_ENABLED`; existing flows unchanged when off.
 
 ## Non-goals (v1)
@@ -24,7 +23,7 @@ The whole feature is gated behind a `VITE_ANON_USERS_ENABLED` env var so it can 
 - Atomic transfer of decks between accounts. The "clone into existing account" flow uses public-read SELECTs + INSERTs and is resumable but not transactional.
 - Server-side Postgres functions to facilitate transfer (`SECURITY DEFINER`). Not needed because cloning is purely client-side.
 - Differentiating anon from real users in RLS (e.g., capping anon to N decks). Existing policies already gate on `owner_id = auth.uid()`; anon users inherit the same constraints naturally.
-- Toast/notification primitive. The first-time explainer uses an existing modal dialog.
+- **Auto-cleanup of stale anon `auth.users` rows.** Scoping the cleanup turned up a long tail of correctness and operational issues for what is essentially hygiene work; deferred until accumulation is observed to matter. Research notes preserved at [`docs/superpowers/handoffs/2026-05-08-anon-user-cleanup-notes.md`](../handoffs/2026-05-08-anon-user-cleanup-notes.md) for whoever revisits.
 
 ## Hard constraints (carried forward)
 
@@ -44,16 +43,18 @@ AuthProvider                                   auth.users
        supabase.auth.signInAnonymously()       Postgres
        (status stays "loading")                  ├ decks   (RLS unchanged)
                                                  └ cards   (RLS unchanged)
-UserMenu                                       pg_cron schedule
-  ├ anonymous → "Sign in to save your work"      └ weekly: delete anon users
-  ├ authenticated → avatar + sign-out                inactive > 30 days
+UserMenu
+  ├ anonymous → "Sign in to save your work"
+  ├ authenticated → avatar + sign-out
   └ unauthenticated (flag off) → "Sign in" link
 LoginView
-  ├ anon? → linkIdentity(provider)
+  ├ anon with decks? → linkIdentity(provider)
+  ├ anon with 0 decks? → signInWithOAuth(provider)
   └ unauthenticated? → signInWithOAuth(provider)
 AuthCallback
-  ├ link succeeded → toast, redirect to next
-  └ link failed (identity already on another account) → import dialog
+  ├ link succeeded → Announcement "Signed in", redirect to next
+  ├ link failed (identity already on another account) → import dialog
+  └ pendingAnonImport present → import progress, then redirect
 anonImport.ts
   ├ stash {anonUuid, importedDeckIds:[]} in localStorage
   ├ on next sign-in: SELECT anon decks/cards (public reads), INSERT clones
@@ -97,14 +98,14 @@ When the flag is off, behavior is identical to today: no-session boot lands in `
 
 Before picking the API, the LoginView checks how many decks the anon user owns:
 
-- **0 decks** → call `signInWithOAuth({ provider })` directly. The anon row is abandoned (and reaped by cron); no link, no dialog. This handles the common returning-user-on-new-device case (where a fresh anon row exists from boot but the user hasn't done anything yet) and the brand-new-user-signing-in-immediately case.
+- **0 decks** → call `signInWithOAuth({ provider })` directly. The anon row is abandoned (cleanup is deferred — see Non-goals); no link, no dialog. This handles the common returning-user-on-new-device case (where a fresh anon row exists from boot but the user hasn't done anything yet) and the brand-new-user-signing-in-immediately case.
 - **≥1 decks** → call `linkIdentity({ provider })`. On the callback we know whether linking succeeded; failure routes to the dialog described below.
 
-The deck count comes from the existing `useDecks(anonUserId)` query. Reading it from the cache or refetching at click time are both fine; for safety we'll refetch (cheap; the user is about to do an OAuth round-trip anyway).
+The deck count is fetched on **OAuth button click**, not on LoginView mount, to avoid an unnecessary query when the user simply navigated to `/login`. We use the existing `useDecks(anonUserId)` infrastructure but trigger via `queryClient.fetchQuery` from the click handler so the OAuth redirect doesn't fire until we know the count.
 
 ### Happy path: linkIdentity succeeds (anon has decks, first time signing in with this provider)
 
-User is anon with N decks. Clicks "Sign in to save your work" in the header CTA. Lands on `/login`. Clicks Google (or GitHub). Because they're anon and have decks, LoginView calls `linkIdentity({ provider })`. OAuth round-trip; on the callback their session updates: same `user.id`, `is_anonymous` is now `false`. All `decks.owner_id` references stay valid. We toast "Signed in" and navigate to `next ?? "/"`.
+User is anon with N decks. Clicks "Sign in to save your work" in the header CTA. Lands on `/login`. Clicks Google (or GitHub). Because they're anon and have decks, LoginView calls `linkIdentity({ provider })`. OAuth round-trip; on the callback their session updates: same `user.id`, `is_anonymous` is now `false`. All `decks.owner_id` references stay valid. We set a "Signed in" announcement and navigate to `next ?? "/"`.
 
 ### Already-linked branch: linkIdentity fails (anon has decks, existing account on this provider)
 
@@ -138,14 +139,16 @@ In both branches of this dialog the user goes through OAuth twice (once for the 
 
 ### `tryResume()` invocation rules
 
-`anonImport.tryResume()` runs whenever:
+`anonImport.tryResume()` runs from a single site: `AuthCallback`, before navigating to `next`. It runs whenever:
 
-1. The session transitions to `authenticated` with `!user.is_anonymous`, **and**
+1. The current session is `authenticated` with `!user.is_anonymous`, **and**
 2. `localStorage.dndCards.pendingAnonImport` exists.
 
-The natural call site is `AuthCallback` (before navigating to `next`), so the import runs in front of the user. For the rare case where the user closes the tab mid-import and returns days later already signed in, a secondary check from `AuthProvider` on the `authenticated` event picks up the resume. The function is idempotent (the `importedDeckIds` list prevents double-cloning) so calling it from both sites is safe.
+If the user closes the tab mid-import, the localStorage key persists; the next time they sign in (which goes through AuthCallback again), `tryResume()` picks up where it left off. The function is idempotent: `importedDeckIds` prevents double-cloning of any deck that already succeeded.
 
-The new decks have new UUIDs (deck and card IDs change). The original anon rows are abandoned and reaped by `pg_cron`.
+We deliberately do **not** call `tryResume()` from a second site like `AuthProvider`. The single call site keeps reasoning simple and is sufficient because every recovery path goes through a sign-in (which routes through AuthCallback).
+
+The new decks have new UUIDs (deck and card IDs change). The original anon rows are abandoned (and accumulate; cleanup is deferred — see Non-goals).
 
 ### Import progress UI
 
@@ -156,18 +159,16 @@ While `tryResume()` is running on the AuthCallback page, the page renders an int
 
 A simple inline counter — no spinner, no progress bar primitive needed. Updates live as `importedDeckIds` grows. Navigation to `next` happens only after the counter reaches `total` and the localStorage key is cleared. The interstitial also doubles as the "Signing you in to import…" cue between the two OAuth round-trips, since the user lands on `AuthCallback` after the second OAuth completes.
 
-If the SELECT or any INSERT fails after retry (a single in-process retry on transient errors), render a recoverable error state:
+If the SELECT or any INSERT fails (a single in-process retry on transient errors first), render a non-blocking error message and continue navigating:
 
 > **Couldn't finish importing your decks**
-> Imported {imported} of {total}. We'll try again automatically next time you sign in.
->
-> [ Retry now ]   <small>Continue without retrying</small>
+> Imported {imported} of {total}. We'll try again next time you sign in.
 
-The localStorage key is preserved so the next sign-in resumes from where this one stopped. "Continue" navigates to `next` without clearing the key.
+The localStorage key is preserved so the next sign-in resumes from where this one stopped. We don't expose a "Retry now" button — the auto-resume on next sign-in covers the same need without the extra UI surface and tests.
 
-### Toast on full success
+### Announcement on full success
 
-`Imported N decks.` Shown once on completion of the import. If the import resumed across multiple sessions (e.g., interrupted at deck 3 of 10, completed on a later visit), the toast still says the total imported, so the user understands the import is fully done.
+The user lands on `next` (typically `/`) and sees a brief inline announcement at the top of the view: `Imported N decks.` (or `Signed in.` for the no-import path). The announcement auto-dismisses after ~5 seconds and is rendered via a small `Announcement` primitive added in this PR (see UI changes). If the import resumed across multiple sessions (e.g., interrupted at deck 3 of 10, completed on a later visit), the announcement still says the total imported.
 
 ### OAuth failure modes
 
@@ -176,7 +177,7 @@ Beyond the already-linked branch, `linkIdentity` and `signInWithOAuth` can fail 
 - **User cancels the OAuth popup / browser back-button.** No callback fires; user is still anon on the LoginView. No state change needed; they can click again.
 - **OAuth provider error (Google/GitHub down, denied consent).** Callback returns with `error_description` query param. We display "Sign-in didn't complete: {message}" on the LoginView and clear any `pendingAnonImport` key set in this attempt — we never started the import, so there's nothing to resume.
 - **Network drops mid-redirect.** Same as cancellation from the user's perspective.
-- **Race: anon row reaped while user is at the OAuth screen.** Possible but extremely unlikely (cron is weekly, OAuth round-trip is seconds). If `tryResume()` SELECTs the anon's decks and gets zero rows, we treat it as already-imported (clear the key, no toast). The user lands signed-in with no anon-decks to import — the same outcome as if they had no anon decks to begin with.
+- **Anon row missing when `tryResume()` SELECTs.** Without an automatic cleanup, this is rare in practice (only happens if someone manually deletes the user via the Supabase dashboard, or an admin bulk-deletes during maintenance), but the code still has to be defensive. If `tryResume()` SELECTs the anon's decks and gets zero rows, we treat it as already-imported (clear the key, no announcement). The user lands signed-in with no anon decks to import — the same outcome as if they had no anon decks to begin with.
 
 ### Dev sign-in path
 
@@ -198,7 +199,7 @@ Branch on `session.user.is_anonymous`:
 - **Authenticated (real)** → existing avatar + sign-out menu, unchanged.
 - **Unauthenticated** (flag off) → existing "Sign in" link, unchanged.
 
-The pill button styling should be visually clearly an action — not a text link. Reuse `Button.module.css` accent variant or extend `UserMenu.module.css`.
+The pill is styled in `UserMenu.module.css` (a new `.pillCta` class). Visually clearly an action — accent fill, padded button, not a text link.
 
 ### First-create explainer dialog
 
@@ -223,6 +224,25 @@ The primary action is "Sign in now" (links to `/login`). "Not yet" is a tertiary
 
 When the current user is anon, the page heading and copy shift from "Sign in to create and edit decks" to "Save your work to your account." OAuth buttons stay visually identical; the underlying handler picks `linkIdentity` vs `signInWithOAuth` based on session state.
 
+### Announcement primitive
+
+A new tiny UI primitive — `src/lib/ui/Announcement.tsx` — for brief, non-blocking confirmation messages. Used on `AuthCallback`'s success interstitial and on the destination view after navigating from `next`.
+
+Behavior:
+
+- Renders a single message at the top of its container (above the deck list when triggered from HomeView; above the page content otherwise).
+- Auto-dismisses after ~5 seconds; user can also dismiss via a small ✕ button.
+- Implemented as a controlled component: parent passes `message` and `onDismiss`. State for "show me an announcement on next render" is held in a small `AnnouncementContext` keyed off router state, so triggering an announcement from `AuthCallback` and rendering it on the destination view doesn't require global state plumbing.
+- Accessible: `role="status"` with `aria-live="polite"` so the message is announced to screen readers without interrupting them.
+
+Scope is deliberately small — this is not a queueable toast system. One message at a time, replaced if a new one is set. If we ever need a queue or multiple stacking notifications, we revisit.
+
+Files:
+- `src/lib/ui/Announcement.tsx` (new) — the component.
+- `src/lib/ui/Announcement.module.css` (new) — styles.
+- `src/lib/ui/Announcement.test.tsx` (new) — render, dismiss, auto-dismiss timer, aria attributes.
+- `src/lib/ui/AnnouncementContext.tsx` (new, or co-located in `Announcement.tsx`) — provider + hook for setting the next announcement across navigation.
+
 ### Accessibility
 
 - All dialogs (`FirstDeckDialog`, the import dialog) use the existing `DialogShell` + `DialogHeader`, which are built on react-aria-components and handle modal focus trap, escape-to-dismiss, and labelled-by relationships out of the box.
@@ -241,104 +261,11 @@ enable_anonymous_sign_ins = true
 
 A corresponding toggle in the Supabase dashboard for prod.
 
-### Cleanup: pg_cron + pg_net → Edge Function
+### Cleanup of stale anon users — deferred
 
-Cleanup uses Supabase's recommended pattern for scheduled work that needs admin privileges: a pg_cron schedule invokes an Edge Function via pg_net, and the Edge Function uses the `service_role` key to call `supabase.auth.admin.deleteUser()` for each stale user.
+Anonymous `auth.users` rows accumulate over time. We considered a `pg_cron` + `pg_net` → Edge Function pattern to reap them, but two review rounds turned up enough Supabase-specific pitfalls (auth-key model on Edge Functions, cascade permission grants, session-retention behavior, Vault read permissions) that the cost outweighs the benefit for a hobby app where there's no current accumulation pressure.
 
-Two non-obvious gotchas this design has to handle:
-
-1. **`auth.sessions` is owned by `supabase_auth_admin`.** Querying it from PostgREST/RPC requires either elevated SQL access or a `SECURITY DEFINER` helper. We use a small read-only helper rather than going through the admin SQL path.
-2. **`auth.users.last_sign_in_at` does not update on token refresh.** A returning anon user whose tokens auto-refresh in the background still has the same `last_sign_in_at` from their initial sign-in — gating cleanup on this column would reap actively-used accounts at 30 days. The correct activity signal is `auth.sessions.updated_at`, which the auth server bumps on every refresh.
-
-#### Migration: `supabase/migrations/<timestamp>_anon_user_cleanup.sql`
-
-```sql
-create extension if not exists pg_cron;
-create extension if not exists pg_net;
-
--- Read-only helper: returns IDs of anon users with no active session
--- in the last 30 days. SECURITY DEFINER because auth.sessions is
--- restricted to supabase_auth_admin.
-create or replace function public.stale_anon_user_ids()
-returns table(id uuid)
-language sql
-security definer
-set search_path = ''
-as $$
-  select u.id
-  from auth.users u
-  where u.is_anonymous is true
-    and u.id is not null
-    and not exists (
-      select 1
-      from auth.sessions s
-      where s.user_id = u.id
-        and s.updated_at > now() - interval '30 days'
-    )
-  limit 1000
-$$;
-
-alter function public.stale_anon_user_ids() owner to supabase_auth_admin;
-grant execute on function public.stale_anon_user_ids() to service_role;
-
--- Schedule weekly invocation of the Edge Function. Project URL and
--- service_role key live in Supabase Vault (created via the dashboard
--- or `select vault.create_secret(...)`).
-select cron.schedule(
-  'cleanup-anon-users',
-  '0 3 * * 0',  -- Sundays 03:00 UTC
-  $$
-    select net.http_post(
-      url := (select decrypted_secret from vault.decrypted_secrets where name = 'project_url')
-             || '/functions/v1/cleanup-anon-users',
-      headers := jsonb_build_object(
-        'Authorization', 'Bearer ' ||
-          (select decrypted_secret from vault.decrypted_secrets where name = 'service_role_key'),
-        'Content-Type', 'application/json'
-      ),
-      body := '{}'::jsonb
-    )
-  $$
-);
-```
-
-The helper is **read-only**: it returns IDs but cannot delete anything. The privilege elevation is narrow — calling it does nothing destructive. Deletion happens in the Edge Function via the admin API.
-
-#### Edge Function: `supabase/functions/cleanup-anon-users/index.ts`
-
-```ts
-import { createClient } from "jsr:@supabase/supabase-js@2";
-
-Deno.serve(async () => {
-  const supabase = createClient(
-    Deno.env.get("SUPABASE_URL")!,
-    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
-  );
-
-  const { data: ids, error } = await supabase.rpc("stale_anon_user_ids");
-  if (error) {
-    return new Response(JSON.stringify({ error: error.message }), { status: 500 });
-  }
-
-  let deleted = 0;
-  const failures: string[] = [];
-  for (const { id } of ids ?? []) {
-    const { error: delError } = await supabase.auth.admin.deleteUser(id);
-    if (delError) failures.push(`${id}: ${delError.message}`);
-    else deleted++;
-  }
-
-  return new Response(JSON.stringify({ deleted, failures }), { status: 200 });
-});
-```
-
-Notes:
-
-- `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are auto-injected into Edge Function runtimes by Supabase — no manual secret setup needed for the function itself.
-- Edge Functions require a valid JWT by default; the cron job's `Authorization: Bearer <service_role_key>` header satisfies that gate, so the function isn't reachable as an anonymous public endpoint.
-- The function returns a JSON summary; pg_net stores the HTTP response in `net._http_response` for inspection.
-- `decks.owner_id` already has `on delete cascade`, so `auth.admin.deleteUser()` cascades to decks → cards.
-- The `LIMIT 1000` in the helper caps blast radius per run; weekly runs will catch up on any backlog.
+The design we evaluated, the pitfalls we found, and the recommended approach when revisiting are captured in [`docs/superpowers/handoffs/2026-05-08-anon-user-cleanup-notes.md`](../handoffs/2026-05-08-anon-user-cleanup-notes.md). When/if accumulation becomes operationally annoying, start there.
 
 ### RLS
 
@@ -370,49 +297,45 @@ No changes. Existing policies (`decks_select_all`, `cards_select_all`, `_insert_
 | `src/views/FirstDeckDialog.test.tsx` (new) | First-create-only behavior |
 | `src/views/HomeView.tsx` | Trigger first-create dialog on first deck create as anon |
 | `src/views/HomeView.test.tsx` | New cases for the anon-create dialog and resume |
+| `src/lib/ui/Announcement.tsx` (new) | Inline non-blocking confirmation primitive |
+| `src/lib/ui/Announcement.module.css` (new) | Styles for the announcement |
+| `src/lib/ui/Announcement.test.tsx` (new) | Render, dismiss, auto-dismiss timer, aria-live |
+| `src/test/msw.ts` | Add MSW handlers for `signInAnonymously`, `linkIdentity`, `updateUser`, and the public-read SELECTs used during clone |
 | `supabase/config.toml` | `enable_anonymous_sign_ins = true` |
-| `supabase/migrations/<ts>_anon_user_cleanup.sql` (new) | Enable `pg_cron` + `pg_net`; create read-only `stale_anon_user_ids()` helper; schedule weekly Edge Function invocation |
-| `supabase/functions/cleanup-anon-users/index.ts` (new) | Deno Edge Function: calls helper, deletes returned IDs via `supabase.auth.admin.deleteUser()` |
 
 ## Testing strategy
 
-- All existing tests remain green with the flag off (the default in test env).
+- All existing tests remain green with the flag off (the default in test env). One explicit baseline test asserts `AuthProvider` flag-off → `unauthenticated` so the regression contract is durable.
 - New behavior gated by stubbing `import.meta.env.VITE_ANON_USERS_ENABLED = "true"` within the relevant tests.
 - Coverage:
-  - `AuthProvider`: with flag on, no session → calls `signInAnonymously`; status never `unauthenticated`.
-  - `UserMenu`: anon → CTA pill; authenticated → avatar/menu; unauthenticated → existing "Sign in" link.
-  - `LoginView`: OAuth click as anon with decks → `linkIdentity`; as anon with no decks → `signInWithOAuth`; as unauthenticated → `signInWithOAuth`. Dev click as anon → `updateUser`.
-  - `AuthCallback`: linkIdentity failure → opens import dialog; partial-import failure → renders recoverable error state with retry button; OAuth provider error → renders recoverable message.
-  - `anonImport`: happy clone, resumable clone (pre-existing partial state), cleared key on full success.
-  - `FirstDeckDialog`: opens on first create; suppressed when flag set.
-  - `HomeView`: integrates the dialog and resume call without breaking existing flows.
+  - `AuthProvider`: flag on, no session → calls `signInAnonymously` and stays `loading` until SIGNED_IN; status never `unauthenticated`. Flag off, no session → `unauthenticated` (baseline).
+  - `UserMenu`: anon → CTA pill (with text label readable to screen readers); authenticated → avatar/menu; unauthenticated → existing "Sign in" link.
+  - `LoginView`: OAuth click as anon with decks → `linkIdentity`; as anon with no decks → `signInWithOAuth`; as unauthenticated → `signInWithOAuth`. Dev click as anon → two-step `updateUser` (email then password).
+  - `AuthCallback`: linkIdentity failure → opens import dialog; partial-import failure → preserves pendingAnonImport for next-sign-in resume; OAuth provider error → renders recoverable message; anon row missing on resume (zero-rows SELECT) → treats as already-imported and clears the key without an announcement.
+  - `anonImport`: happy clone; resumable clone (pre-existing partial state); cleared key on full success.
+  - `FirstDeckDialog`: opens on first deck create as anon; suppressed once dismissed (localStorage flag set); never shown for non-anon users.
+  - `Announcement`: render, programmatic dismiss, auto-dismiss timer, `role="status"` + `aria-live="polite"` attributes.
+  - `HomeView`: integrates the first-create dialog and renders an Announcement passed via context after sign-in.
 
 ## Open verification items (deferred to implementation)
 
 - Behavior of supabase-js's URL detection on a `linkIdentity` failure callback: confirm that no fake "session" event fires when the URL contains `error_code=identity_already_exists`, so AuthCallback's URL parsing is the sole source of truth for the failure branch.
 - `INITIAL_SESSION` event ordering when we synchronously call `signInAnonymously()` from inside the listener. Verified safe (auth-js serializes calls via internal lock), but the slightly more idiomatic alternative is to call `signInAnonymously()` from a `useEffect` after subscribe. Either is acceptable; revisit if the listener-body call produces any odd state transitions in tests.
-- `auth.sessions.updated_at` retention window in Supabase managed config. We assume it stays populated for at least 30 days for active sessions; if Supabase prunes sessions sooner, the cleanup may reap users whose tokens are still valid. Monitor first month after rollout.
-- Ownership-transfer permission for `alter function public.stale_anon_user_ids() owner to supabase_auth_admin` from a standard migration. Most Supabase projects allow `postgres` to alter ownership to `supabase_auth_admin` because `postgres` is a member of the relevant role group, but verify on first migration run; if it fails, the alternative is a dashboard-side SQL edit using a more privileged session.
+- `pendingAnonImport` schema versioning: include a `version: 1` field in the stashed object and have `tryResume()` ignore unknown versions. Cheap insurance against shape changes between PRs.
+- `next` URL preservation across the two OAuth round-trips in the import-into-existing-account flow. The first OAuth (linkIdentity) carries `next` via `redirectTo`; on failure, when we sign out and signInWithOAuth, we need to re-set `redirectTo` so the user lands where they intended. Trivial but easy to forget.
 
 ## Rollout
 
 1. Land the feature behind the flag (default off). All existing tests pass.
 2. Manual smoke locally with `VITE_ANON_USERS_ENABLED=true`:
    - Boot fresh: anon sign-in, create deck, see first-create dialog.
-   - Sign in via Google → verify same UUID, decks attached.
-   - Repeat with a Google identity already on another account → verify import dialog and resumable clone.
-3. Deploy the Edge Function: `supabase functions deploy cleanup-anon-users`.
-4. Store secrets in Vault (one-time, via dashboard or `select vault.create_secret(...)`):
-   - `project_url` — e.g., `https://<ref>.supabase.co`
-   - `service_role_key` — copied from the Supabase dashboard
-5. Pre-flight checks before flipping prod flag:
+   - Sign in via Google → verify same UUID, decks attached, see "Signed in" announcement.
+   - Repeat with a Google identity already on another account → verify import dialog and resumable clone, see "Imported N decks" announcement.
+3. Pre-flight checks before flipping prod flag:
    - Confirm Supabase Auth → URL Configuration restricts redirect URLs to the prod origin and `localhost:5173`. No wildcards.
    - Confirm Supabase Auth → Rate Limits has the default `anonymous_users` limit enabled (30/hr/IP by default).
-   - Confirm migration applied: `select * from cron.job` shows `cleanup-anon-users`.
-   - Manually invoke the function once to validate end-to-end: `select net.http_post(...)` from SQL Editor, then check `cron.job_run_details` and the Edge Function logs.
-6. Flip `enable_anonymous_sign_ins = true` in the Supabase dashboard for prod.
-7. Set `VITE_ANON_USERS_ENABLED=true` in the prod build env (Vercel).
-8. Watch the first scheduled run in `cron.job_run_details` and the Edge Function logs to confirm it executed cleanly.
+4. Flip `enable_anonymous_sign_ins = true` in the Supabase dashboard for prod.
+5. Set `VITE_ANON_USERS_ENABLED=true` in the prod build env (Vercel).
 
 ## Out of scope follow-ups
 
@@ -424,8 +347,6 @@ No changes. Existing policies (`decks_select_all`, `cards_select_all`, `_insert_
 
 ## References
 
-Supabase auth APIs:
-
 - [Anonymous Sign-Ins guide](https://supabase.com/docs/guides/auth/auth-anonymous) — `signInAnonymously()` semantics, `is_anonymous` JWT claim, conversion paths.
 - [Identity Linking guide](https://supabase.com/docs/guides/auth/auth-identity-linking) — `linkIdentity()` API and conceptual flow.
 - [`linkIdentity` failure modes (community discussion #27061)](https://github.com/orgs/supabase/discussions/27061) — confirms that conflict detection happens server-side during the OAuth callback and is surfaced via `error_code=identity_already_exists` in the redirect URL, not via the original method's promise or `onAuthStateChange`.
@@ -433,15 +354,4 @@ Supabase auth APIs:
 - [`updateUser` anon bug #29350](https://github.com/supabase/supabase/issues/29350) — known bug where single-call `updateUser({ email, password })` works on anon users; do not rely on it.
 - [supabase-js `auth-js` source](https://github.com/supabase/auth-js) — `_acquireLock` serialization confirms calling `signInAnonymously()` from inside an `onAuthStateChange` listener body is safe but not idiomatic.
 
-Cleanup pattern:
-
-- [Supabase Cron module](https://supabase.com/modules/cron) and [pg_cron extension docs](https://supabase.com/docs/guides/database/extensions/pg_cron) — scheduled jobs in Postgres.
-- [pg_net extension](https://supabase.com/docs/guides/database/extensions/pg_net) — async HTTP from SQL, used to invoke the Edge Function.
-- [Scheduling Edge Functions guide](https://supabase.com/docs/guides/functions/schedule-functions) — Supabase's recommended pattern: pg_cron + pg_net → Edge Function with service-role auth.
-- [pg_cron free-tier availability (community discussion #37405)](https://github.com/orgs/supabase/discussions/37405) — confirms no tier gating; "Cron is only limited by the resources it uses CPU/Memory/Disk wise on any tier."
-- [Supabase Vault](https://supabase.com/docs/guides/database/vault) — encrypted secret storage for the project URL and service-role key referenced from the cron job.
-
-Postgres roles and permissions:
-
-- [Supabase Postgres Roles guide](https://supabase.com/docs/guides/database/postgres/roles) — role hierarchy and which schemas each role owns; relevant for understanding why `auth.users` and `auth.sessions` need elevated access.
-- [`SECURITY DEFINER` and search_path injection (Postgres docs)](https://www.postgresql.org/docs/current/sql-createfunction.html#SQL-CREATEFUNCTION-SECURITY) — why `set search_path = ''` plus fully-qualified table references are required.
+Anon-user cleanup research notes (separate doc, deferred from this spec): [`docs/superpowers/handoffs/2026-05-08-anon-user-cleanup-notes.md`](../handoffs/2026-05-08-anon-user-cleanup-notes.md).

--- a/docs/superpowers/specs/2026-05-07-anon-supabase-users-design.md
+++ b/docs/superpowers/specs/2026-05-07-anon-supabase-users-design.md
@@ -241,67 +241,104 @@ enable_anonymous_sign_ins = true
 
 A corresponding toggle in the Supabase dashboard for prod.
 
-### Migration: anonymous-user cleanup
+### Cleanup: pg_cron + pg_net → Edge Function
 
-Two non-obvious gotchas to design around:
+Cleanup uses Supabase's recommended pattern for scheduled work that needs admin privileges: a pg_cron schedule invokes an Edge Function via pg_net, and the Edge Function uses the `service_role` key to call `supabase.auth.admin.deleteUser()` for each stale user.
 
-1. **`postgres` role can't `DELETE` from `auth.users`.** That table is owned by `supabase_auth_admin`. The cron job runs as the role that called `cron.schedule()` (typically `postgres`), so the bare `DELETE` will fail with a permission error. We wrap the delete in a `SECURITY DEFINER` function created by `supabase_auth_admin` and have the cron call the function.
-2. **`auth.users.last_sign_in_at` does not update on token refresh.** A returning anon user whose tokens auto-refresh in the background still has the same `last_sign_in_at` from their initial signin — gating cleanup on this column would reap actively-used accounts at 30 days. The correct activity signal is `auth.sessions.updated_at`, which the auth server bumps whenever a refresh happens.
+Two non-obvious gotchas this design has to handle:
 
-New migration `supabase/migrations/<timestamp>_anon_user_cleanup.sql`:
+1. **`auth.sessions` is owned by `supabase_auth_admin`.** Querying it from PostgREST/RPC requires either elevated SQL access or a `SECURITY DEFINER` helper. We use a small read-only helper rather than going through the admin SQL path.
+2. **`auth.users.last_sign_in_at` does not update on token refresh.** A returning anon user whose tokens auto-refresh in the background still has the same `last_sign_in_at` from their initial sign-in — gating cleanup on this column would reap actively-used accounts at 30 days. The correct activity signal is `auth.sessions.updated_at`, which the auth server bumps on every refresh.
+
+#### Migration: `supabase/migrations/<timestamp>_anon_user_cleanup.sql`
 
 ```sql
 create extension if not exists pg_cron;
+create extension if not exists pg_net;
 
-create or replace function auth.delete_stale_anonymous_users()
-returns integer
-language plpgsql
+-- Read-only helper: returns IDs of anon users with no active session
+-- in the last 30 days. SECURITY DEFINER because auth.sessions is
+-- restricted to supabase_auth_admin.
+create or replace function public.stale_anon_user_ids()
+returns table(id uuid)
+language sql
 security definer
 set search_path = ''
 as $$
-declare
-  deleted_count integer;
-begin
-  with stale as (
-    select u.id
-    from auth.users u
-    where u.is_anonymous is true
-      and u.id is not null
-      and not exists (
-        select 1
-        from auth.sessions s
-        where s.user_id = u.id
-          and s.updated_at > now() - interval '30 days'
-      )
-    limit 1000
-  ),
-  deleted as (
-    delete from auth.users
-    where id in (select id from stale)
-    returning 1
-  )
-  select count(*) into deleted_count from deleted;
-  return deleted_count;
-end;
+  select u.id
+  from auth.users u
+  where u.is_anonymous is true
+    and u.id is not null
+    and not exists (
+      select 1
+      from auth.sessions s
+      where s.user_id = u.id
+        and s.updated_at > now() - interval '30 days'
+    )
+  limit 1000
 $$;
 
--- The function must be owned by supabase_auth_admin so SECURITY DEFINER
--- runs with that role's privileges over auth.users.
-alter function auth.delete_stale_anonymous_users() owner to supabase_auth_admin;
+alter function public.stale_anon_user_ids() owner to supabase_auth_admin;
+grant execute on function public.stale_anon_user_ids() to service_role;
 
+-- Schedule weekly invocation of the Edge Function. Project URL and
+-- service_role key live in Supabase Vault (created via the dashboard
+-- or `select vault.create_secret(...)`).
 select cron.schedule(
-  'delete-stale-anon-users',
+  'cleanup-anon-users',
   '0 3 * * 0',  -- Sundays 03:00 UTC
-  $$ select auth.delete_stale_anonymous_users() $$
+  $$
+    select net.http_post(
+      url := (select decrypted_secret from vault.decrypted_secrets where name = 'project_url')
+             || '/functions/v1/cleanup-anon-users',
+      headers := jsonb_build_object(
+        'Authorization', 'Bearer ' ||
+          (select decrypted_secret from vault.decrypted_secrets where name = 'service_role_key'),
+        'Content-Type', 'application/json'
+      ),
+      body := '{}'::jsonb
+    )
+  $$
 );
+```
+
+The helper is **read-only**: it returns IDs but cannot delete anything. The privilege elevation is narrow — calling it does nothing destructive. Deletion happens in the Edge Function via the admin API.
+
+#### Edge Function: `supabase/functions/cleanup-anon-users/index.ts`
+
+```ts
+import { createClient } from "jsr:@supabase/supabase-js@2";
+
+Deno.serve(async () => {
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+  );
+
+  const { data: ids, error } = await supabase.rpc("stale_anon_user_ids");
+  if (error) {
+    return new Response(JSON.stringify({ error: error.message }), { status: 500 });
+  }
+
+  let deleted = 0;
+  const failures: string[] = [];
+  for (const { id } of ids ?? []) {
+    const { error: delError } = await supabase.auth.admin.deleteUser(id);
+    if (delError) failures.push(`${id}: ${delError.message}`);
+    else deleted++;
+  }
+
+  return new Response(JSON.stringify({ deleted, failures }), { status: 200 });
+});
 ```
 
 Notes:
 
-- The `LIMIT 1000` caps blast radius per run if the predicate is ever wrong; it also keeps the lock window short. Multiple weekly runs will catch up if the backlog grows.
-- `is not null` on `u.id` is defensive against any future schema change that produces NULL ids (paranoid but cheap).
-- `decks.owner_id` already has `on delete cascade`, so deleting the user cascades to decks → cards.
-- We can verify `auth.sessions` retention is long enough for our 30-day threshold; Supabase keeps sessions until `refresh_token` expires (~30+ days on default config), which aligns with the cleanup window.
+- `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are auto-injected into Edge Function runtimes by Supabase — no manual secret setup needed for the function itself.
+- Edge Functions require a valid JWT by default; the cron job's `Authorization: Bearer <service_role_key>` header satisfies that gate, so the function isn't reachable as an anonymous public endpoint.
+- The function returns a JSON summary; pg_net stores the HTTP response in `net._http_response` for inspection.
+- `decks.owner_id` already has `on delete cascade`, so `auth.admin.deleteUser()` cascades to decks → cards.
+- The `LIMIT 1000` in the helper caps blast radius per run; weekly runs will catch up on any backlog.
 
 ### RLS
 
@@ -334,7 +371,8 @@ No changes. Existing policies (`decks_select_all`, `cards_select_all`, `_insert_
 | `src/views/HomeView.tsx` | Trigger first-create dialog on first deck create as anon |
 | `src/views/HomeView.test.tsx` | New cases for the anon-create dialog and resume |
 | `supabase/config.toml` | `enable_anonymous_sign_ins = true` |
-| `supabase/migrations/<ts>_anon_user_cleanup.sql` (new) | `pg_cron` schedule + `SECURITY DEFINER` cleanup function |
+| `supabase/migrations/<ts>_anon_user_cleanup.sql` (new) | Enable `pg_cron` + `pg_net`; create read-only `stale_anon_user_ids()` helper; schedule weekly Edge Function invocation |
+| `supabase/functions/cleanup-anon-users/index.ts` (new) | Deno Edge Function: calls helper, deletes returned IDs via `supabase.auth.admin.deleteUser()` |
 
 ## Testing strategy
 
@@ -353,7 +391,8 @@ No changes. Existing policies (`decks_select_all`, `cards_select_all`, `_insert_
 
 - Behavior of supabase-js's URL detection on a `linkIdentity` failure callback: confirm that no fake "session" event fires when the URL contains `error_code=identity_already_exists`, so AuthCallback's URL parsing is the sole source of truth for the failure branch.
 - `INITIAL_SESSION` event ordering when we synchronously call `signInAnonymously()` from inside the listener. Verified safe (auth-js serializes calls via internal lock), but the slightly more idiomatic alternative is to call `signInAnonymously()` from a `useEffect` after subscribe. Either is acceptable; revisit if the listener-body call produces any odd state transitions in tests.
-- `auth.sessions.updated_at` retention window in Supabase managed config. We assume it stays populated for at least 30 days for active sessions; if Supabase prunes sessions sooner, the cleanup query may reap users whose tokens are still valid. Monitor first month after rollout.
+- `auth.sessions.updated_at` retention window in Supabase managed config. We assume it stays populated for at least 30 days for active sessions; if Supabase prunes sessions sooner, the cleanup may reap users whose tokens are still valid. Monitor first month after rollout.
+- Ownership-transfer permission for `alter function public.stale_anon_user_ids() owner to supabase_auth_admin` from a standard migration. Most Supabase projects allow `postgres` to alter ownership to `supabase_auth_admin` because `postgres` is a member of the relevant role group, but verify on first migration run; if it fails, the alternative is a dashboard-side SQL edit using a more privileged session.
 
 ## Rollout
 
@@ -362,13 +401,18 @@ No changes. Existing policies (`decks_select_all`, `cards_select_all`, `_insert_
    - Boot fresh: anon sign-in, create deck, see first-create dialog.
    - Sign in via Google → verify same UUID, decks attached.
    - Repeat with a Google identity already on another account → verify import dialog and resumable clone.
-3. Pre-flight checks before flipping prod flag:
+3. Deploy the Edge Function: `supabase functions deploy cleanup-anon-users`.
+4. Store secrets in Vault (one-time, via dashboard or `select vault.create_secret(...)`):
+   - `project_url` — e.g., `https://<ref>.supabase.co`
+   - `service_role_key` — copied from the Supabase dashboard
+5. Pre-flight checks before flipping prod flag:
    - Confirm Supabase Auth → URL Configuration restricts redirect URLs to the prod origin and `localhost:5173`. No wildcards.
-   - Confirm Supabase Auth → Rate Limits has the default `anonymous_users` limit enabled (currently 30/hr/IP).
-   - Confirm `pg_cron` migration applied and `select * from cron.job` shows the scheduled job. Run `select auth.delete_stale_anonymous_users();` manually once to validate it executes without permission errors against the live `auth.users` schema.
-4. Flip `enable_anonymous_sign_ins = true` in the Supabase dashboard for prod.
-5. Set `VITE_ANON_USERS_ENABLED=true` in the prod build env (Vercel).
-6. Watch the first scheduled run in `cron.job_run_details` to confirm it executed cleanly.
+   - Confirm Supabase Auth → Rate Limits has the default `anonymous_users` limit enabled (30/hr/IP by default).
+   - Confirm migration applied: `select * from cron.job` shows `cleanup-anon-users`.
+   - Manually invoke the function once to validate end-to-end: `select net.http_post(...)` from SQL Editor, then check `cron.job_run_details` and the Edge Function logs.
+6. Flip `enable_anonymous_sign_ins = true` in the Supabase dashboard for prod.
+7. Set `VITE_ANON_USERS_ENABLED=true` in the prod build env (Vercel).
+8. Watch the first scheduled run in `cron.job_run_details` and the Edge Function logs to confirm it executed cleanly.
 
 ## Out of scope follow-ups
 
@@ -377,3 +421,27 @@ No changes. Existing policies (`decks_select_all`, `cards_select_all`, `_insert_
 - Captcha / additional rate limiting on anonymous sign-in if abuse becomes a concern.
 - Telemetry on conversion rate (anon → real user).
 - **Revisit the public-read RLS posture.** `decks_select_all` and `cards_select_all` use `using (true)`, meaning any authenticated user (including anyone with an anon JWT) can SELECT any deck or card. This is pre-existing — not introduced by this PR — but the anon sign-in feature makes the exposure trivial to discover (one API call to mint an anon JWT, then enumerate). For a hobby app where decks are share-by-link by design this is probably fine, but worth a deliberate decision rather than inheriting it by accident. Track as a separate issue.
+
+## References
+
+Supabase auth APIs:
+
+- [Anonymous Sign-Ins guide](https://supabase.com/docs/guides/auth/auth-anonymous) — `signInAnonymously()` semantics, `is_anonymous` JWT claim, conversion paths.
+- [Identity Linking guide](https://supabase.com/docs/guides/auth/auth-identity-linking) — `linkIdentity()` API and conceptual flow.
+- [`linkIdentity` failure modes (community discussion #27061)](https://github.com/orgs/supabase/discussions/27061) — confirms that conflict detection happens server-side during the OAuth callback and is surfaced via `error_code=identity_already_exists` in the redirect URL, not via the original method's promise or `onAuthStateChange`.
+- [Anonymous user `updateUser` two-step (community discussion #29017)](https://github.com/orgs/supabase/discussions/29017) — Supabase rejects setting a password on an anonymous user before email lands; updates must be sequential.
+- [`updateUser` anon bug #29350](https://github.com/supabase/supabase/issues/29350) — known bug where single-call `updateUser({ email, password })` works on anon users; do not rely on it.
+- [supabase-js `auth-js` source](https://github.com/supabase/auth-js) — `_acquireLock` serialization confirms calling `signInAnonymously()` from inside an `onAuthStateChange` listener body is safe but not idiomatic.
+
+Cleanup pattern:
+
+- [Supabase Cron module](https://supabase.com/modules/cron) and [pg_cron extension docs](https://supabase.com/docs/guides/database/extensions/pg_cron) — scheduled jobs in Postgres.
+- [pg_net extension](https://supabase.com/docs/guides/database/extensions/pg_net) — async HTTP from SQL, used to invoke the Edge Function.
+- [Scheduling Edge Functions guide](https://supabase.com/docs/guides/functions/schedule-functions) — Supabase's recommended pattern: pg_cron + pg_net → Edge Function with service-role auth.
+- [pg_cron free-tier availability (community discussion #37405)](https://github.com/orgs/supabase/discussions/37405) — confirms no tier gating; "Cron is only limited by the resources it uses CPU/Memory/Disk wise on any tier."
+- [Supabase Vault](https://supabase.com/docs/guides/database/vault) — encrypted secret storage for the project URL and service-role key referenced from the cron job.
+
+Postgres roles and permissions:
+
+- [Supabase Postgres Roles guide](https://supabase.com/docs/guides/database/postgres/roles) — role hierarchy and which schemas each role owns; relevant for understanding why `auth.users` and `auth.sessions` need elevated access.
+- [`SECURITY DEFINER` and search_path injection (Postgres docs)](https://www.postgresql.org/docs/current/sql-createfunction.html#SQL-CREATEFUNCTION-SECURITY) — why `set search_path = ''` plus fully-qualified table references are required.

--- a/docs/superpowers/specs/2026-05-07-anon-supabase-users-design.md
+++ b/docs/superpowers/specs/2026-05-07-anon-supabase-users-design.md
@@ -124,7 +124,7 @@ Dialog copy (uses existing `DialogShell` / `DialogHeader`). Note: Supabase does 
 
 The primary action is the styled button; "Skip" is a tertiary text-link styled to be visually de-emphasized so a hurried user can't equate it with the import action. The destructive consequence is named explicitly above the buttons.
 
-- **Import branch:** Persist `{ anonUuid, importedDeckIds: [] }` under `localStorage.dndCards.pendingAnonImport`, then `signOut()` and `signInWithOAuth({ provider })`. After OAuth lands the user as the existing real user, `anonImport.tryResume()` runs (see invocation rules below): SELECT decks where `owner_id = anonUuid` (public read), then SELECT their cards. For each deck not already in `importedDeckIds`: INSERT a new deck owned by the current user with the same name; INSERT clones of its cards under the new deck id; append the original deck id to `importedDeckIds` and persist back to localStorage. When the list is complete, clear the key. Toast "Imported N decks."
+- **Import branch:** Persist `{ anonUuid, importedDeckIds: [] }` under `localStorage.dndCards.pendingAnonImport`, then `signOut()` and `signInWithOAuth({ provider })`. After OAuth lands the user as the existing real user, `anonImport.tryResume()` runs (see invocation rules below): SELECT decks where `owner_id = anonUuid` (public read), then SELECT their cards. For each deck not already in `importedDeckIds`: INSERT a new deck owned by the current user with the same name; INSERT clones of its cards under the new deck id; append the original deck id to `importedDeckIds` and persist back to localStorage. When the list is complete, clear the key. The user lands on `next` and sees an Announcement: "Imported N decks."
 - **Sign in without importing branch:** `signOut()` and `signInWithOAuth({ provider })`. localStorage is not touched. The anon's decks are abandoned.
 
 In both branches of this dialog the user goes through OAuth twice (once for the failed link, once for the actual sign-in). That's unavoidable: linkIdentity needs a real OAuth round-trip to discover the conflict, and we can't reuse the failed attempt as a sign-in. The deck-count branch above keeps this 2-round-trip path confined to the case where there's actually data to merge — which is precisely when the user wants the dialog anyway.
@@ -232,8 +232,23 @@ Behavior:
 
 - Renders a single message at the top of its container (above the deck list when triggered from HomeView; above the page content otherwise).
 - Auto-dismisses after ~5 seconds; user can also dismiss via a small ✕ button.
-- Implemented as a controlled component: parent passes `message` and `onDismiss`. State for "show me an announcement on next render" is held in a small `AnnouncementContext` keyed off router state, so triggering an announcement from `AuthCallback` and rendering it on the destination view doesn't require global state plumbing.
 - Accessible: `role="status"` with `aria-live="polite"` so the message is announced to screen readers without interrupting them.
+
+API surface (in `Announcement.tsx`):
+
+```ts
+export function AnnouncementProvider(props: { children: ReactNode }): JSX.Element;
+
+// Set the next announcement to render. Call from AuthCallback before navigating.
+// The announcement renders the next time <Announcement /> mounts (on the destination view).
+export function useSetNextAnnouncement(): (message: string | null) => void;
+
+// Render the active announcement (if any) at this location.
+// Place inside HomeView (above deck list) and inside the LoginView for auth flows that stay on /login.
+export function Announcement(): JSX.Element | null;
+```
+
+State lives in a small in-memory context (no router-state coupling needed): `useSetNextAnnouncement` writes to a ref-backed slot; `<Announcement />` reads it on mount, displays it, and clears the slot. Surviving an OAuth round-trip is not needed because all current call sites set the announcement *after* the OAuth round-trip is complete (during `AuthCallback` rendering).
 
 Scope is deliberately small — this is not a queueable toast system. One message at a time, replaced if a new one is set. If we ever need a queue or multiple stacking notifications, we revisit.
 
@@ -285,13 +300,13 @@ No changes. Existing policies (`decks_select_all`, `cards_select_all`, `_insert_
 | `src/auth/AuthProvider.tsx` | Modify `INITIAL_SESSION` handler to call `signInAnonymously()` and stay loading |
 | `src/auth/AuthProvider.test.tsx` | New cases for the flag-on path |
 | `src/lib/ui/UserMenu.tsx` | Branch on `is_anonymous` for the CTA pill |
-| `src/lib/ui/UserMenu.module.css` | Pill button styling (or reuse `Button` accent variant) |
+| `src/lib/ui/UserMenu.module.css` | New `.pillCta` class for the accent pill button |
 | `src/lib/ui/UserMenu.test.tsx` | New cases for anon CTA |
 | `src/auth/LoginView.tsx` | OAuth buttons branch on anon deck count: 0 → `signInWithOAuth`; ≥1 → `linkIdentity`. Dev path uses `updateUser` |
 | `src/auth/LoginView.test.tsx` | New cases for the link path |
 | `src/auth/AuthCallback.tsx` | Parse callback URL hash/query for `error_code=identity_already_exists`; open import dialog. Render import progress when `pendingAnonImport` exists. |
 | `src/auth/AuthCallback.test.tsx` | New cases for the failure path and dialog |
-| `src/auth/anonImport.ts` (new) | Pure module: stash, resume, clear `pendingAnonImport` |
+| `src/auth/anonImport.ts` (new) | Pure module exporting `stash(payload)`, `tryResume()`, `clear()`, and the `PendingAnonImport` type. Manages the `localStorage.dndCards.pendingAnonImport` key. |
 | `src/auth/anonImport.test.ts` (new) | Unit tests including resumable interruption |
 | `src/views/FirstDeckDialog.tsx` (new) | Modal explainer using `DialogShell` |
 | `src/views/FirstDeckDialog.test.tsx` (new) | First-create-only behavior |

--- a/docs/superpowers/specs/2026-05-07-anon-supabase-users-design.md
+++ b/docs/superpowers/specs/2026-05-07-anon-supabase-users-design.md
@@ -108,12 +108,14 @@ User is anon with N decks. Clicks "Sign in to save your work" in the header CTA.
 
 ### Already-linked branch: linkIdentity fails (anon has decks, existing account on this provider)
 
-If the user's OAuth identity is already attached to a different account, `linkIdentity` returns an error on the callback. We don't pin to a specific error code — any failure routes to the same dialog. The user is still anon (linking failed; session is unchanged).
+If the user's OAuth identity is already attached to a different account, the OAuth callback URL comes back with `error_code=identity_already_exists` and an `error_description` query/hash param. The error is **not** surfaced via `onAuthStateChange` and **not** thrown by the original `linkIdentity()` call — it lives only in the callback URL. `AuthCallback` must explicitly parse the URL to detect this case (anything other than `error_code === "identity_already_exists"` we treat as a generic OAuth failure; see "OAuth failure modes" below).
 
-Dialog copy (uses existing `DialogShell` / `DialogHeader`). The conflicting email is read from the failed-link response (Supabase exposes the OAuth identity's email even on link failure):
+The user remains anon (linking failed; session is unchanged), so RLS continues to permit reading their decks and cards.
+
+Dialog copy (uses existing `DialogShell` / `DialogHeader`). Note: Supabase does **not** expose the conflicting account's email in the failure response, so the dialog can't name it directly:
 
 > **You already have a dnd-cards account**
-> Looks like {email} is already signed up here. Want to bring your N decks into that account?
+> An account on dnd-cards is already linked to that Google identity. Want to bring your N decks into it?
 >
 > If you skip, those decks will be left behind and deleted after 30 days. They cannot be recovered.
 >
@@ -180,10 +182,11 @@ Beyond the already-linked branch, `linkIdentity` and `signInWithOAuth` can fail 
 
 The existing dev sign-in button does `signInWithPassword(DEV_EMAIL, DEV_PASSWORD)` and on first run does `signUp(...)`. With anon-as-default the user is already anon when they click it. The new path:
 
-1. Try `updateUser({ email: DEV_EMAIL, password: DEV_PASSWORD })` — upgrades the anon user in place, preserving the UUID and decks.
-2. On error (e.g., email already exists from a previous dev session): `signOut()` then `signInWithPassword(...)`. Decks are abandoned, same as today.
+1. Call `updateUser({ email: DEV_EMAIL })`. With `enable_confirmations = false` in `supabase/config.toml`, this auto-sets `email_confirmed_at` and flips `is_anonymous` to false synchronously, preserving the UUID and decks.
+2. **Then** call `updateUser({ password: DEV_PASSWORD })` as a separate call — Supabase rejects setting a password on an anonymous user before the email lands, so the two updates must be sequential, not bundled into one call.
+3. On error from either step (e.g., email already exists from a previous dev session): `signOut()` then `signInWithPassword(...)`. Decks are abandoned, same as today.
 
-`enable_confirmations = false` in `supabase/config.toml` already lets `updateUser` complete without an email round-trip locally.
+The single-call path (`updateUser({ email, password })` in one go) appears to work in some Supabase versions due to a known bug; do not rely on it.
 
 ## UI changes
 
@@ -240,23 +243,65 @@ A corresponding toggle in the Supabase dashboard for prod.
 
 ### Migration: anonymous-user cleanup
 
+Two non-obvious gotchas to design around:
+
+1. **`postgres` role can't `DELETE` from `auth.users`.** That table is owned by `supabase_auth_admin`. The cron job runs as the role that called `cron.schedule()` (typically `postgres`), so the bare `DELETE` will fail with a permission error. We wrap the delete in a `SECURITY DEFINER` function created by `supabase_auth_admin` and have the cron call the function.
+2. **`auth.users.last_sign_in_at` does not update on token refresh.** A returning anon user whose tokens auto-refresh in the background still has the same `last_sign_in_at` from their initial signin — gating cleanup on this column would reap actively-used accounts at 30 days. The correct activity signal is `auth.sessions.updated_at`, which the auth server bumps whenever a refresh happens.
+
 New migration `supabase/migrations/<timestamp>_anon_user_cleanup.sql`:
 
 ```sql
 create extension if not exists pg_cron;
 
+create or replace function auth.delete_stale_anonymous_users()
+returns integer
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  deleted_count integer;
+begin
+  with stale as (
+    select u.id
+    from auth.users u
+    where u.is_anonymous is true
+      and u.id is not null
+      and not exists (
+        select 1
+        from auth.sessions s
+        where s.user_id = u.id
+          and s.updated_at > now() - interval '30 days'
+      )
+    limit 1000
+  ),
+  deleted as (
+    delete from auth.users
+    where id in (select id from stale)
+    returning 1
+  )
+  select count(*) into deleted_count from deleted;
+  return deleted_count;
+end;
+$$;
+
+-- The function must be owned by supabase_auth_admin so SECURITY DEFINER
+-- runs with that role's privileges over auth.users.
+alter function auth.delete_stale_anonymous_users() owner to supabase_auth_admin;
+
 select cron.schedule(
   'delete-stale-anon-users',
   '0 3 * * 0',  -- Sundays 03:00 UTC
-  $$
-    delete from auth.users
-    where is_anonymous = true
-      and last_sign_in_at < now() - interval '30 days'
-  $$
+  $$ select auth.delete_stale_anonymous_users() $$
 );
 ```
 
-`decks.owner_id` already has `on delete cascade`, so deleting the user cascades to decks → cards.
+Notes:
+
+- The `LIMIT 1000` caps blast radius per run if the predicate is ever wrong; it also keeps the lock window short. Multiple weekly runs will catch up if the backlog grows.
+- `is not null` on `u.id` is defensive against any future schema change that produces NULL ids (paranoid but cheap).
+- `decks.owner_id` already has `on delete cascade`, so deleting the user cascades to decks → cards.
+- We can verify `auth.sessions` retention is long enough for our 30-day threshold; Supabase keeps sessions until `refresh_token` expires (~30+ days on default config), which aligns with the cleanup window.
 
 ### RLS
 
@@ -280,7 +325,7 @@ No changes. Existing policies (`decks_select_all`, `cards_select_all`, `_insert_
 | `src/lib/ui/UserMenu.test.tsx` | New cases for anon CTA |
 | `src/auth/LoginView.tsx` | OAuth buttons branch on anon deck count: 0 → `signInWithOAuth`; ≥1 → `linkIdentity`. Dev path uses `updateUser` |
 | `src/auth/LoginView.test.tsx` | New cases for the link path |
-| `src/auth/AuthCallback.tsx` | Detect `linkIdentity` failure; open import dialog |
+| `src/auth/AuthCallback.tsx` | Parse callback URL hash/query for `error_code=identity_already_exists`; open import dialog. Render import progress when `pendingAnonImport` exists. |
 | `src/auth/AuthCallback.test.tsx` | New cases for the failure path and dialog |
 | `src/auth/anonImport.ts` (new) | Pure module: stash, resume, clear `pendingAnonImport` |
 | `src/auth/anonImport.test.ts` (new) | Unit tests including resumable interruption |
@@ -289,7 +334,7 @@ No changes. Existing policies (`decks_select_all`, `cards_select_all`, `_insert_
 | `src/views/HomeView.tsx` | Trigger first-create dialog on first deck create as anon |
 | `src/views/HomeView.test.tsx` | New cases for the anon-create dialog and resume |
 | `supabase/config.toml` | `enable_anonymous_sign_ins = true` |
-| `supabase/migrations/<ts>_anon_user_cleanup.sql` (new) | `pg_cron` schedule |
+| `supabase/migrations/<ts>_anon_user_cleanup.sql` (new) | `pg_cron` schedule + `SECURITY DEFINER` cleanup function |
 
 ## Testing strategy
 
@@ -306,9 +351,9 @@ No changes. Existing policies (`decks_select_all`, `cards_select_all`, `_insert_
 
 ## Open verification items (deferred to implementation)
 
-- Exact error code/message returned by `linkIdentity` when the OAuth identity is on a different account. Implementation will catch any error and route to the dialog rather than match a specific code; revisit if the error is also raised in benign cases.
-- `INITIAL_SESSION` event ordering when we synchronously call `signInAnonymously()` from inside the listener. Acceptable fallback: call `signInAnonymously()` from a `useEffect` after subscribe rather than inside the listener body.
-- `updateUser({ email, password })` on an anon user under local config (`enable_confirmations = false`). Expected to complete without email confirmation; verify on first manual run.
+- Behavior of supabase-js's URL detection on a `linkIdentity` failure callback: confirm that no fake "session" event fires when the URL contains `error_code=identity_already_exists`, so AuthCallback's URL parsing is the sole source of truth for the failure branch.
+- `INITIAL_SESSION` event ordering when we synchronously call `signInAnonymously()` from inside the listener. Verified safe (auth-js serializes calls via internal lock), but the slightly more idiomatic alternative is to call `signInAnonymously()` from a `useEffect` after subscribe. Either is acceptable; revisit if the listener-body call produces any odd state transitions in tests.
+- `auth.sessions.updated_at` retention window in Supabase managed config. We assume it stays populated for at least 30 days for active sessions; if Supabase prunes sessions sooner, the cleanup query may reap users whose tokens are still valid. Monitor first month after rollout.
 
 ## Rollout
 
@@ -317,13 +362,18 @@ No changes. Existing policies (`decks_select_all`, `cards_select_all`, `_insert_
    - Boot fresh: anon sign-in, create deck, see first-create dialog.
    - Sign in via Google → verify same UUID, decks attached.
    - Repeat with a Google identity already on another account → verify import dialog and resumable clone.
-3. Flip `enable_anonymous_sign_ins = true` in the Supabase dashboard for prod.
-4. Set `VITE_ANON_USERS_ENABLED=true` in the prod build env (Vercel).
-5. Verify `pg_cron` schedule landed and runs once before relying on it.
+3. Pre-flight checks before flipping prod flag:
+   - Confirm Supabase Auth → URL Configuration restricts redirect URLs to the prod origin and `localhost:5173`. No wildcards.
+   - Confirm Supabase Auth → Rate Limits has the default `anonymous_users` limit enabled (currently 30/hr/IP).
+   - Confirm `pg_cron` migration applied and `select * from cron.job` shows the scheduled job. Run `select auth.delete_stale_anonymous_users();` manually once to validate it executes without permission errors against the live `auth.users` schema.
+4. Flip `enable_anonymous_sign_ins = true` in the Supabase dashboard for prod.
+5. Set `VITE_ANON_USERS_ENABLED=true` in the prod build env (Vercel).
+6. Watch the first scheduled run in `cron.job_run_details` to confirm it executed cleanly.
 
 ## Out of scope follow-ups
 
 - "Clear my work" action for anon users who want to reset (e.g., sharing a device).
 - Per-deck "local only" badge after sign-in if a future feature lets users have a mix of synced and local decks.
-- Captcha / rate limiting on anonymous sign-in if abuse becomes a concern.
+- Captcha / additional rate limiting on anonymous sign-in if abuse becomes a concern.
 - Telemetry on conversion rate (anon → real user).
+- **Revisit the public-read RLS posture.** `decks_select_all` and `cards_select_all` use `using (true)`, meaning any authenticated user (including anyone with an anon JWT) can SELECT any deck or card. This is pre-existing — not introduced by this PR — but the anon sign-in feature makes the exposure trivial to discover (one API call to mint an anon JWT, then enumerate). For a hobby app where decks are share-by-link by design this is probably fine, but worth a deliberate decision rather than inheriting it by accident. Track as a separate issue.

--- a/src/app/Root.tsx
+++ b/src/app/Root.tsx
@@ -1,4 +1,5 @@
 import { Link, Outlet } from "@tanstack/react-router";
+import { Announcement, AnnouncementProvider } from "../lib/ui/Announcement";
 import { GitHubLogo } from "../lib/ui/icons/GitHubLogo";
 import { UserMenu } from "../lib/ui/UserMenu";
 import { DeckBreadcrumb } from "./DeckBreadcrumb";
@@ -8,26 +9,29 @@ const REPO_URL = "https://github.com/ChristopherChudzicki/dnd-cards";
 
 export function Root() {
   return (
-    <div className={styles.shell}>
-      <header className={styles.header}>
-        <Link to="/" className={styles.brand}>
-          D&amp;D Cards
-        </Link>
-        <DeckBreadcrumb />
-        <a
-          href={REPO_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={styles.iconLink}
-          aria-label="View source on GitHub"
-        >
-          <GitHubLogo size={20} />
-        </a>
-        <UserMenu />
-      </header>
-      <main className={styles.main}>
-        <Outlet />
-      </main>
-    </div>
+    <AnnouncementProvider>
+      <div className={styles.shell}>
+        <header className={styles.header}>
+          <Link to="/" className={styles.brand}>
+            D&amp;D Cards
+          </Link>
+          <DeckBreadcrumb />
+          <a
+            href={REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.iconLink}
+            aria-label="View source on GitHub"
+          >
+            <GitHubLogo size={20} />
+          </a>
+          <UserMenu />
+        </header>
+        <main className={styles.main}>
+          <Announcement />
+          <Outlet />
+        </main>
+      </div>
+    </AnnouncementProvider>
   );
 }

--- a/src/auth/AuthCallback.test.tsx
+++ b/src/auth/AuthCallback.test.tsx
@@ -1,9 +1,12 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { supabase } from "../api/supabase";
-import { signInTestUser } from "../test/signInTestUser";
+import { AnnouncementProvider } from "../lib/ui/Announcement";
 import { AuthCallback } from "./AuthCallback";
-import { AuthProvider } from "./AuthProvider";
+import { SessionContext, type SessionState } from "./useSession";
 
 const navigate = vi.fn();
 vi.mock("@tanstack/react-router", async () => {
@@ -12,45 +15,158 @@ vi.mock("@tanstack/react-router", async () => {
   return { ...actual, useNavigate: () => navigate };
 });
 
+function wrap(ui: ReactNode, session: SessionState) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <QueryClientProvider client={client}>
+      <AnnouncementProvider>
+        <SessionContext.Provider value={session}>{ui}</SessionContext.Provider>
+      </AnnouncementProvider>
+    </QueryClientProvider>
+  );
+}
+
+function setLocation(opts: { hash?: string; search?: string; origin?: string }) {
+  Object.defineProperty(window, "location", {
+    writable: true,
+    value: {
+      ...window.location,
+      origin: opts.origin ?? "http://localhost:5173",
+      hash: opts.hash ?? "",
+      search: opts.search ?? "",
+    },
+  });
+}
+
 describe("AuthCallback", () => {
-  const originalLocation = window.location;
-
-  beforeEach(async () => {
-    await supabase.auth.signOut();
+  beforeEach(() => {
     navigate.mockClear();
+    window.localStorage.clear();
   });
-
   afterEach(() => {
-    // Restore window.location after any test that mutated it.
-    Object.defineProperty(window, "location", {
-      value: originalLocation,
-      writable: true,
-      configurable: true,
-    });
+    vi.restoreAllMocks();
   });
 
-  it("renders a loading state while the SDK exchanges the code", () => {
-    render(<AuthCallback />);
-    expect(screen.getByText(/signing you in/i)).toBeInTheDocument();
+  it("opens ImportAccountDialog when URL has error_code=identity_already_exists and user is anon with decks", async () => {
+    setLocation({
+      hash: "#error=invalid_request&error_code=identity_already_exists&error_description=Identity+is+already+linked+to+another+user",
+    });
+    vi.spyOn(supabase, "from").mockReturnValue({
+      select: () => ({
+        eq: () => Promise.resolve({ data: [{ id: "d1" }, { id: "d2" }], error: null }),
+      }),
+    } as never);
+    render(
+      wrap(<AuthCallback />, {
+        status: "authenticated",
+        user: { id: "anon-1", is_anonymous: true } as never,
+        session: {} as never,
+      }),
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: /you already have a dnd-cards account/i }),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /yes, import 2 decks/i })).toBeInTheDocument();
   });
 
-  it("navigates to ?next= once a session is present", async () => {
-    Object.defineProperty(window, "location", {
-      value: { ...originalLocation, search: "?next=%2Fdeck%2Fabc" },
-      writable: true,
-      configurable: true,
-    });
-
-    await signInTestUser();
+  it("on import click: stashes pendingAnonImport, signs out, signInWithOAuth with stashed provider", async () => {
+    setLocation({ hash: "#error_code=identity_already_exists", search: "?next=/" });
+    window.localStorage.setItem("dndCards.lastProvider", "github");
+    vi.spyOn(supabase, "from").mockReturnValue({
+      select: () => ({ eq: () => Promise.resolve({ data: [{ id: "d1" }], error: null }) }),
+    } as never);
+    const signOutSpy = vi
+      .spyOn(supabase.auth, "signOut")
+      .mockResolvedValue({ error: null } as never);
+    const oauthSpy = vi
+      .spyOn(supabase.auth, "signInWithOAuth")
+      .mockResolvedValue({ data: {}, error: null } as never);
 
     render(
-      <AuthProvider>
-        <AuthCallback />
-      </AuthProvider>,
+      wrap(<AuthCallback />, {
+        status: "authenticated",
+        user: { id: "anon-1", is_anonymous: true } as never,
+        session: {} as never,
+      }),
     );
+    await userEvent.click(await screen.findByRole("button", { name: /yes, import 1 decks/i }));
+    const stash = window.localStorage.getItem("dndCards.pendingAnonImport");
+    expect(stash).not.toBeNull();
+    expect(JSON.parse(stash as string)).toMatchObject({ anonUuid: "anon-1", importedDeckIds: [] });
+    expect(signOutSpy).toHaveBeenCalled();
+    expect(oauthSpy).toHaveBeenCalledWith(expect.objectContaining({ provider: "github" }));
+  });
 
-    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: "/deck/abc" }), {
-      timeout: 1500,
-    });
+  it("on skip click: signs out and signInWithOAuth, no stash", async () => {
+    setLocation({ hash: "#error_code=identity_already_exists" });
+    vi.spyOn(supabase, "from").mockReturnValue({
+      select: () => ({ eq: () => Promise.resolve({ data: [{ id: "d1" }], error: null }) }),
+    } as never);
+    const signOutSpy = vi
+      .spyOn(supabase.auth, "signOut")
+      .mockResolvedValue({ error: null } as never);
+    const oauthSpy = vi
+      .spyOn(supabase.auth, "signInWithOAuth")
+      .mockResolvedValue({ data: {}, error: null } as never);
+
+    render(
+      wrap(<AuthCallback />, {
+        status: "authenticated",
+        user: { id: "anon-1", is_anonymous: true } as never,
+        session: {} as never,
+      }),
+    );
+    await userEvent.click(
+      await screen.findByRole("button", { name: /skip — leave decks behind/i }),
+    );
+    expect(window.localStorage.getItem("dndCards.pendingAnonImport")).toBeNull();
+    expect(signOutSpy).toHaveBeenCalled();
+    expect(oauthSpy).toHaveBeenCalled();
+  });
+
+  it("on clean success (non-anon authenticated, no error, no pending): navigates to next and clears lastProvider", async () => {
+    setLocation({ search: "?next=/some/path" });
+    window.localStorage.setItem("dndCards.lastProvider", "google");
+    render(
+      wrap(<AuthCallback />, {
+        status: "authenticated",
+        user: { id: "real-1", is_anonymous: false, email: "x@y.z" } as never,
+        session: {} as never,
+      }),
+    );
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: "/some/path" }));
+    expect(window.localStorage.getItem("dndCards.lastProvider")).toBeNull();
+  });
+
+  it("when pendingAnonImport exists and session is non-anon: runs import then navigates", async () => {
+    window.localStorage.setItem(
+      "dndCards.pendingAnonImport",
+      JSON.stringify({ version: 1, anonUuid: "anon-1", importedDeckIds: [] }),
+    );
+    setLocation({});
+    vi.spyOn(supabase, "from").mockReturnValue({
+      select: () => ({
+        eq: (col: string) =>
+          col === "owner_id"
+            ? Promise.resolve({ data: [{ id: "d1", name: "Goblins" }], error: null })
+            : Promise.resolve({ data: [{ position: 0, payload: {} }], error: null }),
+      }),
+      insert: () => ({
+        select: () => ({
+          single: () => Promise.resolve({ data: { id: "new-deck" }, error: null }),
+        }),
+      }),
+    } as never);
+    render(
+      wrap(<AuthCallback />, {
+        status: "authenticated",
+        user: { id: "real-1", is_anonymous: false, email: "x@y.z" } as never,
+        session: {} as never,
+      }),
+    );
+    await waitFor(() => expect(navigate).toHaveBeenCalled());
+    expect(window.localStorage.getItem("dndCards.pendingAnonImport")).toBeNull();
   });
 });

--- a/src/auth/AuthCallback.test.tsx
+++ b/src/auth/AuthCallback.test.tsx
@@ -91,7 +91,7 @@ describe("AuthCallback", () => {
         session: {} as never,
       }),
     );
-    await userEvent.click(await screen.findByRole("button", { name: /yes, import 1 decks/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /yes, import 1 deck$/i }));
     const stash = window.localStorage.getItem("dndCards.pendingAnonImport");
     expect(stash).not.toBeNull();
     expect(JSON.parse(stash as string)).toMatchObject({ anonUuid: "anon-1", importedDeckIds: [] });

--- a/src/auth/AuthCallback.test.tsx
+++ b/src/auth/AuthCallback.test.tsx
@@ -124,7 +124,7 @@ describe("AuthCallback", () => {
         session: {} as never,
       }),
     );
-    await userEvent.click(await screen.findByRole("button", { name: /close/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /^cancel$/i }));
 
     await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: "/" }));
     expect(signOutSpy).not.toHaveBeenCalled();

--- a/src/auth/AuthCallback.test.tsx
+++ b/src/auth/AuthCallback.test.tsx
@@ -105,6 +105,32 @@ describe("AuthCallback", () => {
     expect(oauthSpy).toHaveBeenCalledWith(expect.objectContaining({ provider: "github" }));
   });
 
+  it("on dismiss (X / Esc): navigates without signOut or signInWithOAuth", async () => {
+    setLocation({ hash: "#error_code=identity_already_exists" });
+    vi.spyOn(supabase, "from").mockReturnValue({
+      select: () => ({ eq: () => Promise.resolve({ data: [{ id: "d1" }], error: null }) }),
+    } as never);
+    const signOutSpy = vi
+      .spyOn(supabase.auth, "signOut")
+      .mockResolvedValue({ error: null } as never);
+    const oauthSpy = vi
+      .spyOn(supabase.auth, "signInWithOAuth")
+      .mockResolvedValue({ data: {}, error: null } as never);
+
+    render(
+      wrap(<AuthCallback />, {
+        status: "authenticated",
+        user: { id: "anon-1", is_anonymous: true } as never,
+        session: {} as never,
+      }),
+    );
+    await userEvent.click(await screen.findByRole("button", { name: /close/i }));
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: "/" }));
+    expect(signOutSpy).not.toHaveBeenCalled();
+    expect(oauthSpy).not.toHaveBeenCalled();
+  });
+
   it("on skip click: signs out and signInWithOAuth, no stash", async () => {
     setLocation({ hash: "#error_code=identity_already_exists" });
     vi.spyOn(supabase, "from").mockReturnValue({

--- a/src/auth/AuthCallback.test.tsx
+++ b/src/auth/AuthCallback.test.tsx
@@ -26,6 +26,8 @@ function wrap(ui: ReactNode, session: SessionState) {
   );
 }
 
+let originalLocation: PropertyDescriptor | undefined;
+
 function setLocation(opts: { hash?: string; search?: string; origin?: string }) {
   Object.defineProperty(window, "location", {
     writable: true,
@@ -40,10 +42,14 @@ function setLocation(opts: { hash?: string; search?: string; origin?: string }) 
 
 describe("AuthCallback", () => {
   beforeEach(() => {
+    originalLocation = Object.getOwnPropertyDescriptor(window, "location");
     navigate.mockClear();
     window.localStorage.clear();
   });
   afterEach(() => {
+    if (originalLocation) {
+      Object.defineProperty(window, "location", originalLocation);
+    }
     vi.restoreAllMocks();
   });
 

--- a/src/auth/AuthCallback.tsx
+++ b/src/auth/AuthCallback.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { supabase } from "../api/supabase";
+import { pluralize } from "../lib/pluralize";
 import { useSetNextAnnouncement } from "../lib/ui/Announcement";
 import { clear, readPending, stash, tryResume } from "./anonImport";
 import { ImportAccountDialog } from "./ImportAccountDialog";
@@ -69,10 +70,10 @@ export function AuthCallback() {
           });
           if (cancelled) return;
           if (result.kind === "completed" && result.importedCount > 0) {
-            setAnnouncement(`Imported ${result.importedCount} decks`);
+            setAnnouncement(`Imported ${pluralize(result.importedCount, "deck")}`);
           } else if (result.kind === "partial") {
             setAnnouncement(
-              `Imported ${result.importedCount} of ${result.total} decks. We'll try again next time you sign in.`,
+              `Imported ${result.importedCount} of ${pluralize(result.total, "deck")}. We'll try again next time you sign in.`,
             );
           }
           window.localStorage.removeItem("dndCards.lastProvider");

--- a/src/auth/AuthCallback.tsx
+++ b/src/auth/AuthCallback.tsx
@@ -1,20 +1,132 @@
 import { useNavigate } from "@tanstack/react-router";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import { supabase } from "../api/supabase";
+import { useSetNextAnnouncement } from "../lib/ui/Announcement";
+import { clear, readPending, stash, tryResume } from "./anonImport";
+import { ImportAccountDialog } from "./ImportAccountDialog";
 import { useSession } from "./useSession";
+
+function parseLinkError(): string | null {
+  const hash = new URLSearchParams(window.location.hash.replace(/^#/, ""));
+  const search = new URLSearchParams(window.location.search);
+  return hash.get("error_code") ?? search.get("error_code");
+}
+
+function getNextPath(): string {
+  return new URLSearchParams(window.location.search).get("next") ?? "/";
+}
+
+function lastProvider(): "google" | "github" {
+  const v = window.localStorage.getItem("dndCards.lastProvider");
+  return v === "github" ? "github" : "google";
+}
 
 export function AuthCallback() {
   const navigate = useNavigate();
   const session = useSession();
+  const setAnnouncement = useSetNextAnnouncement();
+
+  const [phase, setPhase] = useState<"checking" | "importing" | "dialog" | "error">("checking");
+  const [deckCount, setDeckCount] = useState(0);
+  const [progress, setProgress] = useState({ imported: 0, total: 0 });
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
     if (session.status !== "authenticated") return;
-    const next = new URLSearchParams(window.location.search).get("next") ?? "/";
-    navigate({ to: next });
-  }, [session.status, navigate]);
 
-  // AuthProvider handles the URL-based session detection via
-  // onAuthStateChange (which the supabase client fires on its own
-  // when detectSessionInUrl is true, the SDK default).
+    const linkError = parseLinkError();
+    if (linkError === "identity_already_exists" && session.user.is_anonymous) {
+      void (async () => {
+        const { data } = await supabase.from("decks").select("id").eq("owner_id", session.user.id);
+        setDeckCount(data?.length ?? 0);
+        setPhase("dialog");
+      })();
+      return;
+    }
+
+    if (linkError) {
+      setErrorMessage("Sign-in didn't complete. Please try again.");
+      setPhase("error");
+      return;
+    }
+
+    const pending = readPending();
+    if (pending && !session.user.is_anonymous) {
+      setPhase("importing");
+      void (async () => {
+        try {
+          const result = await tryResume({
+            supabase,
+            currentUserId: session.user.id,
+            onProgress: (imported, total) => setProgress({ imported, total }),
+          });
+          if (result.kind === "completed" && result.importedCount > 0) {
+            setAnnouncement(`Imported ${result.importedCount} decks`);
+          } else if (result.kind === "partial") {
+            setAnnouncement(
+              `Imported ${result.importedCount} of ${result.total} decks. We'll try again next time you sign in.`,
+            );
+          }
+          window.localStorage.removeItem("dndCards.lastProvider");
+          navigate({ to: getNextPath() });
+        } catch {
+          setAnnouncement(
+            "Couldn't finish importing your decks. We'll try again next time you sign in.",
+          );
+          navigate({ to: getNextPath() });
+        }
+      })();
+      return;
+    }
+
+    if (!session.user.is_anonymous) {
+      setAnnouncement("Signed in");
+      window.localStorage.removeItem("dndCards.lastProvider");
+    }
+    navigate({ to: getNextPath() });
+  }, [session, navigate, setAnnouncement]);
+
+  const onImport = async () => {
+    if (session.status !== "authenticated") return;
+    stash({ version: 1, anonUuid: session.user.id, importedDeckIds: [] });
+    const next = getNextPath();
+    const redirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`;
+    const provider = lastProvider();
+    await supabase.auth.signOut();
+    await supabase.auth.signInWithOAuth({ provider, options: { redirectTo } });
+  };
+
+  const onSkip = async () => {
+    clear();
+    const next = getNextPath();
+    const redirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`;
+    const provider = lastProvider();
+    await supabase.auth.signOut();
+    await supabase.auth.signInWithOAuth({ provider, options: { redirectTo } });
+  };
+
+  if (phase === "dialog") {
+    return <ImportAccountDialog isOpen deckCount={deckCount} onImport={onImport} onSkip={onSkip} />;
+  }
+
+  if (phase === "importing") {
+    return (
+      <section style={{ textAlign: "center", padding: "4rem" }} role="status" aria-live="polite">
+        <h2>Bringing your decks over</h2>
+        <p>
+          Imported {progress.imported} of {progress.total} decks…
+        </p>
+      </section>
+    );
+  }
+
+  if (phase === "error") {
+    return (
+      <section style={{ textAlign: "center", padding: "4rem" }}>
+        <p>{errorMessage}</p>
+      </section>
+    );
+  }
 
   return (
     <section style={{ textAlign: "center", padding: "4rem" }}>

--- a/src/auth/AuthCallback.tsx
+++ b/src/auth/AuthCallback.tsx
@@ -33,15 +33,19 @@ export function AuthCallback() {
 
   useEffect(() => {
     if (session.status !== "authenticated") return;
+    let cancelled = false;
 
     const linkError = parseLinkError();
     if (linkError === "identity_already_exists" && session.user.is_anonymous) {
       void (async () => {
         const { data } = await supabase.from("decks").select("id").eq("owner_id", session.user.id);
+        if (cancelled) return;
         setDeckCount(data?.length ?? 0);
         setPhase("dialog");
       })();
-      return;
+      return () => {
+        cancelled = true;
+      };
     }
 
     if (linkError) {
@@ -58,8 +62,12 @@ export function AuthCallback() {
           const result = await tryResume({
             supabase,
             currentUserId: session.user.id,
-            onProgress: (imported, total) => setProgress({ imported, total }),
+            onProgress: (imported, total) => {
+              if (cancelled) return;
+              setProgress({ imported, total });
+            },
           });
+          if (cancelled) return;
           if (result.kind === "completed" && result.importedCount > 0) {
             setAnnouncement(`Imported ${result.importedCount} decks`);
           } else if (result.kind === "partial") {
@@ -70,13 +78,16 @@ export function AuthCallback() {
           window.localStorage.removeItem("dndCards.lastProvider");
           navigate({ to: getNextPath() });
         } catch {
+          if (cancelled) return;
           setAnnouncement(
             "Couldn't finish importing your decks. We'll try again next time you sign in.",
           );
           navigate({ to: getNextPath() });
         }
       })();
-      return;
+      return () => {
+        cancelled = true;
+      };
     }
 
     if (!session.user.is_anonymous) {
@@ -84,6 +95,9 @@ export function AuthCallback() {
       window.localStorage.removeItem("dndCards.lastProvider");
     }
     navigate({ to: getNextPath() });
+    return () => {
+      cancelled = true;
+    };
   }, [session, navigate, setAnnouncement]);
 
   const onImport = async () => {

--- a/src/auth/AuthCallback.tsx
+++ b/src/auth/AuthCallback.tsx
@@ -5,16 +5,13 @@ import { pluralize } from "../lib/pluralize";
 import { useSetNextAnnouncement } from "../lib/ui/Announcement";
 import { clear, readPending, stash, tryResume } from "./anonImport";
 import { ImportAccountDialog } from "./ImportAccountDialog";
+import { readNextFromUrl } from "./safeNext";
 import { useSession } from "./useSession";
 
 function parseLinkError(): string | null {
   const hash = new URLSearchParams(window.location.hash.replace(/^#/, ""));
   const search = new URLSearchParams(window.location.search);
   return hash.get("error_code") ?? search.get("error_code");
-}
-
-function getNextPath(): string {
-  return new URLSearchParams(window.location.search).get("next") ?? "/";
 }
 
 function lastProvider(): "google" | "github" {
@@ -77,13 +74,13 @@ export function AuthCallback() {
             );
           }
           window.localStorage.removeItem("dndCards.lastProvider");
-          navigate({ to: getNextPath() });
+          navigate({ to: readNextFromUrl() });
         } catch {
           if (cancelled) return;
           setAnnouncement(
             "Couldn't finish importing your decks. We'll try again next time you sign in.",
           );
-          navigate({ to: getNextPath() });
+          navigate({ to: readNextFromUrl() });
         }
       })();
       return () => {
@@ -95,7 +92,7 @@ export function AuthCallback() {
       setAnnouncement("Signed in");
       window.localStorage.removeItem("dndCards.lastProvider");
     }
-    navigate({ to: getNextPath() });
+    navigate({ to: readNextFromUrl() });
     return () => {
       cancelled = true;
     };
@@ -104,7 +101,7 @@ export function AuthCallback() {
   const onImport = async () => {
     if (session.status !== "authenticated") return;
     stash({ version: 1, anonUuid: session.user.id, importedDeckIds: [] });
-    const next = getNextPath();
+    const next = readNextFromUrl();
     const redirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`;
     const provider = lastProvider();
     await supabase.auth.signOut();
@@ -113,7 +110,7 @@ export function AuthCallback() {
 
   const onSkip = async () => {
     clear();
-    const next = getNextPath();
+    const next = readNextFromUrl();
     const redirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`;
     const provider = lastProvider();
     await supabase.auth.signOut();

--- a/src/auth/AuthCallback.tsx
+++ b/src/auth/AuthCallback.tsx
@@ -117,8 +117,22 @@ export function AuthCallback() {
     await supabase.auth.signInWithOAuth({ provider, options: { redirectTo } });
   };
 
+  const onCancel = () => {
+    // The anon session is preserved by linkIdentity failures, so dismissing
+    // the dialog returns the user to their anon home with decks intact.
+    navigate({ to: "/" });
+  };
+
   if (phase === "dialog") {
-    return <ImportAccountDialog isOpen deckCount={deckCount} onImport={onImport} onSkip={onSkip} />;
+    return (
+      <ImportAccountDialog
+        isOpen
+        deckCount={deckCount}
+        onImport={onImport}
+        onSkip={onSkip}
+        onCancel={onCancel}
+      />
+    );
   }
 
   if (phase === "importing") {

--- a/src/auth/AuthCallback.tsx
+++ b/src/auth/AuthCallback.tsx
@@ -120,6 +120,7 @@ export function AuthCallback() {
   const onCancel = () => {
     // The anon session is preserved by linkIdentity failures, so dismissing
     // the dialog returns the user to their anon home with decks intact.
+    window.localStorage.removeItem("dndCards.lastProvider");
     navigate({ to: "/" });
   };
 

--- a/src/auth/AuthProvider.test.tsx
+++ b/src/auth/AuthProvider.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { supabase } from "../api/supabase";
+import { SB_URL, server } from "../test/msw";
 import { AuthProvider } from "./AuthProvider";
 import { useSession } from "./useSession";
 
@@ -56,6 +58,26 @@ describe("AuthProvider with anon flag on", () => {
     await waitFor(() => expect(spy).toHaveBeenCalled());
     await waitFor(() => {
       expect(screen.getByTestId("status").textContent).toBe("authenticated");
+    });
+  });
+
+  it("falls back to 'unauthenticated' when signInAnonymously fails", async () => {
+    server.use(
+      http.post(
+        `${SB_URL}/auth/v1/signup`,
+        () =>
+          new HttpResponse(JSON.stringify({ msg: "anonymous sign-ins are disabled" }), {
+            status: 422,
+          }),
+      ),
+    );
+    render(
+      <AuthProvider>
+        <ShowSession />
+      </AuthProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("status").textContent).toBe("unauthenticated");
     });
   });
 });

--- a/src/auth/AuthProvider.test.tsx
+++ b/src/auth/AuthProvider.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { supabase } from "../api/supabase";
 import { AuthProvider } from "./AuthProvider";
 import { useSession } from "./useSession";
@@ -32,5 +32,30 @@ describe("AuthProvider", () => {
       expect(screen.getByTestId("status").textContent).toBe("unauthenticated");
     });
     expect(screen.getByTestId("user-id").textContent).toBe("anon");
+  });
+});
+
+describe("AuthProvider with anon flag on", () => {
+  beforeEach(async () => {
+    await supabase.auth.signOut();
+    vi.stubEnv("VITE_ANON_USERS_ENABLED", "true");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("calls signInAnonymously and transitions to authenticated, never unauthenticated", async () => {
+    const spy = vi.spyOn(supabase.auth, "signInAnonymously");
+    render(
+      <AuthProvider>
+        <ShowSession />
+      </AuthProvider>,
+    );
+    expect(screen.getByTestId("status").textContent).toBe("loading");
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(screen.getByTestId("status").textContent).toBe("authenticated");
+    });
   });
 });

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -21,8 +21,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
       if (event === "INITIAL_SESSION" && anonEnabled) {
         // Stay "loading"; signInAnonymously will fire SIGNED_IN, which we'll
-        // pick up on the next listener invocation.
-        void supabase.auth.signInAnonymously();
+        // pick up on the next listener invocation. If it fails (e.g. server
+        // has anon sign-ins disabled), fall back to "unauthenticated" so the
+        // app doesn't deadlock at the loading screen.
+        void supabase.auth.signInAnonymously().then((result) => {
+          if (cancelled) return;
+          if (result.error) {
+            setState({ status: "unauthenticated", user: null, session: null });
+          }
+        });
         return;
       }
       setState({ status: "unauthenticated", user: null, session: null });

--- a/src/auth/AuthProvider.tsx
+++ b/src/auth/AuthProvider.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useEffect, useState } from "react";
 import { supabase } from "../api/supabase";
+import { isAnonUsersEnabled } from "../lib/anonEnabled";
 import { SessionContext, type SessionState } from "./useSession";
 
 export function AuthProvider({ children }: { children: ReactNode }) {
@@ -11,17 +12,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     let cancelled = false;
-    // onAuthStateChange synthesizes an INITIAL_SESSION event on subscribe,
-    // so we don't need a separate getSession() call — the listener seeds
-    // initial state and tracks changes uniformly. (This matches the pattern
-    // Supabase recommends for React contexts.)
-    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+    const anonEnabled = isAnonUsersEnabled();
+    const { data: sub } = supabase.auth.onAuthStateChange((event, session) => {
       if (cancelled) return;
-      setState(
-        session
-          ? { status: "authenticated", user: session.user, session }
-          : { status: "unauthenticated", user: null, session: null },
-      );
+      if (session) {
+        setState({ status: "authenticated", user: session.user, session });
+        return;
+      }
+      if (event === "INITIAL_SESSION" && anonEnabled) {
+        // Stay "loading"; signInAnonymously will fire SIGNED_IN, which we'll
+        // pick up on the next listener invocation.
+        void supabase.auth.signInAnonymously();
+        return;
+      }
+      setState({ status: "unauthenticated", user: null, session: null });
     });
 
     return () => {

--- a/src/auth/ImportAccountDialog.module.css
+++ b/src/auth/ImportAccountDialog.module.css
@@ -1,0 +1,34 @@
+.body {
+  padding: var(--space-3) var(--space-4);
+}
+
+.body p {
+  margin: 0 0 var(--space-3) 0;
+}
+
+.warning {
+  color: var(--color-warning, var(--color-text-muted));
+  font-size: var(--fs-sm);
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+}
+
+.skip {
+  background: transparent;
+  border: 0;
+  color: var(--color-text-muted);
+  font-size: var(--fs-sm);
+  cursor: pointer;
+  padding: var(--space-2) var(--space-3);
+  text-decoration: underline;
+}
+
+.skip:hover {
+  color: var(--color-text);
+}

--- a/src/auth/ImportAccountDialog.module.css
+++ b/src/auth/ImportAccountDialog.module.css
@@ -30,21 +30,20 @@
 
 .skip {
   background: transparent;
-  border: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
   color: var(--color-text-muted);
   font-size: var(--fs-sm);
   cursor: pointer;
   padding: var(--space-2) var(--space-3);
-  text-decoration: underline;
-  text-underline-offset: 3px;
 }
 
 .skip:hover {
   color: var(--color-danger);
+  border-color: var(--color-border);
 }
 
 .skip:focus-visible {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
-  border-radius: var(--radius-sm);
 }

--- a/src/auth/ImportAccountDialog.module.css
+++ b/src/auth/ImportAccountDialog.module.css
@@ -7,28 +7,44 @@
 }
 
 .warning {
-  color: var(--color-warning, var(--color-text-muted));
+  background: var(--color-warning-bg);
+  color: var(--color-warning-fg);
+  border: 1px solid var(--color-warning-border);
+  border-left-width: 4px;
+  border-radius: var(--radius-sm);
+  padding: var(--space-2) var(--space-3);
   font-size: var(--fs-sm);
+}
+
+.warning strong {
+  font-weight: 600;
 }
 
 .actions {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: space-between;
   gap: var(--space-3);
   padding: var(--space-3) var(--space-4);
 }
 
 .skip {
   background: transparent;
-  border: 0;
-  color: var(--color-text-muted);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-danger);
   font-size: var(--fs-sm);
+  font-weight: 500;
   cursor: pointer;
   padding: var(--space-2) var(--space-3);
-  text-decoration: underline;
 }
 
 .skip:hover {
-  color: var(--color-text);
+  background: var(--color-danger-bg-hover);
+  border-color: var(--color-danger);
+}
+
+.skip:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
 }

--- a/src/auth/ImportAccountDialog.module.css
+++ b/src/auth/ImportAccountDialog.module.css
@@ -23,7 +23,7 @@
 .actions {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: var(--space-3);
   padding: var(--space-3) var(--space-4);
 }

--- a/src/auth/ImportAccountDialog.module.css
+++ b/src/auth/ImportAccountDialog.module.css
@@ -30,7 +30,7 @@
 
 .skip {
   background: transparent;
-  border: 1px solid transparent;
+  border: none;
   border-radius: var(--radius-md);
   color: var(--color-text-muted);
   font-size: var(--fs-sm);
@@ -40,7 +40,7 @@
 
 .skip:hover {
   color: var(--color-danger);
-  border-color: var(--color-border);
+  background: var(--color-surface-2);
 }
 
 .skip:focus-visible {

--- a/src/auth/ImportAccountDialog.module.css
+++ b/src/auth/ImportAccountDialog.module.css
@@ -30,21 +30,21 @@
 
 .skip {
   background: transparent;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  color: var(--color-danger);
+  border: none;
+  color: var(--color-text-muted);
   font-size: var(--fs-sm);
-  font-weight: 500;
   cursor: pointer;
   padding: var(--space-2) var(--space-3);
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
 .skip:hover {
-  background: var(--color-danger-bg-hover);
-  border-color: var(--color-danger);
+  color: var(--color-danger);
 }
 
 .skip:focus-visible {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
+  border-radius: var(--radius-sm);
 }

--- a/src/auth/ImportAccountDialog.test.tsx
+++ b/src/auth/ImportAccountDialog.test.tsx
@@ -87,7 +87,7 @@ describe("<ImportAccountDialog>", () => {
     expect(onSkip).not.toHaveBeenCalled();
   });
 
-  it("calls onCancel (NOT onSkip) when the close (X) button is clicked", async () => {
+  it("calls onCancel (NOT onSkip) when the labelled Cancel button is clicked", async () => {
     const onSkip = vi.fn();
     const onCancel = vi.fn();
     render(
@@ -99,7 +99,7 @@ describe("<ImportAccountDialog>", () => {
         onCancel={onCancel}
       />,
     );
-    await userEvent.click(screen.getByRole("button", { name: /close/i }));
+    await userEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
     expect(onCancel).toHaveBeenCalled();
     expect(onSkip).not.toHaveBeenCalled();
   });

--- a/src/auth/ImportAccountDialog.test.tsx
+++ b/src/auth/ImportAccountDialog.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ImportAccountDialog } from "./ImportAccountDialog";
+
+describe("<ImportAccountDialog>", () => {
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <ImportAccountDialog isOpen={false} deckCount={3} onImport={() => {}} onSkip={() => {}} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders heading, deck count, and unrecoverable warning", () => {
+    render(<ImportAccountDialog isOpen deckCount={3} onImport={() => {}} onSkip={() => {}} />);
+    expect(
+      screen.getByRole("heading", { name: /you already have a dnd-cards account/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/bring your/)).toHaveTextContent("3 decks");
+    expect(screen.getByText(/cannot be recovered/i)).toBeInTheDocument();
+  });
+
+  it("calls onImport when the primary action is clicked", async () => {
+    const onImport = vi.fn();
+    render(<ImportAccountDialog isOpen deckCount={2} onImport={onImport} onSkip={() => {}} />);
+    await userEvent.click(screen.getByRole("button", { name: /yes, import 2 decks/i }));
+    expect(onImport).toHaveBeenCalled();
+  });
+
+  it("calls onSkip when the skip text link is clicked", async () => {
+    const onSkip = vi.fn();
+    render(<ImportAccountDialog isOpen deckCount={2} onImport={() => {}} onSkip={onSkip} />);
+    await userEvent.click(screen.getByRole("button", { name: /skip — leave decks behind/i }));
+    expect(onSkip).toHaveBeenCalled();
+  });
+});

--- a/src/auth/ImportAccountDialog.test.tsx
+++ b/src/auth/ImportAccountDialog.test.tsx
@@ -4,15 +4,25 @@ import { describe, expect, it, vi } from "vitest";
 import { ImportAccountDialog } from "./ImportAccountDialog";
 
 describe("<ImportAccountDialog>", () => {
+  const noop = () => {};
+
   it("renders nothing when closed", () => {
     const { container } = render(
-      <ImportAccountDialog isOpen={false} deckCount={3} onImport={() => {}} onSkip={() => {}} />,
+      <ImportAccountDialog
+        isOpen={false}
+        deckCount={3}
+        onImport={noop}
+        onSkip={noop}
+        onCancel={noop}
+      />,
     );
     expect(container).toBeEmptyDOMElement();
   });
 
   it("renders heading, deck count, and unrecoverable warning", () => {
-    render(<ImportAccountDialog isOpen deckCount={3} onImport={() => {}} onSkip={() => {}} />);
+    render(
+      <ImportAccountDialog isOpen deckCount={3} onImport={noop} onSkip={noop} onCancel={noop} />,
+    );
     expect(
       screen.getByRole("heading", { name: /you already have a dnd-cards account/i }),
     ).toBeInTheDocument();
@@ -21,36 +31,76 @@ describe("<ImportAccountDialog>", () => {
   });
 
   it("uses the singular form when deckCount is 1", () => {
-    render(<ImportAccountDialog isOpen deckCount={1} onImport={() => {}} onSkip={() => {}} />);
+    render(
+      <ImportAccountDialog isOpen deckCount={1} onImport={noop} onSkip={noop} onCancel={noop} />,
+    );
     expect(screen.getByText(/bring your/)).toHaveTextContent("1 deck");
     expect(screen.getByRole("button", { name: /yes, import 1 deck$/i })).toBeInTheDocument();
   });
 
   it("calls onImport when the primary action is clicked", async () => {
     const onImport = vi.fn();
-    render(<ImportAccountDialog isOpen deckCount={2} onImport={onImport} onSkip={() => {}} />);
+    render(
+      <ImportAccountDialog
+        isOpen
+        deckCount={2}
+        onImport={onImport}
+        onSkip={noop}
+        onCancel={noop}
+      />,
+    );
     await userEvent.click(screen.getByRole("button", { name: /yes, import 2 decks/i }));
     expect(onImport).toHaveBeenCalled();
   });
 
-  it("calls onSkip when the skip text link is clicked", async () => {
+  it("calls onSkip (NOT onCancel) when the skip text link is clicked", async () => {
     const onSkip = vi.fn();
-    render(<ImportAccountDialog isOpen deckCount={2} onImport={() => {}} onSkip={onSkip} />);
+    const onCancel = vi.fn();
+    render(
+      <ImportAccountDialog
+        isOpen
+        deckCount={2}
+        onImport={noop}
+        onSkip={onSkip}
+        onCancel={onCancel}
+      />,
+    );
     await userEvent.click(screen.getByRole("button", { name: /skip — leave decks behind/i }));
     expect(onSkip).toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
   });
 
-  it("calls onSkip when the dialog is dismissed via Escape", async () => {
+  it("calls onCancel (NOT onSkip) when the dialog is dismissed via Escape", async () => {
     const onSkip = vi.fn();
-    render(<ImportAccountDialog isOpen deckCount={2} onImport={() => {}} onSkip={onSkip} />);
+    const onCancel = vi.fn();
+    render(
+      <ImportAccountDialog
+        isOpen
+        deckCount={2}
+        onImport={noop}
+        onSkip={onSkip}
+        onCancel={onCancel}
+      />,
+    );
     await userEvent.keyboard("{Escape}");
-    expect(onSkip).toHaveBeenCalled();
+    expect(onCancel).toHaveBeenCalled();
+    expect(onSkip).not.toHaveBeenCalled();
   });
 
-  it("calls onSkip when the close (X) button is clicked", async () => {
+  it("calls onCancel (NOT onSkip) when the close (X) button is clicked", async () => {
     const onSkip = vi.fn();
-    render(<ImportAccountDialog isOpen deckCount={2} onImport={() => {}} onSkip={onSkip} />);
+    const onCancel = vi.fn();
+    render(
+      <ImportAccountDialog
+        isOpen
+        deckCount={2}
+        onImport={noop}
+        onSkip={onSkip}
+        onCancel={onCancel}
+      />,
+    );
     await userEvent.click(screen.getByRole("button", { name: /close/i }));
-    expect(onSkip).toHaveBeenCalled();
+    expect(onCancel).toHaveBeenCalled();
+    expect(onSkip).not.toHaveBeenCalled();
   });
 });

--- a/src/auth/ImportAccountDialog.test.tsx
+++ b/src/auth/ImportAccountDialog.test.tsx
@@ -20,6 +20,12 @@ describe("<ImportAccountDialog>", () => {
     expect(screen.getByText(/cannot be recovered/i)).toBeInTheDocument();
   });
 
+  it("uses the singular form when deckCount is 1", () => {
+    render(<ImportAccountDialog isOpen deckCount={1} onImport={() => {}} onSkip={() => {}} />);
+    expect(screen.getByText(/bring your/)).toHaveTextContent("1 deck");
+    expect(screen.getByRole("button", { name: /yes, import 1 deck$/i })).toBeInTheDocument();
+  });
+
   it("calls onImport when the primary action is clicked", async () => {
     const onImport = vi.fn();
     render(<ImportAccountDialog isOpen deckCount={2} onImport={onImport} onSkip={() => {}} />);
@@ -31,6 +37,20 @@ describe("<ImportAccountDialog>", () => {
     const onSkip = vi.fn();
     render(<ImportAccountDialog isOpen deckCount={2} onImport={() => {}} onSkip={onSkip} />);
     await userEvent.click(screen.getByRole("button", { name: /skip — leave decks behind/i }));
+    expect(onSkip).toHaveBeenCalled();
+  });
+
+  it("calls onSkip when the dialog is dismissed via Escape", async () => {
+    const onSkip = vi.fn();
+    render(<ImportAccountDialog isOpen deckCount={2} onImport={() => {}} onSkip={onSkip} />);
+    await userEvent.keyboard("{Escape}");
+    expect(onSkip).toHaveBeenCalled();
+  });
+
+  it("calls onSkip when the close (X) button is clicked", async () => {
+    const onSkip = vi.fn();
+    render(<ImportAccountDialog isOpen deckCount={2} onImport={() => {}} onSkip={onSkip} />);
+    await userEvent.click(screen.getByRole("button", { name: /close/i }));
     expect(onSkip).toHaveBeenCalled();
   });
 });

--- a/src/auth/ImportAccountDialog.tsx
+++ b/src/auth/ImportAccountDialog.tsx
@@ -1,0 +1,45 @@
+import { Button } from "../lib/ui/Button";
+import { DialogHeader } from "../lib/ui/DialogHeader";
+import { DialogShell } from "../lib/ui/DialogShell";
+import styles from "./ImportAccountDialog.module.css";
+
+type Props = {
+  isOpen: boolean;
+  deckCount: number;
+  onImport: () => void;
+  onSkip: () => void;
+};
+
+export function ImportAccountDialog({ isOpen, deckCount, onImport, onSkip }: Props) {
+  if (!isOpen) return null;
+  return (
+    <DialogShell
+      isOpen={isOpen}
+      onOpenChange={() => {}}
+      aria-label="You already have a dnd-cards account"
+    >
+      {({ close }) => (
+        <>
+          <DialogHeader title="You already have a dnd-cards account" onClose={close} />
+          <div className={styles.body}>
+            <p>
+              An account on dnd-cards is already linked to that identity. Want to bring your{" "}
+              {deckCount} decks into that account?
+            </p>
+            <p className={styles.warning}>
+              If you skip, those decks will be left behind. They cannot be recovered.
+            </p>
+          </div>
+          <div className={styles.actions}>
+            <Button variant="primary" onPress={onImport}>
+              Yes, import {deckCount} decks
+            </Button>
+            <button type="button" className={styles.skip} onClick={onSkip}>
+              Skip — leave decks behind
+            </button>
+          </div>
+        </>
+      )}
+    </DialogShell>
+  );
+}

--- a/src/auth/ImportAccountDialog.tsx
+++ b/src/auth/ImportAccountDialog.tsx
@@ -24,7 +24,11 @@ export function ImportAccountDialog({ isOpen, deckCount, onImport, onSkip, onCan
     >
       {() => (
         <>
-          <DialogHeader title="You already have a dnd-cards account" onClose={onCancel} />
+          <DialogHeader
+            title="You already have a dnd-cards account"
+            onClose={onCancel}
+            closeLabel="Cancel"
+          />
           <div className={styles.body}>
             <p>
               An account on dnd-cards is already linked to that identity. Want to bring your{" "}

--- a/src/auth/ImportAccountDialog.tsx
+++ b/src/auth/ImportAccountDialog.tsx
@@ -1,3 +1,4 @@
+import { pluralize } from "../lib/pluralize";
 import { Button } from "../lib/ui/Button";
 import { DialogHeader } from "../lib/ui/DialogHeader";
 import { DialogShell } from "../lib/ui/DialogShell";
@@ -15,28 +16,31 @@ export function ImportAccountDialog({ isOpen, deckCount, onImport, onSkip }: Pro
   return (
     <DialogShell
       isOpen={isOpen}
-      onOpenChange={() => {}}
+      onOpenChange={(open) => {
+        if (!open) onSkip();
+      }}
       aria-label="You already have a dnd-cards account"
     >
-      {({ close }) => (
+      {() => (
         <>
-          <DialogHeader title="You already have a dnd-cards account" onClose={close} />
+          <DialogHeader title="You already have a dnd-cards account" onClose={onSkip} />
           <div className={styles.body}>
             <p>
               An account on dnd-cards is already linked to that identity. Want to bring your{" "}
-              {deckCount} decks into that account?
+              {pluralize(deckCount, "deck")} into that account?
             </p>
             <p className={styles.warning}>
-              If you skip, those decks will be left behind. They cannot be recovered.
+              <strong>Heads up:</strong> if you skip, those decks will be left behind. They cannot
+              be recovered.
             </p>
           </div>
           <div className={styles.actions}>
-            <Button variant="primary" onPress={onImport}>
-              Yes, import {deckCount} decks
-            </Button>
             <button type="button" className={styles.skip} onClick={onSkip}>
               Skip — leave decks behind
             </button>
+            <Button variant="primary" onPress={onImport}>
+              Yes, import {pluralize(deckCount, "deck")}
+            </Button>
           </div>
         </>
       )}

--- a/src/auth/ImportAccountDialog.tsx
+++ b/src/auth/ImportAccountDialog.tsx
@@ -9,21 +9,22 @@ type Props = {
   deckCount: number;
   onImport: () => void;
   onSkip: () => void;
+  onCancel: () => void;
 };
 
-export function ImportAccountDialog({ isOpen, deckCount, onImport, onSkip }: Props) {
+export function ImportAccountDialog({ isOpen, deckCount, onImport, onSkip, onCancel }: Props) {
   if (!isOpen) return null;
   return (
     <DialogShell
       isOpen={isOpen}
       onOpenChange={(open) => {
-        if (!open) onSkip();
+        if (!open) onCancel();
       }}
       aria-label="You already have a dnd-cards account"
     >
       {() => (
         <>
-          <DialogHeader title="You already have a dnd-cards account" onClose={onSkip} />
+          <DialogHeader title="You already have a dnd-cards account" onClose={onCancel} />
           <div className={styles.body}>
             <p>
               An account on dnd-cards is already linked to that identity. Want to bring your{" "}

--- a/src/auth/LoginView.test.tsx
+++ b/src/auth/LoginView.test.tsx
@@ -5,6 +5,7 @@ import { HttpResponse, http } from "msw";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { supabase } from "../api/supabase";
+import { AnnouncementProvider } from "../lib/ui/Announcement";
 import { SB_URL, server } from "../test/msw";
 import { LoginView } from "./LoginView";
 import { SessionContext, type SessionState } from "./useSession";
@@ -21,7 +22,11 @@ function wrap(ui: ReactNode, session?: SessionState) {
   ) : (
     ui
   );
-  return <QueryClientProvider client={client}>{inner}</QueryClientProvider>;
+  return (
+    <QueryClientProvider client={client}>
+      <AnnouncementProvider>{inner}</AnnouncementProvider>
+    </QueryClientProvider>
+  );
 }
 
 describe("LoginView", () => {
@@ -186,5 +191,138 @@ describe("LoginView OAuth branching", () => {
 
     await waitFor(() => expect(oauthSpy).toHaveBeenCalled());
     expect(linkSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("LoginView dev path conflict", () => {
+  beforeEach(() => {
+    vi.stubEnv("DEV", true);
+    vi.stubEnv("VITE_ANON_USERS_ENABLED", "true");
+    window.localStorage.clear();
+    navigate.mockClear();
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("opens ImportAccountDialog when anon dev sign-in hits an email conflict and anon has decks", async () => {
+    vi.spyOn(supabase.auth, "updateUser").mockResolvedValue({
+      data: { user: null },
+      error: { message: "email already exists" },
+    } as never);
+    server.use(
+      http.get(`${SB_URL}/rest/v1/decks`, () =>
+        HttpResponse.json([{ id: "d1" }, { id: "d2" }, { id: "d3" }]),
+      ),
+    );
+
+    render(
+      wrap(<LoginView />, {
+        status: "authenticated",
+        user: { id: "anon-1", is_anonymous: true } as never,
+        session: {} as never,
+      }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /sign in as dev user/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: /you already have a dnd-cards account/i }),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /yes, import 3 decks/i })).toBeInTheDocument();
+  });
+
+  it("on import: stashes pending, signs out, signs in to existing dev account, and navigates", async () => {
+    vi.spyOn(supabase.auth, "updateUser").mockResolvedValue({
+      data: { user: null },
+      error: { message: "email already exists" },
+    } as never);
+    const signOutSpy = vi
+      .spyOn(supabase.auth, "signOut")
+      .mockResolvedValue({ error: null } as never);
+    const signInSpy = vi.spyOn(supabase.auth, "signInWithPassword").mockResolvedValue({
+      data: { user: { id: "dev-1" }, session: {} },
+      error: null,
+    } as never);
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem");
+    server.use(http.get(`${SB_URL}/rest/v1/decks`, () => HttpResponse.json([{ id: "d1" }])));
+
+    render(
+      wrap(<LoginView />, {
+        status: "authenticated",
+        user: { id: "anon-1", is_anonymous: true } as never,
+        session: {} as never,
+      }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /sign in as dev user/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /yes, import 1 deck$/i }));
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: "/" }));
+    expect(setItemSpy).toHaveBeenCalledWith(
+      "dndCards.pendingAnonImport",
+      expect.stringContaining("anon-1"),
+    );
+    expect(signOutSpy).toHaveBeenCalled();
+    expect(signInSpy).toHaveBeenCalledWith({ email: "dev@local", password: "devpass" });
+  });
+
+  it("on skip: clears pending, signs out, signs in to existing dev account, and navigates", async () => {
+    vi.spyOn(supabase.auth, "updateUser").mockResolvedValue({
+      data: { user: null },
+      error: { message: "email already exists" },
+    } as never);
+    const signOutSpy = vi
+      .spyOn(supabase.auth, "signOut")
+      .mockResolvedValue({ error: null } as never);
+    const signInSpy = vi
+      .spyOn(supabase.auth, "signInWithPassword")
+      .mockResolvedValue({ data: { user: { id: "dev-1" }, session: {} }, error: null } as never);
+    server.use(http.get(`${SB_URL}/rest/v1/decks`, () => HttpResponse.json([{ id: "d1" }])));
+    window.localStorage.setItem(
+      "dndCards.pendingAnonImport",
+      JSON.stringify({ version: 1, anonUuid: "anon-old", importedDeckIds: [] }),
+    );
+
+    render(
+      wrap(<LoginView />, {
+        status: "authenticated",
+        user: { id: "anon-1", is_anonymous: true } as never,
+        session: {} as never,
+      }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /sign in as dev user/i }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: /skip — leave decks behind/i }),
+    );
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: "/" }));
+    expect(window.localStorage.getItem("dndCards.pendingAnonImport")).toBeNull();
+    expect(signOutSpy).toHaveBeenCalled();
+    expect(signInSpy).toHaveBeenCalledWith({ email: "dev@local", password: "devpass" });
+  });
+
+  it("falls through silently when anon dev sign-in conflicts but anon has no decks", async () => {
+    vi.spyOn(supabase.auth, "updateUser").mockResolvedValue({
+      data: { user: null },
+      error: { message: "email already exists" },
+    } as never);
+    const signInSpy = vi
+      .spyOn(supabase.auth, "signInWithPassword")
+      .mockResolvedValue({ data: { user: { id: "dev-1" }, session: {} }, error: null } as never);
+    server.use(http.get(`${SB_URL}/rest/v1/decks`, () => HttpResponse.json([])));
+
+    render(
+      wrap(<LoginView />, {
+        status: "authenticated",
+        user: { id: "anon-1", is_anonymous: true } as never,
+        session: {} as never,
+      }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /sign in as dev user/i }));
+
+    await waitFor(() => expect(signInSpy).toHaveBeenCalled());
+    expect(
+      screen.queryByRole("heading", { name: /you already have a dnd-cards account/i }),
+    ).not.toBeInTheDocument();
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: "/" }));
   });
 });

--- a/src/auth/LoginView.test.tsx
+++ b/src/auth/LoginView.test.tsx
@@ -300,6 +300,39 @@ describe("LoginView dev path conflict", () => {
     expect(signInSpy).toHaveBeenCalledWith({ email: "dev@local", password: "devpass" });
   });
 
+  it("on dismiss: closes the dialog without signOut or signInWithPassword", async () => {
+    vi.spyOn(supabase.auth, "updateUser").mockResolvedValue({
+      data: { user: null },
+      error: { message: "email already exists" },
+    } as never);
+    const signOutSpy = vi
+      .spyOn(supabase.auth, "signOut")
+      .mockResolvedValue({ error: null } as never);
+    const signInSpy = vi
+      .spyOn(supabase.auth, "signInWithPassword")
+      .mockResolvedValue({ data: { user: { id: "dev-1" }, session: {} }, error: null } as never);
+    server.use(http.get(`${SB_URL}/rest/v1/decks`, () => HttpResponse.json([{ id: "d1" }])));
+
+    render(
+      wrap(<LoginView />, {
+        status: "authenticated",
+        user: { id: "anon-1", is_anonymous: true } as never,
+        session: {} as never,
+      }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /sign in as dev user/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /close/i }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("heading", { name: /you already have a dnd-cards account/i }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(signOutSpy).not.toHaveBeenCalled();
+    expect(signInSpy).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
   it("falls through silently when anon dev sign-in conflicts but anon has no decks", async () => {
     vi.spyOn(supabase.auth, "updateUser").mockResolvedValue({
       data: { user: null },

--- a/src/auth/LoginView.test.tsx
+++ b/src/auth/LoginView.test.tsx
@@ -321,7 +321,7 @@ describe("LoginView dev path conflict", () => {
       }),
     );
     await userEvent.click(screen.getByRole("button", { name: /sign in as dev user/i }));
-    await userEvent.click(await screen.findByRole("button", { name: /close/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /^cancel$/i }));
 
     await waitFor(() =>
       expect(

--- a/src/auth/LoginView.test.tsx
+++ b/src/auth/LoginView.test.tsx
@@ -1,13 +1,28 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { HttpResponse, http } from "msw";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { supabase } from "../api/supabase";
+import { SB_URL, server } from "../test/msw";
 import { LoginView } from "./LoginView";
+import { SessionContext, type SessionState } from "./useSession";
 
 const navigate = vi.fn();
 vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => navigate,
 }));
+
+function wrap(ui: ReactNode, session?: SessionState) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const inner = session ? (
+    <SessionContext.Provider value={session}>{ui}</SessionContext.Provider>
+  ) : (
+    ui
+  );
+  return <QueryClientProvider client={client}>{inner}</QueryClientProvider>;
+}
 
 describe("LoginView", () => {
   it("calls signInWithOAuth with google when the Google button is clicked", async () => {
@@ -15,7 +30,7 @@ describe("LoginView", () => {
     const spy = vi
       .spyOn(supabase.auth, "signInWithOAuth")
       .mockResolvedValue({ data: { provider: "google", url: "https://x" }, error: null });
-    render(<LoginView />);
+    render(wrap(<LoginView />));
     await userEvent.click(screen.getByRole("button", { name: /sign in with google/i }));
     expect(spy).toHaveBeenCalledWith(
       expect.objectContaining({ provider: "google", options: expect.any(Object) }),
@@ -28,14 +43,14 @@ describe("LoginView", () => {
     const spy = vi
       .spyOn(supabase.auth, "signInWithOAuth")
       .mockResolvedValue({ data: { provider: "github", url: "https://x" }, error: null });
-    render(<LoginView />);
+    render(wrap(<LoginView />));
     await userEvent.click(screen.getByRole("button", { name: /sign in with github/i }));
     expect(spy).toHaveBeenCalledWith(expect.objectContaining({ provider: "github" }));
     vi.unstubAllEnvs();
   });
 
   it("hides Google and GitHub buttons when their env vars are unset", () => {
-    render(<LoginView />);
+    render(wrap(<LoginView />));
     expect(screen.queryByRole("button", { name: /sign in with google/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /sign in with github/i })).not.toBeInTheDocument();
   });
@@ -46,7 +61,7 @@ describe("LoginView", () => {
     const signInSpy = vi
       .spyOn(supabase.auth, "signInWithPassword")
       .mockResolvedValue({ data: { session: null, user: null }, error: null } as never);
-    render(<LoginView />);
+    render(wrap(<LoginView />));
     await userEvent.click(screen.getByRole("button", { name: /sign in as dev user/i }));
     expect(signInSpy).toHaveBeenCalledWith({ email: "dev@local", password: "devpass" });
     await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: "/" }));
@@ -62,7 +77,7 @@ describe("LoginView", () => {
     const signUpSpy = vi
       .spyOn(supabase.auth, "signUp")
       .mockResolvedValue({ data: { session: null, user: null }, error: null } as never);
-    render(<LoginView />);
+    render(wrap(<LoginView />));
     await userEvent.click(screen.getByRole("button", { name: /sign in as dev user/i }));
     expect(signUpSpy).toHaveBeenCalledWith({ email: "dev@local", password: "devpass" });
     vi.unstubAllEnvs();
@@ -70,8 +85,90 @@ describe("LoginView", () => {
 
   it("does NOT show the dev sign-in button outside dev mode", () => {
     vi.stubEnv("DEV", false);
-    render(<LoginView />);
+    render(wrap(<LoginView />));
     expect(screen.queryByRole("button", { name: /sign in as dev user/i })).not.toBeInTheDocument();
     vi.unstubAllEnvs();
+  });
+});
+
+describe("LoginView OAuth branching", () => {
+  beforeEach(() => {
+    vi.stubEnv("VITE_ANON_USERS_ENABLED", "true");
+    vi.stubEnv("VITE_AUTH_GOOGLE_ENABLED", "true");
+    window.localStorage.clear();
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("calls linkIdentity (and stashes lastProvider) when user is anonymous and has decks", async () => {
+    const linkSpy = vi.spyOn(supabase.auth, "linkIdentity").mockResolvedValue({
+      data: { provider: "google", url: "https://example.com" },
+      error: null,
+    } as never);
+    const oauthSpy = vi.spyOn(supabase.auth, "signInWithOAuth").mockResolvedValue({
+      data: { provider: "google", url: "https://example.com" },
+      error: null,
+    } as never);
+
+    server.use(
+      http.get(`${SB_URL}/rest/v1/decks`, () =>
+        HttpResponse.json([{ id: "d1", owner_id: "anon-1", name: "Goblins" }]),
+      ),
+    );
+
+    render(
+      wrap(<LoginView />, {
+        status: "authenticated",
+        user: { id: "anon-1", is_anonymous: true } as never,
+        session: {} as never,
+      }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /sign in with google/i }));
+
+    await waitFor(() =>
+      expect(linkSpy).toHaveBeenCalledWith(expect.objectContaining({ provider: "google" })),
+    );
+    expect(oauthSpy).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem("dndCards.lastProvider")).toBe("google");
+  });
+
+  it("calls signInWithOAuth when user is anonymous with zero decks", async () => {
+    const linkSpy = vi
+      .spyOn(supabase.auth, "linkIdentity")
+      .mockResolvedValue({ data: {}, error: null } as never);
+    const oauthSpy = vi.spyOn(supabase.auth, "signInWithOAuth").mockResolvedValue({
+      data: { provider: "google", url: "https://example.com" },
+      error: null,
+    } as never);
+    server.use(http.get(`${SB_URL}/rest/v1/decks`, () => HttpResponse.json([])));
+
+    render(
+      wrap(<LoginView />, {
+        status: "authenticated",
+        user: { id: "anon-1", is_anonymous: true } as never,
+        session: {} as never,
+      }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /sign in with google/i }));
+
+    await waitFor(() =>
+      expect(oauthSpy).toHaveBeenCalledWith(expect.objectContaining({ provider: "google" })),
+    );
+    expect(linkSpy).not.toHaveBeenCalled();
+  });
+
+  it("calls signInWithOAuth when user is unauthenticated", async () => {
+    const linkSpy = vi
+      .spyOn(supabase.auth, "linkIdentity")
+      .mockResolvedValue({ data: {}, error: null } as never);
+    const oauthSpy = vi.spyOn(supabase.auth, "signInWithOAuth").mockResolvedValue({
+      data: { provider: "google", url: "https://example.com" },
+      error: null,
+    } as never);
+
+    render(wrap(<LoginView />, { status: "unauthenticated", user: null, session: null }));
+    await userEvent.click(screen.getByRole("button", { name: /sign in with google/i }));
+
+    await waitFor(() => expect(oauthSpy).toHaveBeenCalled());
+    expect(linkSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/auth/LoginView.test.tsx
+++ b/src/auth/LoginView.test.tsx
@@ -89,6 +89,22 @@ describe("LoginView", () => {
     expect(screen.queryByRole("button", { name: /sign in as dev user/i })).not.toBeInTheDocument();
     vi.unstubAllEnvs();
   });
+
+  it("ignores a rapid second click after the first OAuth click", async () => {
+    vi.stubEnv("VITE_AUTH_GOOGLE_ENABLED", "true");
+    let resolveOAuth: (value: unknown) => void = () => {};
+    const oauthPromise = new Promise((resolve) => {
+      resolveOAuth = resolve;
+    });
+    const spy = vi.spyOn(supabase.auth, "signInWithOAuth").mockReturnValue(oauthPromise as never);
+    render(wrap(<LoginView />));
+    const button = screen.getByRole("button", { name: /sign in with google/i });
+    await userEvent.click(button);
+    await userEvent.click(button);
+    expect(spy).toHaveBeenCalledTimes(1);
+    resolveOAuth({ data: { provider: "google", url: "https://x" }, error: null });
+    vi.unstubAllEnvs();
+  });
 });
 
 describe("LoginView OAuth branching", () => {

--- a/src/auth/LoginView.tsx
+++ b/src/auth/LoginView.tsx
@@ -146,6 +146,13 @@ export function LoginView() {
     await switchToExistingDevAccount(readNextFromUrl());
   };
 
+  const onImportCancel = () => {
+    // The anon session is intact (updateUser failed before any signOut), so
+    // closing the dialog leaves the user where they were.
+    setImportPrompt(null);
+    setPending(null);
+  };
+
   const heading = isAnon ? "Save your work to your account" : "Sign in";
   const copy = isAnon
     ? "Sign in to save your decks to your account, where you can access them from any device."
@@ -194,6 +201,7 @@ export function LoginView() {
           deckCount={importPrompt.deckCount}
           onImport={() => void onImportConfirm()}
           onSkip={() => void onImportSkip()}
+          onCancel={onImportCancel}
         />
       )}
     </section>

--- a/src/auth/LoginView.tsx
+++ b/src/auth/LoginView.tsx
@@ -59,7 +59,13 @@ export function LoginView() {
 
   const switchToExistingDevAccount = async (next: string) => {
     await supabase.auth.signOut();
-    await supabase.auth.signInWithPassword({ email: DEV_EMAIL, password: DEV_PASSWORD });
+    const { error } = await supabase.auth.signInWithPassword({
+      email: DEV_EMAIL,
+      password: DEV_PASSWORD,
+    });
+    if (error) {
+      setAnnouncement("Couldn't sign in to existing dev account.");
+    }
     navigate({ to: next });
   };
 
@@ -75,8 +81,15 @@ export function LoginView() {
         // Email is taken — an existing dev account already exists. Mirror the
         // OAuth identity_already_exists flow: if the anon has decks, prompt
         // to import them; otherwise switch silently.
-        const { data: decks } = await supabase.from("decks").select("id").eq("owner_id", userId);
-        const deckCount = decks?.length ?? 0;
+        const decks = await queryClient.fetchQuery({
+          queryKey: decksKey(userId),
+          queryFn: async () => {
+            const { data } = await supabase.from("decks").select("id").eq("owner_id", userId);
+            return data ?? [];
+          },
+          staleTime: 0,
+        });
+        const deckCount = decks.length;
         if (deckCount > 0) {
           setImportPrompt({ deckCount, anonUuid: userId });
           return;

--- a/src/auth/LoginView.tsx
+++ b/src/auth/LoginView.tsx
@@ -1,9 +1,11 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
 import { supabase } from "../api/supabase";
 import { decksKey } from "../decks/queries";
 import { OAuthButton } from "../lib/ui/OAuthButton";
 import styles from "./LoginView.module.css";
+import { readNextFromUrl } from "./safeNext";
 import { useSession } from "./useSession";
 
 const DEV_EMAIL = "dev@local";
@@ -13,34 +15,43 @@ export function LoginView() {
   const navigate = useNavigate();
   const session = useSession();
   const queryClient = useQueryClient();
+  const [pending, setPending] = useState<"google" | "github" | "dev" | null>(null);
 
   const isAnon = session.status === "authenticated" && session.user.is_anonymous === true;
   const userId = session.status === "authenticated" ? session.user.id : null;
 
   const signIn = async (provider: "google" | "github") => {
-    const next = new URLSearchParams(window.location.search).get("next") ?? "/";
-    const redirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`;
+    if (pending !== null) return;
+    setPending(provider);
+    try {
+      const next = readNextFromUrl();
+      const redirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`;
 
-    if (isAnon && userId) {
-      const decks = await queryClient.fetchQuery({
-        queryKey: decksKey(userId),
-        queryFn: async () => {
-          const { data } = await supabase.from("decks").select("id").eq("owner_id", userId);
-          return data ?? [];
-        },
-        staleTime: 0,
-      });
-      if ((decks?.length ?? 0) > 0) {
-        window.localStorage.setItem("dndCards.lastProvider", provider);
-        await supabase.auth.linkIdentity({ provider, options: { redirectTo } });
-        return;
+      if (isAnon && userId) {
+        const decks = await queryClient.fetchQuery({
+          queryKey: decksKey(userId),
+          queryFn: async () => {
+            const { data } = await supabase.from("decks").select("id").eq("owner_id", userId);
+            return data ?? [];
+          },
+          staleTime: 0,
+        });
+        if ((decks?.length ?? 0) > 0) {
+          window.localStorage.setItem("dndCards.lastProvider", provider);
+          await supabase.auth.linkIdentity({ provider, options: { redirectTo } });
+          return;
+        }
       }
+      await supabase.auth.signInWithOAuth({ provider, options: { redirectTo } });
+    } catch {
+      setPending(null);
     }
-    await supabase.auth.signInWithOAuth({ provider, options: { redirectTo } });
   };
 
   const devSignIn = async () => {
-    const next = new URLSearchParams(window.location.search).get("next") ?? "/";
+    if (pending !== null) return;
+    setPending("dev");
+    const next = readNextFromUrl();
     if (isAnon) {
       // Supabase rejects setting a password on an anon user before the email
       // lands, so update email first, then password. If the email is already
@@ -90,17 +101,32 @@ export function LoginView() {
       <ul className={styles.providers} role="list">
         {import.meta.env.VITE_AUTH_GOOGLE_ENABLED === "true" && (
           <li>
-            <OAuthButton provider="google" onPress={() => void signIn("google")} />
+            <OAuthButton
+              provider="google"
+              onPress={() => void signIn("google")}
+              isDisabled={pending !== null && pending !== "google"}
+              isPending={pending === "google"}
+            />
           </li>
         )}
         {import.meta.env.VITE_AUTH_GITHUB_ENABLED === "true" && (
           <li>
-            <OAuthButton provider="github" onPress={() => void signIn("github")} />
+            <OAuthButton
+              provider="github"
+              onPress={() => void signIn("github")}
+              isDisabled={pending !== null && pending !== "github"}
+              isPending={pending === "github"}
+            />
           </li>
         )}
         {import.meta.env.DEV && (
           <li>
-            <OAuthButton provider="dev" onPress={() => void devSignIn()} />
+            <OAuthButton
+              provider="dev"
+              onPress={() => void devSignIn()}
+              isDisabled={pending !== null && pending !== "dev"}
+              isPending={pending === "dev"}
+            />
           </li>
         )}
       </ul>

--- a/src/auth/LoginView.tsx
+++ b/src/auth/LoginView.tsx
@@ -3,7 +3,11 @@ import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 import { supabase } from "../api/supabase";
 import { decksKey } from "../decks/queries";
+import { pluralize } from "../lib/pluralize";
+import { useSetNextAnnouncement } from "../lib/ui/Announcement";
 import { OAuthButton } from "../lib/ui/OAuthButton";
+import { clear, stash, tryResume } from "./anonImport";
+import { ImportAccountDialog } from "./ImportAccountDialog";
 import styles from "./LoginView.module.css";
 import { readNextFromUrl } from "./safeNext";
 import { useSession } from "./useSession";
@@ -15,7 +19,12 @@ export function LoginView() {
   const navigate = useNavigate();
   const session = useSession();
   const queryClient = useQueryClient();
+  const setAnnouncement = useSetNextAnnouncement();
   const [pending, setPending] = useState<"google" | "github" | "dev" | null>(null);
+  const [importPrompt, setImportPrompt] = useState<{
+    deckCount: number;
+    anonUuid: string;
+  } | null>(null);
 
   const isAnon = session.status === "authenticated" && session.user.is_anonymous === true;
   const userId = session.status === "authenticated" ? session.user.id : null;
@@ -48,26 +57,36 @@ export function LoginView() {
     }
   };
 
+  const switchToExistingDevAccount = async (next: string) => {
+    await supabase.auth.signOut();
+    await supabase.auth.signInWithPassword({ email: DEV_EMAIL, password: DEV_PASSWORD });
+    navigate({ to: next });
+  };
+
   const devSignIn = async () => {
     if (pending !== null) return;
     setPending("dev");
     const next = readNextFromUrl();
-    if (isAnon) {
+    if (isAnon && userId) {
       // Supabase rejects setting a password on an anon user before the email
-      // lands, so update email first, then password. If the email is already
-      // taken, fall back to sign-out + sign-in.
+      // lands, so update email first, then password.
       const { error: emailError } = await supabase.auth.updateUser({ email: DEV_EMAIL });
       if (emailError) {
-        await supabase.auth.signOut();
-        await supabase.auth.signInWithPassword({ email: DEV_EMAIL, password: DEV_PASSWORD });
-        navigate({ to: next });
+        // Email is taken — an existing dev account already exists. Mirror the
+        // OAuth identity_already_exists flow: if the anon has decks, prompt
+        // to import them; otherwise switch silently.
+        const { data: decks } = await supabase.from("decks").select("id").eq("owner_id", userId);
+        const deckCount = decks?.length ?? 0;
+        if (deckCount > 0) {
+          setImportPrompt({ deckCount, anonUuid: userId });
+          return;
+        }
+        await switchToExistingDevAccount(next);
         return;
       }
       const { error: pwError } = await supabase.auth.updateUser({ password: DEV_PASSWORD });
       if (pwError) {
-        await supabase.auth.signOut();
-        await supabase.auth.signInWithPassword({ email: DEV_EMAIL, password: DEV_PASSWORD });
-        navigate({ to: next });
+        await switchToExistingDevAccount(next);
         return;
       }
       navigate({ to: next });
@@ -86,6 +105,45 @@ export function LoginView() {
     // OAuth providers route back through /auth/callback which navigates;
     // dev sign-in is direct, so navigate manually.
     navigate({ to: next });
+  };
+
+  const onImportConfirm = async () => {
+    if (!importPrompt) return;
+    const { anonUuid } = importPrompt;
+    setImportPrompt(null);
+    const next = readNextFromUrl();
+    stash({ version: 1, anonUuid, importedDeckIds: [] });
+    await supabase.auth.signOut();
+    const { data, error } = await supabase.auth.signInWithPassword({
+      email: DEV_EMAIL,
+      password: DEV_PASSWORD,
+    });
+    if (error || !data?.user) {
+      setAnnouncement("Couldn't sign in to existing dev account.");
+      navigate({ to: next });
+      return;
+    }
+    try {
+      const result = await tryResume({ supabase, currentUserId: data.user.id });
+      if (result.kind === "completed" && result.importedCount > 0) {
+        setAnnouncement(`Imported ${pluralize(result.importedCount, "deck")}`);
+      } else if (result.kind === "partial") {
+        setAnnouncement(
+          `Imported ${result.importedCount} of ${pluralize(result.total, "deck")}. We'll try again next time you sign in.`,
+        );
+      }
+    } catch {
+      setAnnouncement(
+        "Couldn't finish importing your decks. We'll try again next time you sign in.",
+      );
+    }
+    navigate({ to: next });
+  };
+
+  const onImportSkip = async () => {
+    setImportPrompt(null);
+    clear();
+    await switchToExistingDevAccount(readNextFromUrl());
   };
 
   const heading = isAnon ? "Save your work to your account" : "Sign in";
@@ -130,6 +188,14 @@ export function LoginView() {
           </li>
         )}
       </ul>
+      {importPrompt && (
+        <ImportAccountDialog
+          isOpen
+          deckCount={importPrompt.deckCount}
+          onImport={() => void onImportConfirm()}
+          onSkip={() => void onImportSkip()}
+        />
+      )}
     </section>
   );
 }

--- a/src/auth/LoginView.tsx
+++ b/src/auth/LoginView.tsx
@@ -1,25 +1,67 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { supabase } from "../api/supabase";
+import { decksKey } from "../decks/queries";
 import { OAuthButton } from "../lib/ui/OAuthButton";
 import styles from "./LoginView.module.css";
+import { useSession } from "./useSession";
 
 const DEV_EMAIL = "dev@local";
 const DEV_PASSWORD = "devpass";
 
 export function LoginView() {
   const navigate = useNavigate();
+  const session = useSession();
+  const queryClient = useQueryClient();
 
-  const signIn = (provider: "google" | "github") => {
+  const isAnon = session.status === "authenticated" && session.user.is_anonymous === true;
+  const userId = session.status === "authenticated" ? session.user.id : null;
+
+  const signIn = async (provider: "google" | "github") => {
     const next = new URLSearchParams(window.location.search).get("next") ?? "/";
-    supabase.auth.signInWithOAuth({
-      provider,
-      options: {
-        redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`,
-      },
-    });
+    const redirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`;
+
+    if (isAnon && userId) {
+      const decks = await queryClient.fetchQuery({
+        queryKey: decksKey(userId),
+        queryFn: async () => {
+          const { data } = await supabase.from("decks").select("id").eq("owner_id", userId);
+          return data ?? [];
+        },
+        staleTime: 0,
+      });
+      if ((decks?.length ?? 0) > 0) {
+        window.localStorage.setItem("dndCards.lastProvider", provider);
+        await supabase.auth.linkIdentity({ provider, options: { redirectTo } });
+        return;
+      }
+    }
+    await supabase.auth.signInWithOAuth({ provider, options: { redirectTo } });
   };
 
   const devSignIn = async () => {
+    const next = new URLSearchParams(window.location.search).get("next") ?? "/";
+    if (isAnon) {
+      // Supabase rejects setting a password on an anon user before the email
+      // lands, so update email first, then password. If the email is already
+      // taken, fall back to sign-out + sign-in.
+      const { error: emailError } = await supabase.auth.updateUser({ email: DEV_EMAIL });
+      if (emailError) {
+        await supabase.auth.signOut();
+        await supabase.auth.signInWithPassword({ email: DEV_EMAIL, password: DEV_PASSWORD });
+        navigate({ to: next });
+        return;
+      }
+      const { error: pwError } = await supabase.auth.updateUser({ password: DEV_PASSWORD });
+      if (pwError) {
+        await supabase.auth.signOut();
+        await supabase.auth.signInWithPassword({ email: DEV_EMAIL, password: DEV_PASSWORD });
+        navigate({ to: next });
+        return;
+      }
+      navigate({ to: next });
+      return;
+    }
     const { error } = await supabase.auth.signInWithPassword({
       email: DEV_EMAIL,
       password: DEV_PASSWORD,
@@ -32,26 +74,28 @@ export function LoginView() {
     }
     // OAuth providers route back through /auth/callback which navigates;
     // dev sign-in is direct, so navigate manually.
-    const next = new URLSearchParams(window.location.search).get("next") ?? "/";
     navigate({ to: next });
   };
 
+  const heading = isAnon ? "Save your work to your account" : "Sign in";
+  const copy = isAnon
+    ? "Sign in to save your decks to your account, where you can access them from any device."
+    : "Sign in to create and edit decks. Anyone can view shared decks via link.";
+
   return (
     <section className={styles.login} aria-labelledby="signin-heading">
-      <h1 id="signin-heading">Sign in</h1>
-      <p className={styles.copy}>
-        Sign in to create and edit decks. Anyone can view shared decks via link.
-      </p>
+      <h1 id="signin-heading">{heading}</h1>
+      <p className={styles.copy}>{copy}</p>
       {/* biome-ignore lint/a11y/noRedundantRoles: required because list-style:none strips the implicit list role in WebKit */}
       <ul className={styles.providers} role="list">
         {import.meta.env.VITE_AUTH_GOOGLE_ENABLED === "true" && (
           <li>
-            <OAuthButton provider="google" onPress={() => signIn("google")} />
+            <OAuthButton provider="google" onPress={() => void signIn("google")} />
           </li>
         )}
         {import.meta.env.VITE_AUTH_GITHUB_ENABLED === "true" && (
           <li>
-            <OAuthButton provider="github" onPress={() => signIn("github")} />
+            <OAuthButton provider="github" onPress={() => void signIn("github")} />
           </li>
         )}
         {import.meta.env.DEV && (

--- a/src/auth/anonImport.test.ts
+++ b/src/auth/anonImport.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { clear, type PendingAnonImport, readPending, stash, tryResume } from "./anonImport";
+
+describe("anonImport storage", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns null when nothing is stashed", () => {
+    expect(readPending()).toBeNull();
+  });
+
+  it("round-trips a stashed payload", () => {
+    const payload: PendingAnonImport = {
+      version: 1,
+      anonUuid: "00000000-0000-0000-0000-000000000001",
+      importedDeckIds: [],
+    };
+    stash(payload);
+    expect(readPending()).toEqual(payload);
+  });
+
+  it("clears the stashed payload", () => {
+    stash({ version: 1, anonUuid: "x", importedDeckIds: [] });
+    clear();
+    expect(readPending()).toBeNull();
+  });
+
+  it("returns null and does not throw on a malformed value", () => {
+    window.localStorage.setItem("dndCards.pendingAnonImport", "not json");
+    expect(readPending()).toBeNull();
+  });
+
+  it("returns null on a stashed value with an unknown version", () => {
+    window.localStorage.setItem(
+      "dndCards.pendingAnonImport",
+      JSON.stringify({ version: 999, anonUuid: "x", importedDeckIds: [] }),
+    );
+    expect(readPending()).toBeNull();
+  });
+});
+
+type FakeSupabase = {
+  decks: { ownerId: string; id: string; name: string }[];
+  cards: { id: string; deck_id: string; position: number; payload: unknown }[];
+  inserts: { decks: unknown[]; cards: unknown[] };
+};
+
+function makeFakeSupabase(initial: FakeSupabase) {
+  return {
+    state: initial,
+    from(table: string) {
+      const state = initial;
+      return {
+        select() {
+          return {
+            eq(_col: string, val: string) {
+              if (table === "decks") {
+                return Promise.resolve({
+                  data: state.decks
+                    .filter((d) => d.ownerId === val)
+                    .map((d) => ({ id: d.id, owner_id: d.ownerId, name: d.name })),
+                  error: null,
+                });
+              }
+              if (table === "cards") {
+                return Promise.resolve({
+                  data: state.cards.filter((c) => c.deck_id === val),
+                  error: null,
+                });
+              }
+              return Promise.resolve({ data: [], error: null });
+            },
+          };
+        },
+        insert(rows: unknown) {
+          state.inserts[table as "decks" | "cards"].push(rows);
+          return {
+            select() {
+              return {
+                single() {
+                  return Promise.resolve({
+                    data: { id: "new-deck-id", ...(Array.isArray(rows) ? rows[0] : rows) },
+                    error: null,
+                  });
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe("tryResume", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("clones each anon-owned deck and its cards under the new user, then clears the key", async () => {
+    stash({ version: 1, anonUuid: "anon-1", importedDeckIds: [] });
+    const fake = makeFakeSupabase({
+      decks: [{ ownerId: "anon-1", id: "d1", name: "Goblins" }],
+      cards: [{ id: "c1", deck_id: "d1", position: 0, payload: { kind: "item", name: "Sword" } }],
+      inserts: { decks: [], cards: [] },
+    });
+    await tryResume({ supabase: fake as never, currentUserId: "real-1" });
+    expect(fake.state.inserts.decks).toHaveLength(1);
+    expect(fake.state.inserts.cards).toHaveLength(1);
+    expect(readPending()).toBeNull();
+  });
+
+  it("skips decks already in importedDeckIds (resumable)", async () => {
+    stash({ version: 1, anonUuid: "anon-1", importedDeckIds: ["d1"] });
+    const fake = makeFakeSupabase({
+      decks: [
+        { ownerId: "anon-1", id: "d1", name: "Done" },
+        { ownerId: "anon-1", id: "d2", name: "Pending" },
+      ],
+      cards: [{ id: "c2", deck_id: "d2", position: 0, payload: {} }],
+      inserts: { decks: [], cards: [] },
+    });
+    await tryResume({ supabase: fake as never, currentUserId: "real-1" });
+    expect(fake.state.inserts.decks).toHaveLength(1);
+  });
+
+  it("treats zero-rows as already-imported and clears the key without inserting", async () => {
+    stash({ version: 1, anonUuid: "missing-anon", importedDeckIds: [] });
+    const fake = makeFakeSupabase({
+      decks: [],
+      cards: [],
+      inserts: { decks: [], cards: [] },
+    });
+    await tryResume({ supabase: fake as never, currentUserId: "real-1" });
+    expect(fake.state.inserts.decks).toHaveLength(0);
+    expect(readPending()).toBeNull();
+  });
+
+  it("is a no-op when there is no pending import", async () => {
+    const fake = makeFakeSupabase({ decks: [], cards: [], inserts: { decks: [], cards: [] } });
+    const result = await tryResume({ supabase: fake as never, currentUserId: "real-1" });
+    expect(result).toEqual({ kind: "noop" });
+  });
+});

--- a/src/auth/anonImport.test.ts
+++ b/src/auth/anonImport.test.ts
@@ -44,9 +44,11 @@ type FakeSupabase = {
   decks: { ownerId: string; id: string; name: string }[];
   cards: { id: string; deck_id: string; position: number; payload: unknown }[];
   inserts: { decks: unknown[]; cards: unknown[] };
+  insertResults?: { table: string; error: Error | null }[];
 };
 
 function makeFakeSupabase(initial: FakeSupabase) {
+  let insertCallCount = 0;
   return {
     state: initial,
     from(table: string) {
@@ -75,6 +77,15 @@ function makeFakeSupabase(initial: FakeSupabase) {
         },
         insert(rows: unknown) {
           state.inserts[table as "decks" | "cards"].push(rows);
+          const callNum = insertCallCount++;
+          const resultConfig = state.insertResults?.[callNum];
+          if (resultConfig?.error) {
+            return {
+              select: () => ({
+                single: () => Promise.resolve({ data: null, error: resultConfig.error }),
+              }),
+            };
+          }
           return {
             select() {
               return {
@@ -141,5 +152,26 @@ describe("tryResume", () => {
     const fake = makeFakeSupabase({ decks: [], cards: [], inserts: { decks: [], cards: [] } });
     const result = await tryResume({ supabase: fake as never, currentUserId: "real-1" });
     expect(result).toEqual({ kind: "noop" });
+  });
+
+  it("returns partial and re-stashes when deck insert fails mid-loop", async () => {
+    stash({ version: 1, anonUuid: "anon-1", importedDeckIds: [] });
+    const fake = makeFakeSupabase({
+      decks: [
+        { ownerId: "anon-1", id: "d1", name: "First" },
+        { ownerId: "anon-1", id: "d2", name: "Second" },
+      ],
+      cards: [],
+      inserts: { decks: [], cards: [] },
+      insertResults: [
+        { table: "decks", error: null },
+        { table: "decks", error: new Error("boom") },
+      ],
+    });
+    const result = await tryResume({ supabase: fake as never, currentUserId: "real-1" });
+    expect(result).toEqual({ kind: "partial", importedCount: 1, total: 2 });
+    const stashed = readPending();
+    expect(stashed).not.toBeNull();
+    expect(stashed?.importedDeckIds).toEqual(["d1"]);
   });
 });

--- a/src/auth/anonImport.ts
+++ b/src/auth/anonImport.ts
@@ -1,0 +1,101 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const STORAGE_KEY = "dndCards.pendingAnonImport";
+
+export type PendingAnonImport = {
+  version: 1;
+  anonUuid: string;
+  importedDeckIds: string[];
+};
+
+export function stash(payload: PendingAnonImport): void {
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+}
+
+export function clear(): void {
+  window.localStorage.removeItem(STORAGE_KEY);
+}
+
+export function readPending(): PendingAnonImport | null {
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as { version?: number };
+    if (parsed.version !== 1) return null;
+    return parsed as PendingAnonImport;
+  } catch {
+    return null;
+  }
+}
+
+export type ResumeResult =
+  | { kind: "noop" }
+  | { kind: "completed"; importedCount: number }
+  | { kind: "partial"; importedCount: number; total: number };
+
+export async function tryResume(args: {
+  supabase: SupabaseClient;
+  currentUserId: string;
+  onProgress?: (imported: number, total: number) => void;
+}): Promise<ResumeResult> {
+  const pending = readPending();
+  if (!pending) return { kind: "noop" };
+
+  const { data: anonDecks, error: deckError } = await args.supabase
+    .from("decks")
+    .select("id, name")
+    .eq("owner_id", pending.anonUuid);
+  if (deckError) throw deckError;
+  if (!anonDecks || anonDecks.length === 0) {
+    clear();
+    return { kind: "completed", importedCount: 0 };
+  }
+
+  const total = anonDecks.length;
+  let imported = pending.importedDeckIds.length;
+  args.onProgress?.(imported, total);
+
+  for (const deck of anonDecks as Array<{ id: string; name: string }>) {
+    if (pending.importedDeckIds.includes(deck.id)) continue;
+
+    const { data: newDeck, error: insertDeckError } = await args.supabase
+      .from("decks")
+      .insert({ owner_id: args.currentUserId, name: deck.name })
+      .select()
+      .single();
+    if (insertDeckError) {
+      stash(pending);
+      return { kind: "partial", importedCount: imported, total };
+    }
+
+    const { data: cards, error: cardsError } = await args.supabase
+      .from("cards")
+      .select("position, payload")
+      .eq("deck_id", deck.id);
+    if (cardsError) {
+      stash(pending);
+      return { kind: "partial", importedCount: imported, total };
+    }
+
+    if (cards && cards.length > 0) {
+      const rows = (cards as Array<{ position: number; payload: unknown }>).map((c) => ({
+        deck_id: (newDeck as { id: string }).id,
+        position: c.position,
+        payload: c.payload,
+      }));
+      const { error: insertCardsError } = await args.supabase.from("cards").insert(rows);
+      if (insertCardsError) {
+        stash(pending);
+        return { kind: "partial", importedCount: imported, total };
+      }
+    }
+
+    pending.importedDeckIds.push(deck.id);
+    imported += 1;
+    stash(pending);
+    args.onProgress?.(imported, total);
+  }
+
+  clear();
+  return { kind: "completed", importedCount: imported };
+}

--- a/src/auth/safeNext.test.ts
+++ b/src/auth/safeNext.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { safeNext } from "./safeNext";
+
+describe("safeNext", () => {
+  it("returns / for null/undefined/empty/non-string", () => {
+    expect(safeNext(null)).toBe("/");
+    expect(safeNext(undefined)).toBe("/");
+    expect(safeNext("")).toBe("/");
+    expect(safeNext(42)).toBe("/");
+  });
+
+  it("returns / for protocol-relative URLs", () => {
+    expect(safeNext("//evil.com")).toBe("/");
+    expect(safeNext("//evil.com/foo")).toBe("/");
+  });
+
+  it("returns / for absolute URLs", () => {
+    expect(safeNext("https://evil.com")).toBe("/");
+    expect(safeNext("http://evil.com/path")).toBe("/");
+  });
+
+  it("returns / for backslash-prefixed paths", () => {
+    expect(safeNext("/\\evil.com")).toBe("/");
+  });
+
+  it("returns / for paths that don't start with /", () => {
+    expect(safeNext("evil.com")).toBe("/");
+    expect(safeNext("./../etc")).toBe("/");
+  });
+
+  it("returns the path for valid relative paths", () => {
+    expect(safeNext("/")).toBe("/");
+    expect(safeNext("/deck/abc")).toBe("/deck/abc");
+    expect(safeNext("/login?next=/foo")).toBe("/login?next=/foo");
+  });
+});

--- a/src/auth/safeNext.ts
+++ b/src/auth/safeNext.ts
@@ -1,0 +1,17 @@
+// Restrict `next` to a relative same-origin path. Rejects:
+//  - protocol-relative URLs ("//evil.com")
+//  - absolute URLs ("https://evil.com", "http://...")
+//  - backslash-prefixed paths ("/\\evil.com" — IE/Edge quirk)
+//  - empty / non-string
+// Returns "/" for any rejected input.
+export function safeNext(raw: unknown): string {
+  if (typeof raw !== "string" || raw.length === 0) return "/";
+  if (!raw.startsWith("/")) return "/";
+  if (raw.startsWith("//")) return "/";
+  if (raw.startsWith("/\\")) return "/";
+  return raw;
+}
+
+export function readNextFromUrl(): string {
+  return safeNext(new URLSearchParams(window.location.search).get("next"));
+}

--- a/src/lib/anonEnabled.test.ts
+++ b/src/lib/anonEnabled.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isAnonUsersEnabled } from "./anonEnabled";
+
+describe("isAnonUsersEnabled", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns true when VITE_ANON_USERS_ENABLED === "true"', () => {
+    vi.stubEnv("VITE_ANON_USERS_ENABLED", "true");
+    expect(isAnonUsersEnabled()).toBe(true);
+  });
+
+  it("returns false when the env var is unset", () => {
+    vi.stubEnv("VITE_ANON_USERS_ENABLED", "");
+    expect(isAnonUsersEnabled()).toBe(false);
+  });
+
+  it('returns false for any non-"true" value', () => {
+    vi.stubEnv("VITE_ANON_USERS_ENABLED", "1");
+    expect(isAnonUsersEnabled()).toBe(false);
+  });
+});

--- a/src/lib/anonEnabled.ts
+++ b/src/lib/anonEnabled.ts
@@ -1,0 +1,3 @@
+export function isAnonUsersEnabled(): boolean {
+  return import.meta.env.VITE_ANON_USERS_ENABLED === "true";
+}

--- a/src/lib/pluralize.test.ts
+++ b/src/lib/pluralize.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { pluralize } from "./pluralize";
+
+describe("pluralize", () => {
+  it("uses the plural form for zero", () => {
+    expect(pluralize(0, "deck")).toBe("0 decks");
+  });
+
+  it("uses the singular form for one", () => {
+    expect(pluralize(1, "deck")).toBe("1 deck");
+  });
+
+  it("uses the plural form for counts greater than one", () => {
+    expect(pluralize(2, "deck")).toBe("2 decks");
+  });
+
+  it("accepts a custom plural form", () => {
+    expect(pluralize(3, "octopus", "octopi")).toBe("3 octopi");
+  });
+});

--- a/src/lib/pluralize.ts
+++ b/src/lib/pluralize.ts
@@ -1,0 +1,3 @@
+export function pluralize(count: number, singular: string, plural?: string): string {
+  return count === 1 ? `${count} ${singular}` : `${count} ${plural ?? `${singular}s`}`;
+}

--- a/src/lib/ui/Announcement.module.css
+++ b/src/lib/ui/Announcement.module.css
@@ -1,0 +1,30 @@
+.root {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  margin-bottom: var(--space-3);
+  color: var(--color-text);
+  font-size: var(--fs-sm);
+}
+
+.message {
+  flex: 1;
+}
+
+.dismiss {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  font-size: var(--fs-md);
+  color: var(--color-text-muted);
+  padding: 0 var(--space-1);
+}
+
+.dismiss:hover {
+  color: var(--color-text);
+}

--- a/src/lib/ui/Announcement.test.tsx
+++ b/src/lib/ui/Announcement.test.tsx
@@ -44,7 +44,7 @@ describe("<Announcement>", () => {
     expect(screen.getByRole("status")).toHaveTextContent("Signed in");
   });
 
-  it("auto-dismisses after 5 seconds", async () => {
+  it("auto-dismisses after 10 seconds", async () => {
     const user = userEvent.setup();
     render(
       <AnnouncementProvider>
@@ -55,7 +55,11 @@ describe("<Announcement>", () => {
     await user.click(screen.getByText("set"));
     expect(screen.getByRole("status")).toBeInTheDocument();
     act(() => {
-      vi.advanceTimersByTime(5000);
+      vi.advanceTimersByTime(9000);
+    });
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(1000);
     });
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
   });

--- a/src/lib/ui/Announcement.test.tsx
+++ b/src/lib/ui/Announcement.test.tsx
@@ -1,0 +1,88 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Announcement, AnnouncementProvider, useSetNextAnnouncement } from "./Announcement";
+
+function Setter({ message }: { message: string | null }) {
+  const setNext = useSetNextAnnouncement();
+  return (
+    <button type="button" onClick={() => setNext(message)}>
+      set
+    </button>
+  );
+}
+
+describe("<Announcement>", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders nothing when no announcement is queued", () => {
+    const { container } = render(
+      <AnnouncementProvider>
+        <Announcement />
+      </AnnouncementProvider>,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the queued message when mounted after the setter ran", async () => {
+    const user = userEvent.setup();
+    function Harness() {
+      return (
+        <AnnouncementProvider>
+          <Setter message="Signed in" />
+          <Announcement />
+        </AnnouncementProvider>
+      );
+    }
+    render(<Harness />);
+    await user.click(screen.getByText("set"));
+    expect(screen.getByRole("status")).toHaveTextContent("Signed in");
+  });
+
+  it("auto-dismisses after 5 seconds", async () => {
+    const user = userEvent.setup();
+    render(
+      <AnnouncementProvider>
+        <Setter message="Imported 3 decks" />
+        <Announcement />
+      </AnnouncementProvider>,
+    );
+    await user.click(screen.getByText("set"));
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("dismisses on user click of the close button", async () => {
+    const user = userEvent.setup();
+    render(
+      <AnnouncementProvider>
+        <Setter message="Imported 3 decks" />
+        <Announcement />
+      </AnnouncementProvider>,
+    );
+    await user.click(screen.getByText("set"));
+    await user.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it('marks the message with role="status" and aria-live="polite"', async () => {
+    const user = userEvent.setup();
+    render(
+      <AnnouncementProvider>
+        <Setter message="Hello" />
+        <Announcement />
+      </AnnouncementProvider>,
+    );
+    await user.click(screen.getByText("set"));
+    const status = screen.getByRole("status");
+    expect(status).toHaveAttribute("aria-live", "polite");
+  });
+});

--- a/src/lib/ui/Announcement.tsx
+++ b/src/lib/ui/Announcement.tsx
@@ -35,7 +35,7 @@ export function AnnouncementProvider({ children }: { children: ReactNode }) {
     },
     setNext: (message) => {
       slotRef.current.message = message;
-      for (const fn of subsRef.current) fn();
+      for (const fn of Array.from(subsRef.current)) fn();
     },
   }).current;
   return <AnnouncementContext.Provider value={value}>{children}</AnnouncementContext.Provider>;

--- a/src/lib/ui/Announcement.tsx
+++ b/src/lib/ui/Announcement.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import styles from "./Announcement.module.css";
 
-const AUTO_DISMISS_MS = 5000;
+const AUTO_DISMISS_MS = 10000;
 
 type Slot = { message: string | null };
 type Subscriber = () => void;

--- a/src/lib/ui/Announcement.tsx
+++ b/src/lib/ui/Announcement.tsx
@@ -1,0 +1,94 @@
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import styles from "./Announcement.module.css";
+
+const AUTO_DISMISS_MS = 5000;
+
+type Slot = { message: string | null };
+type Subscriber = () => void;
+
+type ContextValue = {
+  slotRef: { current: Slot };
+  subscribe: (fn: Subscriber) => () => void;
+  setNext: (message: string | null) => void;
+};
+
+const AnnouncementContext = createContext<ContextValue | null>(null);
+
+export function AnnouncementProvider({ children }: { children: ReactNode }) {
+  const slotRef = useRef<Slot>({ message: null });
+  const subsRef = useRef<Set<Subscriber>>(new Set());
+  const value = useRef<ContextValue>({
+    slotRef,
+    subscribe: (fn) => {
+      subsRef.current.add(fn);
+      return () => {
+        subsRef.current.delete(fn);
+      };
+    },
+    setNext: (message) => {
+      slotRef.current.message = message;
+      for (const fn of subsRef.current) fn();
+    },
+  }).current;
+  return <AnnouncementContext.Provider value={value}>{children}</AnnouncementContext.Provider>;
+}
+
+export function useSetNextAnnouncement() {
+  const ctx = useContext(AnnouncementContext);
+  if (!ctx) {
+    throw new Error("useSetNextAnnouncement must be used inside <AnnouncementProvider>");
+  }
+  return useCallback(
+    (message: string | null) => {
+      ctx.setNext(message);
+    },
+    [ctx],
+  );
+}
+
+export function Announcement() {
+  const ctx = useContext(AnnouncementContext);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!ctx) return;
+    const consume = () => {
+      const queued = ctx.slotRef.current.message;
+      if (queued) {
+        setMessage(queued);
+        ctx.slotRef.current.message = null;
+      }
+    };
+    consume();
+    return ctx.subscribe(consume);
+  }, [ctx]);
+
+  useEffect(() => {
+    if (!message) return;
+    const id = window.setTimeout(() => setMessage(null), AUTO_DISMISS_MS);
+    return () => window.clearTimeout(id);
+  }, [message]);
+
+  if (!message) return null;
+  return (
+    <div className={styles.root} role="status" aria-live="polite">
+      <span className={styles.message}>{message}</span>
+      <button
+        type="button"
+        className={styles.dismiss}
+        aria-label="Dismiss announcement"
+        onClick={() => setMessage(null)}
+      >
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/src/lib/ui/DialogHeader.tsx
+++ b/src/lib/ui/DialogHeader.tsx
@@ -18,7 +18,7 @@ export function DialogHeader({ title, onClose, closeLabel, children }: DialogHea
       {children !== undefined && <div className={styles.slot}>{children}</div>}
       {closeLabel ? (
         <Button variant="secondary" size="sm" onPress={onClose}>
-          <XIcon size={16} aria-hidden /> {closeLabel}
+          <XIcon size={16} /> {closeLabel}
         </Button>
       ) : (
         <IconButton aria-label="Close" onPress={onClose}>

--- a/src/lib/ui/DialogHeader.tsx
+++ b/src/lib/ui/DialogHeader.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { Button } from "./Button";
 import styles from "./DialogHeader.module.css";
 import { IconButton } from "./IconButton";
 import { XIcon } from "./icons/XIcon";
@@ -6,17 +7,24 @@ import { XIcon } from "./icons/XIcon";
 export type DialogHeaderProps = {
   title: string;
   onClose: () => void;
+  closeLabel?: string;
   children?: ReactNode;
 };
 
-export function DialogHeader({ title, onClose, children }: DialogHeaderProps) {
+export function DialogHeader({ title, onClose, closeLabel, children }: DialogHeaderProps) {
   return (
     <header className={styles.header}>
       <h2 className={styles.title}>{title}</h2>
       {children !== undefined && <div className={styles.slot}>{children}</div>}
-      <IconButton aria-label="Close" onPress={onClose}>
-        <XIcon size={20} />
-      </IconButton>
+      {closeLabel ? (
+        <Button variant="secondary" size="sm" onPress={onClose}>
+          <XIcon size={16} aria-hidden /> {closeLabel}
+        </Button>
+      ) : (
+        <IconButton aria-label="Close" onPress={onClose}>
+          <XIcon size={20} />
+        </IconButton>
+      )}
     </header>
   );
 }

--- a/src/lib/ui/UserMenu.module.css
+++ b/src/lib/ui/UserMenu.module.css
@@ -71,3 +71,29 @@
 .menuItem[data-hovered] {
   background: var(--color-surface-2);
 }
+
+.pillCta {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-accent);
+  color: var(--color-accent-fg);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: var(--fs-sm);
+  transition:
+    background 0.12s,
+    box-shadow 0.12s,
+    transform 0.05s;
+}
+
+.pillCta:hover {
+  background: var(--color-accent-hover);
+  box-shadow: var(--shadow-accent);
+}
+
+.pillCta:active {
+  background: var(--color-accent-active);
+  transform: translateY(1px);
+}

--- a/src/lib/ui/UserMenu.test.tsx
+++ b/src/lib/ui/UserMenu.test.tsx
@@ -74,4 +74,23 @@ describe("<UserMenu>", () => {
     await userEvent.click(screen.getByRole("menuitem", { name: /sign out/i }));
     expect(spy).toHaveBeenCalled();
   });
+
+  it("renders an accent pill linking to /login when the user is anonymous", () => {
+    wrap({
+      status: "authenticated",
+      user: { id: "anon-1", email: null, is_anonymous: true } as never,
+      session: {} as never,
+    });
+    const link = screen.getByRole("link", { name: /sign in to save your work/i });
+    expect(link).toHaveAttribute("href", "/login");
+  });
+
+  it("does NOT render the avatar/menu when the user is anonymous", () => {
+    wrap({
+      status: "authenticated",
+      user: { id: "anon-1", email: null, is_anonymous: true } as never,
+      session: {} as never,
+    });
+    expect(screen.queryByRole("button", { name: /account menu/i })).not.toBeInTheDocument();
+  });
 });

--- a/src/lib/ui/UserMenu.tsx
+++ b/src/lib/ui/UserMenu.tsx
@@ -23,6 +23,14 @@ export function UserMenu() {
     );
   }
 
+  if (session.user.is_anonymous) {
+    return (
+      <Link to="/login" className={styles.pillCta}>
+        Sign in to save your work
+      </Link>
+    );
+  }
+
   const email = session.user.email ?? "";
 
   return (

--- a/src/test/msw.ts
+++ b/src/test/msw.ts
@@ -51,6 +51,9 @@ export const supabaseDefaultHandlers = [
     });
   }),
   http.post(`${SB_URL}/auth/v1/logout`, () => new HttpResponse(null, { status: 204 })),
+  http.post(`${SB_URL}/auth/v1/user/identities/authorize`, () =>
+    HttpResponse.json({ url: "https://example.com/oauth", provider: "google" }),
+  ),
   http.post(`${SB_URL}/auth/v1/signup`, async ({ request }) => {
     // The Supabase client calls /signup with no email/password for
     // signInAnonymously(); we only mock that anon-signup case here.

--- a/src/test/msw.ts
+++ b/src/test/msw.ts
@@ -51,6 +51,21 @@ export const supabaseDefaultHandlers = [
     });
   }),
   http.post(`${SB_URL}/auth/v1/logout`, () => new HttpResponse(null, { status: 204 })),
+  http.post(`${SB_URL}/auth/v1/signup`, async ({ request }) => {
+    // The Supabase client calls /signup with no email/password for
+    // signInAnonymously(); we only mock that anon-signup case here.
+    const body = (await request.json()) as { email?: string; password?: string };
+    if (body.email || body.password) {
+      return new HttpResponse("only anon signup mocked", { status: 400 });
+    }
+    return HttpResponse.json({
+      access_token: "fake-anon-jwt",
+      refresh_token: "fake-anon-refresh",
+      token_type: "bearer",
+      expires_in: 3600,
+      user: { id: "anon-test-id", is_anonymous: true, email: null },
+    });
+  }),
 ];
 
 // Pass the defaults to setupServer so they survive `server.resetHandlers()`

--- a/src/views/FirstDeckDialog.module.css
+++ b/src/views/FirstDeckDialog.module.css
@@ -1,0 +1,35 @@
+.body {
+  padding: var(--space-3) var(--space-4);
+  color: var(--color-text);
+}
+
+.body p {
+  margin: 0 0 var(--space-3) 0;
+}
+
+.body p:last-child {
+  margin-bottom: 0;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+}
+
+.primary {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-accent);
+  color: var(--color-accent-fg);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.primary:hover {
+  background: var(--color-accent-hover);
+}

--- a/src/views/FirstDeckDialog.test.tsx
+++ b/src/views/FirstDeckDialog.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { FirstDeckDialog } from "./FirstDeckDialog";
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual =
+    await vi.importActual<typeof import("@tanstack/react-router")>("@tanstack/react-router");
+  return {
+    ...actual,
+    Link: ({
+      children,
+      to,
+      ...rest
+    }: { children: ReactNode; to?: string } & Record<string, unknown>) => (
+      <a href={to as string} {...rest}>
+        {children}
+      </a>
+    ),
+  };
+});
+
+describe("<FirstDeckDialog>", () => {
+  it("renders the heading and copy when open", () => {
+    render(<FirstDeckDialog isOpen onOpenChange={() => {}} />);
+    expect(
+      screen.getByRole("heading", { name: /your decks live on this browser/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/30 days/i)).toBeInTheDocument();
+  });
+
+  it("renders nothing when closed", () => {
+    const { container } = render(<FirstDeckDialog isOpen={false} onOpenChange={() => {}} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('calls onOpenChange(false) when "Not yet" is clicked', async () => {
+    const onOpenChange = vi.fn();
+    render(<FirstDeckDialog isOpen onOpenChange={onOpenChange} />);
+    await userEvent.click(screen.getByRole("button", { name: /not yet/i }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('"Sign in now" is a link to /login', () => {
+    render(<FirstDeckDialog isOpen onOpenChange={() => {}} />);
+    const link = screen.getByRole("link", { name: /sign in now/i });
+    expect(link).toHaveAttribute("href", "/login");
+  });
+});

--- a/src/views/FirstDeckDialog.tsx
+++ b/src/views/FirstDeckDialog.tsx
@@ -22,14 +22,10 @@ export function FirstDeckDialog({ isOpen, onOpenChange }: Props) {
           <DialogHeader title="Your decks live on this browser" onClose={close} />
           <div className={styles.body}>
             <p>
-              You're not signed in, so your new deck only exists here on this device — not on your
-              phone, your other laptop, or anywhere else. Sign in any time to save your decks to
-              your account, where you can access them from any device.
+              You're not signed in, so your decks only exist on this device. If you clear browsing
+              data, switch browsers, or don't visit for 30 days, your decks may be lost.
             </p>
-            <p>
-              Otherwise, your decks may be lost if you clear browsing data, switch browsers, or
-              don't visit for 30 days.
-            </p>
+            <p>Link an account to save decks permanently and from any device.</p>
           </div>
           <div className={styles.actions}>
             <Button variant="secondary" onPress={close}>

--- a/src/views/FirstDeckDialog.tsx
+++ b/src/views/FirstDeckDialog.tsx
@@ -1,0 +1,46 @@
+import { Link } from "@tanstack/react-router";
+import { Button } from "../lib/ui/Button";
+import { DialogHeader } from "../lib/ui/DialogHeader";
+import { DialogShell } from "../lib/ui/DialogShell";
+import styles from "./FirstDeckDialog.module.css";
+
+type Props = {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function FirstDeckDialog({ isOpen, onOpenChange }: Props) {
+  if (!isOpen) return null;
+  return (
+    <DialogShell
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      aria-label="Your decks live on this browser"
+    >
+      {({ close }) => (
+        <>
+          <DialogHeader title="Your decks live on this browser" onClose={close} />
+          <div className={styles.body}>
+            <p>
+              You're not signed in, so your new deck only exists here on this device — not on your
+              phone, your other laptop, or anywhere else. Sign in any time to save your decks to
+              your account, where you can access them from any device.
+            </p>
+            <p>
+              Otherwise, your decks may be lost if you clear browsing data, switch browsers, or
+              don't visit for 30 days.
+            </p>
+          </div>
+          <div className={styles.actions}>
+            <Button variant="secondary" onPress={close}>
+              Not yet
+            </Button>
+            <Link to="/login" className={styles.primary}>
+              Sign in now
+            </Link>
+          </div>
+        </>
+      )}
+    </DialogShell>
+  );
+}

--- a/src/views/HomeView.test.tsx
+++ b/src/views/HomeView.test.tsx
@@ -3,9 +3,10 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { supabase } from "../api/supabase";
 import { AuthProvider } from "../auth/AuthProvider";
+import * as useSessionMod from "../auth/useSession";
 import { makeCardRow, makeDeckRow } from "../test/factories";
 import { server } from "../test/msw";
 import { signInTestUser } from "../test/signInTestUser";
@@ -154,5 +155,60 @@ describe("HomeView", () => {
     const del = await screen.findByRole("button", { name: `Delete ${deck.name}` });
     await userEvent.click(del);
     await waitFor(() => expect(onDelete).toHaveBeenCalled());
+  });
+});
+
+describe("HomeView with anon user", () => {
+  beforeEach(() => {
+    navigate.mockClear();
+    window.localStorage.clear();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function renderAsAnon() {
+    vi.spyOn(useSessionMod, "useSession").mockReturnValue({
+      status: "authenticated",
+      user: { id: "anon-1", email: null, is_anonymous: true } as never,
+      session: {} as never,
+    });
+    return render(wrap(<HomeView />));
+  }
+
+  it("opens the FirstDeckDialog after an anonymous user creates their first deck", async () => {
+    const inserted = makeDeckRow.build({ name: "Untitled deck", owner_id: "anon-1" });
+    server.use(
+      http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([])),
+      http.post(`${SB}/rest/v1/decks`, () => HttpResponse.json([inserted], { status: 201 })),
+    );
+    renderAsAnon();
+    await userEvent.click(await screen.findByRole("button", { name: /create your first deck/i }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: /your decks live on this browser/i }),
+      ).toBeInTheDocument(),
+    );
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("does NOT open the FirstDeckDialog if it has already been seen", async () => {
+    window.localStorage.setItem("dndCards.firstDeckExplainerSeen", "1");
+    const inserted = makeDeckRow.build({ name: "Untitled deck", owner_id: "anon-1" });
+    server.use(
+      http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([])),
+      http.post(`${SB}/rest/v1/decks`, () => HttpResponse.json([inserted], { status: 201 })),
+    );
+    renderAsAnon();
+    await userEvent.click(await screen.findByRole("button", { name: /create your first deck/i }));
+    await waitFor(() =>
+      expect(navigate).toHaveBeenCalledWith({
+        to: "/deck/$deckId",
+        params: { deckId: inserted.id },
+      }),
+    );
+    expect(
+      screen.queryByRole("heading", { name: /your decks live on this browser/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/views/HomeView.test.tsx
+++ b/src/views/HomeView.test.tsx
@@ -52,6 +52,17 @@ describe("HomeView", () => {
     await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: "/login" }));
   });
 
+  it("renders a LoadingState while the session is initializing", () => {
+    vi.spyOn(useSessionMod, "useSession").mockReturnValue({
+      status: "loading",
+      user: null,
+      session: null,
+    });
+    render(wrap(<HomeView />));
+    expect(screen.getByRole("status")).toHaveTextContent(/loading/i);
+    vi.restoreAllMocks();
+  });
+
   it("shows the user's decks when authenticated", async () => {
     await signInTestUser();
     const decks = [makeDeckRow.build(), makeDeckRow.build()];

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -30,6 +30,7 @@ export function HomeView() {
     }
   }, [session.status, navigate]);
 
+  if (session.status === "loading") return <LoadingState />;
   if (session.status !== "authenticated") return null;
 
   const maybeShowFirstDeckExplainer = () => {

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -1,5 +1,5 @@
 import { Link, useNavigate } from "@tanstack/react-router";
-import { type ChangeEvent, useEffect, useRef } from "react";
+import { type ChangeEvent, useEffect, useRef, useState } from "react";
 import { useSession } from "../auth/useSession";
 import { parseDeckJson } from "../decks/io";
 import { useCreateDeck, useDeleteDeck, useSaveCard } from "../decks/mutations";
@@ -10,6 +10,7 @@ import { EmptyHero } from "../lib/ui/EmptyHero";
 import { IconButton } from "../lib/ui/IconButton";
 import { TrashIcon } from "../lib/ui/icons/TrashIcon";
 import { LoadingState } from "../lib/ui/LoadingState";
+import { FirstDeckDialog } from "./FirstDeckDialog";
 import styles from "./HomeView.module.css";
 
 export function HomeView() {
@@ -21,6 +22,7 @@ export function HomeView() {
   const deleteDeck = useDeleteDeck();
   const saveCard = useSaveCard();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [showFirstDeckDialog, setShowFirstDeckDialog] = useState(false);
 
   useEffect(() => {
     if (session.status === "unauthenticated") {
@@ -29,6 +31,15 @@ export function HomeView() {
   }, [session.status, navigate]);
 
   if (session.status !== "authenticated") return null;
+
+  const maybeShowFirstDeckExplainer = () => {
+    if (session.status !== "authenticated") return false;
+    if (!session.user.is_anonymous) return false;
+    if (window.localStorage.getItem("dndCards.firstDeckExplainerSeen")) return false;
+    window.localStorage.setItem("dndCards.firstDeckExplainerSeen", "1");
+    setShowFirstDeckDialog(true);
+    return true;
+  };
 
   const handleImport = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -52,6 +63,7 @@ export function HomeView() {
         alert(`Import failed mid-way: ${err instanceof Error ? err.message : "unknown error"}`);
         return;
       }
+      if (maybeShowFirstDeckExplainer()) return;
       navigate({ to: "/deck/$deckId", params: { deckId: deck.id } });
     } finally {
       e.target.value = "";
@@ -61,6 +73,7 @@ export function HomeView() {
   const handleCreate = async () => {
     if (!ownerId) return;
     const deck = await createDeck.mutateAsync({ name: "Untitled deck", ownerId });
+    if (maybeShowFirstDeckExplainer()) return;
     navigate({ to: "/deck/$deckId", params: { deckId: deck.id } });
   };
 
@@ -69,7 +82,17 @@ export function HomeView() {
     deleteDeck.mutate(deckId);
   };
 
-  if (decks.isLoading) return <LoadingState />;
+  const dialog = (
+    <FirstDeckDialog isOpen={showFirstDeckDialog} onOpenChange={setShowFirstDeckDialog} />
+  );
+
+  if (decks.isLoading)
+    return (
+      <>
+        <LoadingState />
+        {dialog}
+      </>
+    );
 
   if (!decks.data || decks.data.length === 0) {
     return (
@@ -95,47 +118,51 @@ export function HomeView() {
           hidden
           onChange={handleImport}
         />
+        {dialog}
       </>
     );
   }
 
   return (
-    <section>
-      <header className={styles.header}>
-        <h2>Your decks</h2>
-        <div className={styles.headerActions}>
-          <Button variant="secondary" onPress={() => fileInputRef.current?.click()}>
-            Import JSON
-          </Button>
-          <Button variant="primary" onPress={handleCreate} isDisabled={createDeck.isPending}>
-            New deck
-          </Button>
-        </div>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="application/json"
-          aria-label="Import JSON"
-          hidden
-          onChange={handleImport}
-        />
-      </header>
-      <ul className={styles.list}>
-        {decks.data.map((d) => (
-          <li key={d.id} className={styles.row}>
-            <Link to="/deck/$deckId" params={{ deckId: d.id }} className={styles.deckLink}>
-              {d.name}
-            </Link>
-            <IconButton
-              aria-label={`Delete ${d.name}`}
-              variant="danger"
-              onPress={() => handleDelete(d.id, d.name)}
-            >
-              <TrashIcon />
-            </IconButton>
-          </li>
-        ))}
-      </ul>
-    </section>
+    <>
+      <section>
+        <header className={styles.header}>
+          <h2>Your decks</h2>
+          <div className={styles.headerActions}>
+            <Button variant="secondary" onPress={() => fileInputRef.current?.click()}>
+              Import JSON
+            </Button>
+            <Button variant="primary" onPress={handleCreate} isDisabled={createDeck.isPending}>
+              New deck
+            </Button>
+          </div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="application/json"
+            aria-label="Import JSON"
+            hidden
+            onChange={handleImport}
+          />
+        </header>
+        <ul className={styles.list}>
+          {decks.data.map((d) => (
+            <li key={d.id} className={styles.row}>
+              <Link to="/deck/$deckId" params={{ deckId: d.id }} className={styles.deckLink}>
+                {d.name}
+              </Link>
+              <IconButton
+                aria-label={`Delete ${d.name}`}
+                variant="danger"
+                onPress={() => handleDelete(d.id, d.name)}
+              >
+                <TrashIcon />
+              </IconButton>
+            </li>
+          ))}
+        </ul>
+      </section>
+      {dialog}
+    </>
   );
 }

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -168,7 +168,7 @@ refresh_token_reuse_interval = 10
 # Allow/disallow new user signups to your project.
 enable_signup = true
 # Allow/disallow anonymous sign-ins to your project.
-enable_anonymous_sign_ins = false
+enable_anonymous_sign_ins = true
 # Allow/disallow testing manual linking of accounts
 enable_manual_linking = false
 # Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.


### PR DESCRIPTION
## Summary

Adds anonymous Supabase user support behind `VITE_ANON_USERS_ENABLED` (on by default in dev). Visitors get a real `auth.users` row from `signInAnonymously()` so they can use the full app without sign-in. When they sign in, the OAuth identity is linked in place (same UUID) — but if that identity is already on a different account, an `ImportAccountDialog` offers a resumable client-side clone of their decks into the existing account. A matching flow exists for the dev sign-in path.

The cancel UX was hardened in response to smoke testing: Esc / X / overlay click no longer destroy the anon session — they just close the dialog. Only an explicit "Skip — leave decks behind" click commits to the destructive path. The header close button is labelled `[✕ Cancel]` to make the safe exit visible.

## Notable details

- **Resumable clone** stashed in `localStorage.dndCards.pendingAnonImport`; survives partial failures and resumes on next sign-in
- **Dev path mirrors OAuth** — same dialog, same handlers — so the import flow is exercisable without OAuth providers configured
- **`AuthProvider` falls back to `unauthenticated`** if `signInAnonymously()` fails (e.g. server has the feature disabled), preventing a forever-loading deadlock
- **`.env.development`** turns the flag on for `vite dev`; production builds and vitest are unaffected
- **Anon-user cleanup is deferred** — research notes captured in `docs/superpowers/handoffs/2026-05-08-anon-user-cleanup-notes.md` for a follow-up
- **RLS hardening via RPC functions is deferred** as a separate PR — universal-read on `decks`/`cards` is pre-existing, worsened by anon sign-in but not introduced by this branch

## Test plan

- [x] 465 unit tests pass (`npm test`)
- [x] Type-check clean (`npx tsc --noEmit`)
- [x] Lint clean (`npx biome check src`)
- [x] Smoke test: anon → save deck → sign in as dev → decks appear (in-place conversion)
- [x] Smoke test: anon → save deck → sign in as existing dev account → import dialog → confirm → decks appear in dev account
- [x] Smoke test: anon → save deck → sign in attempt → Cancel button / Esc → returns to anon home with decks intact
- [x] Branch reviewed locally by code-quality, security, and UX agents — findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)