### PR TITLE
fix(header): use custom focus ring on brand and breadcrumb links

### DIFF
--- a/src/app/root.module.css
+++ b/src/app/root.module.css
@@ -20,6 +20,12 @@
   color: var(--color-text);
   text-decoration: none;
   letter-spacing: 0.02em;
+  border-radius: var(--radius-sm);
+}
+
+.brand:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
 }
 
 .link {
@@ -31,6 +37,11 @@
 
 .link:hover {
   background: var(--color-surface-2);
+}
+
+.link:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 1px;
 }
 
 .iconLink {


### PR DESCRIPTION
### Description (What does it do?)

The brand link ("D&D Cards") and breadcrumb links ("Decks", deck name) in the header had no `:focus-visible` rule, so they fell back to the browser default blue focus outline instead of the site's custom focus ring color (`--color-focus-ring`). This matches the pattern already used by `.iconLink` for the GitHub icon.

### Screenshots (if appropriate):
- [ ] Desktop screenshots

### How can this be tested?

Tab through the header — the brand link and breadcrumb links should now show the site's custom focus ring instead of the browser default.