### PR TITLE
Harden RLS via RPC functions (#49)

### DIFF
--- a/docs/superpowers/plans/2026-05-08-rls-rpc-hardening.md
+++ b/docs/superpowers/plans/2026-05-08-rls-rpc-hardening.md
@@ -1,0 +1,1225 @@
+# RLS + RPC Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the universal-read RLS posture on `decks` and `cards` with owner-only SELECT policies plus three SECURITY DEFINER RPC functions that encode the intended access model (owner-private deck listing, public-by-UUID deck viewing). Refactor TypeScript callers and tests to match.
+
+**Architecture:** SQL migration tightens SELECT policies and adds three RPCs (`list_my_decks`, `get_public_deck`, `get_public_deck_cards`). `get_public_deck` returns an `is_owner` boolean computed server-side from `auth.uid()`, so the client never sees other users' UUIDs. Client-side: `src/decks/queries.ts` calls the RPCs; `DeckView` / `RequireOwner` consume `is_owner` instead of comparing `owner_id` themselves; `decksKey` becomes a no-arg helper; `anonImport` switches to a v2 localStorage payload that stores deck IDs (not the anon UUID) and iterates via the public RPCs. Mutations stay on direct-table operations — owner-only SELECT permits `INSERT/UPDATE … RETURNING` for owner rows.
+
+**Tech Stack:** PostgreSQL + Supabase (RLS, SECURITY DEFINER), React 18 + TypeScript, TanStack Query, `@supabase/supabase-js`, Vitest + RTL + MSW, fishery factories.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-08-rls-rpc-hardening-design.md`
+
+---
+
+## File map
+
+**Create:**
+
+- `supabase/migrations/20260508000000_rls_rpc_hardening.sql` — migration
+
+**Modify:**
+
+- `src/decks/types.ts` — add `DeckSummary`, `PublicDeck` types
+- `src/decks/queries.ts` — `decksKey` no-arg; `useDecks` no-arg + RPC; `useDeck` → RPC returning `PublicDeck`; `useDeckCards` → RPC
+- `src/decks/mutations.ts` — drop arg from two `decksKey(...)` invalidation calls
+- `src/views/HomeView.tsx` — `useDecks()` no arg
+- `src/views/DeckView.tsx` — `isOwner` from `deck.is_owner`
+- `src/auth/RequireOwner.tsx` — `is_owner` instead of `owner_id` comparison
+- `src/auth/anonImport.ts` — v2 payload + RPC-based `tryResume`
+- `src/auth/LoginView.tsx` — two `fetchQuery` blocks switch to RPC + drop `decksKey` arg; `onImportConfirm` prefetches deck ids before stash
+- `src/auth/AuthCallback.tsx` — `onImport` prefetches deck ids before stash
+- `src/test/factories.ts` — add `makeDeckSummary`, `makePublicDeck` factories
+
+**Test files to update:**
+
+- `src/decks/queries.test.tsx` — RPC handlers replace REST GETs; new `useDecks` no-arg signature; `is_owner` on `useDeck`
+- `src/decks/mutations.test.tsx` — drop `decksKey(arg)` if asserted
+- `src/views/HomeView.test.tsx` — RPC handler for `list_my_decks`
+- `src/views/DeckView.test.tsx` — RPC handler for `get_public_deck` + `get_public_deck_cards`; assert on `is_owner` instead of session-vs-owner_id
+- `src/views/EditorView.test.tsx` — RPC handlers for both deck/cards
+- `src/views/PrintView.test.tsx` — same
+- `src/views/BrowseApiModal.test.tsx` — same
+- `src/app/DeckBreadcrumb.test.tsx` — `get_public_deck` handler
+- `src/auth/RequireOwner.test.tsx` — `get_public_deck` with `is_owner`
+- `src/auth/LoginView.test.tsx` — `list_my_decks` handler for the deck-count and stash-prefetch flows
+- `src/auth/AuthCallback.test.tsx` — supabase stub swap from `from('decks')` to `rpc('list_my_decks')`
+- `src/auth/anonImport.test.ts` — v2 payload; fake supabase gains an `rpc` method
+- `e2e/fixtures.ts` — only if it stubs deck reads at the network layer
+
+---
+
+## Order of work
+
+```
+Task 1   Migration (no code dependencies)
+Task 2   Type additions + factories
+Task 3   useDecks + decksKey + all callers
+Task 4   useDeck + PublicDeck + DeckView + RequireOwner
+Task 5   useDeckCards
+Task 6   anonImport v2 (storage + tryResume)
+Task 7   LoginView + AuthCallback stash sites
+Task 8   Final verification (full suite + manual smoke)
+```
+
+Each task is one commit. The full Vitest suite is green at the end of every task.
+
+---
+
+## Task 1: SQL migration
+
+**Files:**
+
+- Create: `supabase/migrations/20260508000000_rls_rpc_hardening.sql`
+
+This task has no direct test coverage. Vitest mocks Supabase at the HTTP layer; the migration is verified end-to-end in Task 8.
+
+- [ ] **Step 1: Create the migration file**
+
+```sql
+-- Replace the universal-read SELECT policies with owner-only.
+-- Cross-identity reads (share-by-link, anon-import) go through the
+-- SECURITY DEFINER RPC functions defined below.
+drop policy if exists decks_select_all on public.decks;
+drop policy if exists cards_select_all on public.cards;
+
+create policy decks_select_owner on public.decks for select
+  using (owner_id = auth.uid());
+
+create policy cards_select_owner on public.cards for select
+  using (exists (
+    select 1 from public.decks d
+    where d.id = cards.deck_id and d.owner_id = auth.uid()
+  ));
+
+-- Owner-scoped: HomeView's deck list.
+create or replace function public.list_my_decks()
+returns table(
+  id          uuid,
+  name        text,
+  created_at  timestamptz,
+  updated_at  timestamptz
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select id, name, created_at, updated_at
+  from public.decks
+  where owner_id = auth.uid()
+  order by created_at desc
+$$;
+
+comment on function public.list_my_decks() is
+  'Owner-scoped read. Returns decks owned by the calling user.';
+
+-- Public read by UUID.
+create or replace function public.get_public_deck(deck_id uuid)
+returns table(
+  id          uuid,
+  name        text,
+  created_at  timestamptz,
+  updated_at  timestamptz,
+  is_owner    boolean
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select
+    id,
+    name,
+    created_at,
+    updated_at,
+    coalesce(owner_id = auth.uid(), false) as is_owner
+  from public.decks
+  where id = deck_id
+$$;
+
+comment on function public.get_public_deck(uuid) is
+  'Public read by UUID — anyone with the deck id can read it. Decks '
+  'are intentionally public-by-link. owner_id is NOT in the return '
+  'shape; is_owner is computed server-side instead.';
+
+create or replace function public.get_public_deck_cards(deck_id uuid)
+returns table(
+  id          uuid,
+  deck_id     uuid,
+  position    integer,
+  payload     jsonb,
+  created_at  timestamptz,
+  updated_at  timestamptz
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select c.id, c.deck_id, c.position, c.payload, c.created_at, c.updated_at
+  from public.cards c
+  where c.deck_id = get_public_deck_cards.deck_id
+  order by c.created_at asc
+$$;
+
+comment on function public.get_public_deck_cards(uuid) is
+  'Public read by UUID — returns cards for a deck readable by anyone '
+  'with the deck id. Same trust model as get_public_deck.';
+
+revoke execute on function public.list_my_decks() from public;
+revoke execute on function public.get_public_deck(uuid) from public;
+revoke execute on function public.get_public_deck_cards(uuid) from public;
+
+grant execute on function public.list_my_decks() to authenticated;
+grant execute on function public.get_public_deck(uuid) to authenticated;
+grant execute on function public.get_public_deck_cards(uuid)
+  to authenticated;
+```
+
+- [ ] **Step 2: Verify the migration parses (syntactically)**
+
+```bash
+npx supabase db reset --debug 2>&1 | tail -20
+```
+
+Expected: migration applies cleanly. If `supabase` CLI isn't available, skip — Task 8 verifies end-to-end. If it errors, fix the SQL inline.
+
+- [ ] **Step 3: Run the existing test suite — should still pass**
+
+```bash
+npm test -- --run
+```
+
+Expected: green. Tests don't talk to the DB, so the migration alone changes nothing in test land.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add supabase/migrations/20260508000000_rls_rpc_hardening.sql
+git commit -m "feat(db): owner-only SELECT + public RPCs for decks/cards (#49)"
+```
+
+---
+
+## Task 2: Add `DeckSummary` and `PublicDeck` types and factories
+
+**Files:**
+
+- Modify: `src/decks/types.ts`
+- Modify: `src/test/factories.ts`
+
+These types are net-additive in this task. The existing `DeckRow` stays — it's still the wire shape for `mutations.ts` (insert/update RETURNING).
+
+- [ ] **Step 1: Add types in `src/decks/types.ts`**
+
+Append to the file (after the existing `CardRow` type):
+
+```ts
+// Returned by list_my_decks() RPC.
+export type DeckSummary = {
+  id: string;
+  name: string;
+  created_at: string;
+  updated_at: string;
+};
+
+// Returned by get_public_deck(deck_id) RPC. Adds is_owner so callers
+// can gate UI without learning the owner's UUID.
+export type PublicDeck = DeckSummary & {
+  is_owner: boolean;
+};
+```
+
+- [ ] **Step 2: Add factories in `src/test/factories.ts`**
+
+Append:
+
+```ts
+import type { DeckSummary, PublicDeck } from "../decks/types";
+
+export const makeDeckSummary = Factory.define<DeckSummary>(() => {
+  const now = faker.date.recent().toISOString();
+  return {
+    id: faker.string.uuid(),
+    name: faker.lorem.words({ min: 2, max: 4 }),
+    created_at: now,
+    updated_at: now,
+  };
+});
+
+export const makePublicDeck = Factory.define<PublicDeck>(() => {
+  const now = faker.date.recent().toISOString();
+  return {
+    id: faker.string.uuid(),
+    name: faker.lorem.words({ min: 2, max: 4 }),
+    created_at: now,
+    updated_at: now,
+    is_owner: false,
+  };
+});
+```
+
+Also extend the existing `export type` re-export line at the top of the file to include the new types:
+
+```ts
+export type { CardRow, DeckRow, DeckSummary, PublicDeck };
+```
+
+- [ ] **Step 3: Run typecheck + tests**
+
+```bash
+npm test -- --run
+```
+
+Expected: green. New types are unused; nothing breaks.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/decks/types.ts src/test/factories.ts
+git commit -m "feat(decks): add DeckSummary and PublicDeck types"
+```
+
+---
+
+## Task 3: `useDecks` + `decksKey` no-arg + all callers
+
+**Files:**
+
+- Modify: `src/decks/queries.ts`
+- Modify: `src/decks/mutations.ts`
+- Modify: `src/views/HomeView.tsx`
+- Modify: `src/auth/LoginView.tsx`
+- Test: `src/decks/queries.test.tsx`
+- Test: `src/views/HomeView.test.tsx`
+- Test: `src/auth/LoginView.test.tsx`
+
+This is a coordinated change: `decksKey` drops its argument, and every caller updates atomically.
+
+- [ ] **Step 1: Update the `useDecks` test in `src/decks/queries.test.tsx`**
+
+Replace the existing `describe("useDecks", ...)` block with:
+
+```tsx
+import { makeDeckSummary } from "../test/factories";
+// ... existing imports
+
+describe("useDecks", () => {
+  it("returns the user's decks via list_my_decks RPC", async () => {
+    const decks = [makeDeckSummary.build(), makeDeckSummary.build()];
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/list_my_decks`, () => HttpResponse.json(decks)),
+    );
+    const { result } = renderHook(() => useDecks(), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(decks);
+  });
+});
+```
+
+(The "is disabled when ownerId is undefined" case goes away — there's no
+ownerId argument anymore.)
+
+- [ ] **Step 2: Run the test — it should fail**
+
+```bash
+npm test -- queries.test
+```
+
+Expected: TypeScript error or runtime error from `useDecks()` being called with no args, plus other tests in the file likely failing because `useDecks` still expects an arg.
+
+- [ ] **Step 3: Update `src/decks/queries.ts`**
+
+Replace lines 1–26 with:
+
+```ts
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "../api/supabase";
+import type { Card } from "../cards/types";
+import { rowToCard } from "./rowMappers";
+import type { CardRow, DeckSummary, PublicDeck } from "./types";
+
+export const decksKey = () => ["decks"] as const;
+export const deckKey = (deckId: string | undefined) => ["deck", deckId] as const;
+export const deckCardsKey = (deckId: string | undefined) =>
+  ["deck-cards", deckId] as const;
+
+/**
+ * Decks owned by the current user — for the home view's deck list.
+ * Server-side: RPC list_my_decks reads auth.uid().
+ */
+export function useDecks() {
+  return useQuery<DeckSummary[]>({
+    queryKey: decksKey(),
+    queryFn: async () => {
+      const { data, error } = await supabase.rpc("list_my_decks");
+      if (error) throw error;
+      return (data ?? []) as DeckSummary[];
+    },
+  });
+}
+```
+
+(Leave `useDeck` and `useDeckCards` untouched for now — Tasks 4 and 5
+handle them.)
+
+- [ ] **Step 4: Update `src/decks/mutations.ts`**
+
+At line 28: `qc.invalidateQueries({ queryKey: decksKey(vars.ownerId) });`
+becomes:
+
+```ts
+qc.invalidateQueries({ queryKey: decksKey() });
+```
+
+At line 49: `qc.invalidateQueries({ queryKey: decksKey(data.owner_id) });`
+becomes:
+
+```ts
+qc.invalidateQueries({ queryKey: decksKey() });
+```
+
+- [ ] **Step 5: Update `src/views/HomeView.tsx`**
+
+Find `const decks = useDecks(ownerId);` (around line 20). Change to:
+
+```ts
+const decks = useDecks();
+```
+
+Leave the surrounding `ownerId` derivation in place — it's still needed
+by `createDeck.mutateAsync({ name, ownerId })` on lines 56 and 76.
+
+- [ ] **Step 6: Update `src/auth/LoginView.tsx`**
+
+Two `queryClient.fetchQuery` blocks (around lines 40–47 and 84–91) switch
+from a direct table query to the RPC. Replace each block:
+
+```ts
+const decks = await queryClient.fetchQuery({
+  queryKey: decksKey(),
+  queryFn: async () => {
+    const { data, error } = await supabase.rpc("list_my_decks");
+    if (error) throw error;
+    return data ?? [];
+  },
+  staleTime: 0,
+});
+```
+
+(The `userId` variable in the surrounding scope is still used elsewhere
+in the function — don't remove it.)
+
+- [ ] **Step 7: Update `src/views/HomeView.test.tsx`**
+
+Replace each `http.get(\`${SB_URL}/rest/v1/decks\`, ...)` handler with the
+RPC equivalent. For example line 69:
+
+```ts
+// Before
+server.use(http.get(`${SB_URL}/rest/v1/decks`, () => HttpResponse.json(decks)));
+// After
+server.use(http.post(`${SB_URL}/rest/v1/rpc/list_my_decks`, () => HttpResponse.json(decks)));
+```
+
+Apply this replacement to each `GET /rest/v1/decks` handler in this file.
+The handlers that mock `POST` / `DELETE` / `PATCH` for `/rest/v1/decks`
+(used by mutations) stay as-is — mutations still hit the table directly.
+
+If existing tests build a `DeckRow` (with `owner_id`), switch to
+`makeDeckSummary.build()` for the list-fetching tests since the new shape
+has no `owner_id`. Tests that exercise mutations keep `makeDeckRow`.
+
+- [ ] **Step 8: Update `src/auth/LoginView.test.tsx`**
+
+Same pattern: GET `/rest/v1/decks` handlers used to back the deck-count
+prefetch become `POST /rest/v1/rpc/list_my_decks`. The response body
+shape changes from rows with `owner_id` to `DeckSummary` (use
+`makeDeckSummary.build()` or simple `[{ id: "d1" }]` literals — the
+prefetch only reads `decks?.length`).
+
+- [ ] **Step 9: Run the suite**
+
+```bash
+npm test -- --run
+```
+
+Expected: all green. If a test you didn't expect to touch fails, audit
+it for `useDecks(ownerId)` calls or `decksKey(arg)` references and
+update.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/decks/queries.ts src/decks/mutations.ts src/views/HomeView.tsx src/auth/LoginView.tsx src/decks/queries.test.tsx src/views/HomeView.test.tsx src/auth/LoginView.test.tsx
+git commit -m "refactor(decks): useDecks via list_my_decks RPC; decksKey no-arg"
+```
+
+---
+
+## Task 4: `useDeck` returns `PublicDeck` + `DeckView` + `RequireOwner`
+
+**Files:**
+
+- Modify: `src/decks/queries.ts`
+- Modify: `src/views/DeckView.tsx`
+- Modify: `src/auth/RequireOwner.tsx`
+- Test: `src/decks/queries.test.tsx`
+- Test: `src/views/DeckView.test.tsx`
+- Test: `src/auth/RequireOwner.test.tsx`
+- Test: `src/app/DeckBreadcrumb.test.tsx`
+- Test: `src/views/EditorView.test.tsx`
+- Test: `src/views/PrintView.test.tsx`
+- Test: `src/views/BrowseApiModal.test.tsx`
+
+- [ ] **Step 1: Update the `useDeck` test**
+
+In `src/decks/queries.test.tsx`, replace the `useDeck` describe block:
+
+```tsx
+import { makePublicDeck } from "../test/factories";
+// ...
+
+describe("useDeck", () => {
+  it("returns a PublicDeck via get_public_deck RPC", async () => {
+    const deck = makePublicDeck.build({ is_owner: true });
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(deck)),
+    );
+    const { result } = renderHook(() => useDeck(deck.id), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(deck);
+  });
+
+  it("returns null when the deck doesn't exist", async () => {
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(null)),
+    );
+    const { result } = renderHook(() => useDeck("missing"), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — should fail**
+
+```bash
+npm test -- queries.test
+```
+
+Expected: failure on `useDeck` tests; rest still green.
+
+- [ ] **Step 3: Update `useDeck` in `src/decks/queries.ts`**
+
+Replace the existing `useDeck` function with:
+
+```ts
+/**
+ * A single deck by id. PUBLIC READ — any caller with the deck id can
+ * read it. There is no ownership filter; this matches the share-by-link
+ * model. The returned row includes `is_owner`, computed server-side
+ * from auth.uid(), which UI uses to gate edit affordances. Mutations
+ * are still owner-gated by RLS on the underlying table.
+ */
+export function useDeck(deckId: string | undefined) {
+  return useQuery<PublicDeck | null>({
+    queryKey: deckKey(deckId),
+    enabled: Boolean(deckId),
+    queryFn: async () => {
+      if (!deckId) return null;
+      const { data, error } = await supabase
+        .rpc("get_public_deck", { deck_id: deckId })
+        .maybeSingle();
+      if (error) throw error;
+      return (data ?? null) as PublicDeck | null;
+    },
+  });
+}
+```
+
+- [ ] **Step 4: Update `src/views/DeckView.tsx`**
+
+At line 32, replace:
+
+```ts
+const isOwner = session.status === "authenticated" && session.user.id === deck.owner_id;
+```
+
+with:
+
+```ts
+const isOwner = deck.is_owner;
+```
+
+If TypeScript flags an unused `session` import, clean it up — but the
+session is likely still used elsewhere in the file. Check before
+deleting.
+
+- [ ] **Step 5: Update `src/auth/RequireOwner.tsx`**
+
+Replace the entire body of the component (the `userId` derivation,
+`ownerId`, the effect, and the render gate) so the new structure reads:
+
+```tsx
+export function RequireOwner({ deckId, children }: Props) {
+  const session = useSession();
+  const deckQuery = useDeck(deckId);
+  const navigate = useNavigate();
+
+  const sessionLoading = session.status === "loading";
+  const userId = session.status === "authenticated" ? session.user.id : null;
+  const isOwner = deckQuery.data?.is_owner;
+
+  useEffect(() => {
+    if (sessionLoading || deckQuery.isLoading) return;
+
+    if (!userId) {
+      const next = `${window.location.pathname}${window.location.search}`;
+      navigate({ to: "/login", search: { next } });
+      return;
+    }
+    if (isOwner === false) {
+      navigate({ to: "/deck/$deckId", params: { deckId } });
+    }
+  }, [sessionLoading, deckQuery.isLoading, userId, isOwner, deckId, navigate]);
+
+  if (sessionLoading || deckQuery.isLoading) return null;
+  if (!userId) return null;
+  if (isOwner !== true) return null;
+  return <>{children}</>;
+}
+```
+
+(Imports stay unchanged. The login-redirect path still depends on the
+session, so `userId` derivation stays — only the ownership comparison
+swaps from `ownerId !== userId` to `isOwner !== true`.)
+
+- [ ] **Step 6: Update `src/views/DeckView.test.tsx`**
+
+Replace `GET /rest/v1/decks` handlers with `POST /rest/v1/rpc/get_public_deck`.
+Use `makePublicDeck.build({ is_owner: true })` for owner scenarios and
+`makePublicDeck.build({ is_owner: false })` for non-owner scenarios.
+Tests that previously asserted ownership via `session.user.id === owner_id`
+no longer need that — the `is_owner` boolean directly carries the truth.
+
+If a test builds `makeDeckRow.build({ owner_id: user.id })` and feeds it
+to a `GET /rest/v1/decks` handler, replace with
+`makePublicDeck.build({ is_owner: true })` and the RPC handler.
+
+Same pattern for the cards mocks: any `GET /rest/v1/cards` handlers
+become `POST /rest/v1/rpc/get_public_deck_cards` (in Task 5; for now the
+DeckView test may still pass with default empty-array behavior from
+existing handlers — verify).
+
+- [ ] **Step 7: Update `src/auth/RequireOwner.test.tsx`**
+
+Replace the two `http.get(\`${SB}/rest/v1/decks\`, ...)` handlers
+(lines ~46 and ~56) with `POST /rest/v1/rpc/get_public_deck` returning
+a `PublicDeck`. The `is_owner` flag drives the test outcome:
+`makePublicDeck.build({ is_owner: true })` for the owner case,
+`makePublicDeck.build({ is_owner: false })` for the non-owner case.
+
+- [ ] **Step 8: Update `src/app/DeckBreadcrumb.test.tsx`, `src/views/EditorView.test.tsx`, `src/views/PrintView.test.tsx`, `src/views/BrowseApiModal.test.tsx`**
+
+Each: any `http.get(\`${SB_URL}/rest/v1/decks\`, ...)` handler that
+backs a `useDeck` call becomes
+`http.post(\`${SB_URL}/rest/v1/rpc/get_public_deck\`, ...)` returning a
+single `PublicDeck` (or null for not-found). Most consumers don't read
+`is_owner` so any boolean works; default to `false` unless the test
+specifically asserts owner-gated UI.
+
+- [ ] **Step 9: Run the suite**
+
+```bash
+npm test -- --run
+```
+
+Expected: green. If `useDeckCards`-related tests fail, defer them — Task 5
+handles those.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/decks/queries.ts src/views/DeckView.tsx src/auth/RequireOwner.tsx src/decks/queries.test.tsx src/views/DeckView.test.tsx src/auth/RequireOwner.test.tsx src/app/DeckBreadcrumb.test.tsx src/views/EditorView.test.tsx src/views/PrintView.test.tsx src/views/BrowseApiModal.test.tsx
+git commit -m "refactor(decks): useDeck via get_public_deck RPC; consume is_owner"
+```
+
+---
+
+## Task 5: `useDeckCards` via `get_public_deck_cards` RPC
+
+**Files:**
+
+- Modify: `src/decks/queries.ts`
+- Test: `src/decks/queries.test.tsx`
+- Test: `src/views/DeckView.test.tsx`
+- Test: `src/views/EditorView.test.tsx`
+- Test: `src/views/PrintView.test.tsx`
+
+- [ ] **Step 1: Update the `useDeckCards` test**
+
+In `src/decks/queries.test.tsx`, replace the existing `useDeckCards`
+describe with:
+
+```tsx
+describe("useDeckCards", () => {
+  it("returns cards for a deck via get_public_deck_cards RPC", async () => {
+    const [firstRow, secondRow] = [makeCardRow.build(), makeCardRow.build()];
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () =>
+        HttpResponse.json([firstRow, secondRow]),
+      ),
+    );
+    const { result } = renderHook(() => useDeckCards("deck-id"), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const cards = result.current.data ?? [];
+    expect(cards).toHaveLength(2);
+    expect(cards.at(0)?.id).toBe(firstRow.id);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — should fail**
+
+```bash
+npm test -- queries.test
+```
+
+Expected: failure on `useDeckCards` test.
+
+- [ ] **Step 3: Update `useDeckCards` in `src/decks/queries.ts`**
+
+Replace the existing function with:
+
+```ts
+/**
+ * Cards for a deck. Same PUBLIC READ semantics as useDeck.
+ */
+export function useDeckCards(deckId: string | undefined) {
+  return useQuery<Card[]>({
+    queryKey: deckCardsKey(deckId),
+    enabled: Boolean(deckId),
+    queryFn: async () => {
+      if (!deckId) return [];
+      const { data, error } = await supabase.rpc(
+        "get_public_deck_cards",
+        { deck_id: deckId },
+      );
+      if (error) throw error;
+      return ((data ?? []) as CardRow[]).map(rowToCard);
+    },
+  });
+}
+```
+
+- [ ] **Step 4: Update view tests**
+
+In each of `src/views/DeckView.test.tsx`, `src/views/EditorView.test.tsx`,
+`src/views/PrintView.test.tsx`: replace any
+`http.get(\`${SB_URL}/rest/v1/cards\`, ...)` handler with
+`http.post(\`${SB_URL}/rest/v1/rpc/get_public_deck_cards\`, ...)`.
+The response body shape (array of `CardRow`) is unchanged.
+
+- [ ] **Step 5: Run the suite**
+
+```bash
+npm test -- --run
+```
+
+Expected: green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/decks/queries.ts src/decks/queries.test.tsx src/views/DeckView.test.tsx src/views/EditorView.test.tsx src/views/PrintView.test.tsx
+git commit -m "refactor(decks): useDeckCards via get_public_deck_cards RPC"
+```
+
+---
+
+## Task 6: `anonImport` v2 payload + RPC-based `tryResume`
+
+**Files:**
+
+- Modify: `src/auth/anonImport.ts`
+- Test: `src/auth/anonImport.test.ts`
+
+- [ ] **Step 1: Update the storage tests**
+
+In `src/auth/anonImport.test.ts`, replace the storage describe block:
+
+```ts
+describe("anonImport storage", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns null when nothing is stashed", () => {
+    expect(readPending()).toBeNull();
+  });
+
+  it("round-trips a v2 payload", () => {
+    const payload: PendingAnonImport = {
+      version: 2,
+      anonDeckIds: ["d1", "d2"],
+      importedDeckIds: [],
+    };
+    stash(payload);
+    expect(readPending()).toEqual(payload);
+  });
+
+  it("clears the stashed payload", () => {
+    stash({ version: 2, anonDeckIds: ["d1"], importedDeckIds: [] });
+    clear();
+    expect(readPending()).toBeNull();
+  });
+
+  it("returns null and does not throw on a malformed value", () => {
+    window.localStorage.setItem("dndCards.pendingAnonImport", "not json");
+    expect(readPending()).toBeNull();
+  });
+
+  it("returns null on a stashed v1 payload (silently dropped)", () => {
+    window.localStorage.setItem(
+      "dndCards.pendingAnonImport",
+      JSON.stringify({
+        version: 1,
+        anonUuid: "00000000-0000-0000-0000-000000000001",
+        importedDeckIds: [],
+      }),
+    );
+    expect(readPending()).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Update `tryResume` tests**
+
+The hand-rolled `makeFakeSupabase` helper needs an `rpc` method. Replace
+the helper and its consumers:
+
+```ts
+type FakeRpcResult = { data: unknown; error: Error | null };
+
+type FakeSupabase = {
+  decksByOwner: Record<string, Array<{ id: string; name: string }>>;
+  deckById: Record<string, { id: string; name: string } | null>;
+  cardsByDeck: Record<string, Array<{ id: string; deck_id: string; position: number; payload: unknown }>>;
+  inserts: { decks: unknown[]; cards: unknown[] };
+  insertResults?: { table: string; error: Error | null }[];
+  rpcResults?: Record<string, FakeRpcResult>;
+};
+
+function makeFakeSupabase(initial: FakeSupabase) {
+  let insertCallCount = 0;
+  return {
+    state: initial,
+    rpc(name: string, params?: Record<string, unknown>) {
+      const override = initial.rpcResults?.[name];
+      if (override) {
+        return {
+          maybeSingle: () => Promise.resolve(override),
+          then: (resolve: (v: FakeRpcResult) => unknown) => Promise.resolve(override).then(resolve),
+        };
+      }
+      if (name === "get_public_deck") {
+        const id = params?.deck_id as string;
+        const row = initial.deckById[id] ?? null;
+        return {
+          maybeSingle: () => Promise.resolve({ data: row, error: null }),
+        };
+      }
+      if (name === "get_public_deck_cards") {
+        const id = params?.deck_id as string;
+        const rows = initial.cardsByDeck[id] ?? [];
+        return Promise.resolve({ data: rows, error: null });
+      }
+      if (name === "list_my_decks") {
+        // Used at stash sites, not in tryResume.
+        return Promise.resolve({ data: [], error: null });
+      }
+      throw new Error(`unmocked rpc: ${name}`);
+    },
+    from(table: string) {
+      // Insert path — kept from the original helper.
+      return {
+        insert(rows: unknown) {
+          initial.inserts[table as "decks" | "cards"].push(rows);
+          const callNum = insertCallCount++;
+          const resultConfig = initial.insertResults?.[callNum];
+          if (resultConfig?.error) {
+            return {
+              select: () => ({
+                single: () => Promise.resolve({ data: null, error: resultConfig.error }),
+              }),
+            };
+          }
+          return {
+            select: () => ({
+              single: () => Promise.resolve({
+                data: { id: "new-deck-id", ...(Array.isArray(rows) ? rows[0] : rows) },
+                error: null,
+              }),
+            }),
+          };
+        },
+      };
+    },
+  };
+}
+```
+
+Update each existing `tryResume` test to (a) stash a v2 payload with
+`anonDeckIds` and (b) populate `deckById` / `cardsByDeck` keyed by deck
+id rather than owner. For example:
+
+```ts
+it("clones each anon-owned deck and its cards under the new user", async () => {
+  stash({ version: 2, anonDeckIds: ["d1"], importedDeckIds: [] });
+  const fake = makeFakeSupabase({
+    decksByOwner: {},
+    deckById: { d1: { id: "d1", name: "Goblins" } },
+    cardsByDeck: { d1: [{ id: "c1", deck_id: "d1", position: 0, payload: { kind: "item", name: "Sword" } }] },
+    inserts: { decks: [], cards: [] },
+  });
+  await tryResume({ supabase: fake as never, currentUserId: "real-1" });
+  expect(fake.state.inserts.decks).toHaveLength(1);
+  expect(fake.state.inserts.cards).toHaveLength(1);
+  expect(readPending()).toBeNull();
+});
+```
+
+Update the partial-resume test similarly: stash with
+`anonDeckIds: ["d1", "d2"]`, populate both deck rows, configure
+`insertResults` so the second deck insert errors, expect
+`{ kind: "partial", importedCount: 1, total: 2 }`. Update the
+"deleted between stash and resume" test (was "zero rows"): stash a
+deck id, set `deckById["missing"] = null`, expect the imported count
+to advance past it without inserting.
+
+- [ ] **Step 3: Run tests — should fail**
+
+```bash
+npm test -- anonImport
+```
+
+Expected: failures on the v2 payload and `tryResume` tests.
+
+- [ ] **Step 4: Rewrite `src/auth/anonImport.ts`**
+
+```ts
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const STORAGE_KEY = "dndCards.pendingAnonImport";
+
+export type PendingAnonImport = {
+  version: 2;
+  anonDeckIds: string[];
+  importedDeckIds: string[];
+};
+
+export function stash(payload: PendingAnonImport): void {
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+}
+
+export function clear(): void {
+  window.localStorage.removeItem(STORAGE_KEY);
+}
+
+export function readPending(): PendingAnonImport | null {
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as { version?: number };
+    if (parsed.version !== 2) return null;
+    return parsed as PendingAnonImport;
+  } catch {
+    return null;
+  }
+}
+
+export type ResumeResult =
+  | { kind: "noop" }
+  | { kind: "completed"; importedCount: number }
+  | { kind: "partial"; importedCount: number; total: number };
+
+export async function tryResume(args: {
+  supabase: SupabaseClient;
+  currentUserId: string;
+  onProgress?: (imported: number, total: number) => void;
+}): Promise<ResumeResult> {
+  const pending = readPending();
+  if (!pending) return { kind: "noop" };
+  if (pending.anonDeckIds.length === 0) {
+    clear();
+    return { kind: "completed", importedCount: 0 };
+  }
+
+  const total = pending.anonDeckIds.length;
+  let imported = pending.importedDeckIds.length;
+  args.onProgress?.(imported, total);
+
+  for (const deckId of pending.anonDeckIds) {
+    if (pending.importedDeckIds.includes(deckId)) continue;
+
+    const { data: oldDeck, error: deckError } = await args.supabase
+      .rpc("get_public_deck", { deck_id: deckId })
+      .maybeSingle();
+    if (deckError) {
+      stash(pending);
+      return { kind: "partial", importedCount: imported, total };
+    }
+    if (!oldDeck) {
+      // Anon deck deleted between stash and resume — mark as imported and continue.
+      pending.importedDeckIds.push(deckId);
+      imported += 1;
+      stash(pending);
+      args.onProgress?.(imported, total);
+      continue;
+    }
+
+    const oldDeckRow = oldDeck as { id: string; name: string };
+
+    const { data: newDeck, error: insertDeckError } = await args.supabase
+      .from("decks")
+      .insert({ owner_id: args.currentUserId, name: oldDeckRow.name })
+      .select()
+      .single();
+    if (insertDeckError) {
+      stash(pending);
+      return { kind: "partial", importedCount: imported, total };
+    }
+
+    const { data: cards, error: cardsError } = await args.supabase.rpc(
+      "get_public_deck_cards",
+      { deck_id: deckId },
+    );
+    if (cardsError) {
+      stash(pending);
+      return { kind: "partial", importedCount: imported, total };
+    }
+
+    const cardRows = (cards ?? []) as Array<{ position: number; payload: unknown }>;
+    if (cardRows.length > 0) {
+      const rows = cardRows.map((c) => ({
+        deck_id: (newDeck as { id: string }).id,
+        position: c.position,
+        payload: c.payload,
+      }));
+      const { error: insertCardsError } = await args.supabase.from("cards").insert(rows);
+      if (insertCardsError) {
+        stash(pending);
+        return { kind: "partial", importedCount: imported, total };
+      }
+    }
+
+    pending.importedDeckIds.push(deckId);
+    imported += 1;
+    stash(pending);
+    args.onProgress?.(imported, total);
+  }
+
+  clear();
+  return { kind: "completed", importedCount: imported };
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+npm test -- anonImport
+```
+
+Expected: green.
+
+- [ ] **Step 6: Run full suite**
+
+```bash
+npm test -- --run
+```
+
+Expected: green. (LoginView/AuthCallback may still pass with default
+handlers; Task 7 cleans up.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/auth/anonImport.ts src/auth/anonImport.test.ts
+git commit -m "refactor(auth): anonImport v2 payload + RPC-based tryResume"
+```
+
+---
+
+## Task 7: `LoginView` + `AuthCallback` stash sites prefetch deck ids
+
+**Files:**
+
+- Modify: `src/auth/LoginView.tsx`
+- Modify: `src/auth/AuthCallback.tsx`
+- Test: `src/auth/LoginView.test.tsx`
+- Test: `src/auth/AuthCallback.test.tsx`
+
+- [ ] **Step 1: Update `src/auth/LoginView.tsx` `onImportConfirm`**
+
+Find the `onImportConfirm` handler (around line 123). Replace the line
+`stash({ version: 1, anonUuid, importedDeckIds: [] });` (around line 128)
+with:
+
+```ts
+const { data: anonDecks, error: listError } = await supabase.rpc("list_my_decks");
+if (listError) {
+  setAnnouncement("Couldn't fetch your decks for import.");
+  return;
+}
+const anonDeckIds = (anonDecks ?? []).map((d: { id: string }) => d.id);
+stash({ version: 2, anonDeckIds, importedDeckIds: [] });
+```
+
+The surrounding `anonUuid` destructuring (around line 125) becomes
+unused — remove it. The rest of the handler (signOut, signInWithPassword,
+tryResume) is unchanged.
+
+- [ ] **Step 2: Update `src/auth/AuthCallback.tsx` `onImport`**
+
+Find the `onImport` handler (around line 101). Replace the line
+`stash({ version: 1, anonUuid: session.user.id, importedDeckIds: [] });`
+(around line 103) with:
+
+```ts
+const { data: anonDecks, error: listError } = await supabase.rpc("list_my_decks");
+if (listError) {
+  setAnnouncement("Couldn't fetch your decks for import.");
+  return;
+}
+const anonDeckIds = (anonDecks ?? []).map((d: { id: string }) => d.id);
+stash({ version: 2, anonDeckIds, importedDeckIds: [] });
+```
+
+- [ ] **Step 3: Update `src/auth/LoginView.test.tsx`**
+
+For tests that exercise the import flow, add a mock for the new
+`list_my_decks` call. Most tests already mock it via Task 3; verify
+the mock returns the right shape (an array with `id` fields). For the
+new failure-mode test:
+
+```tsx
+it("aborts import flow when list_my_decks errors", async () => {
+  server.use(
+    http.post(`${SB_URL}/rest/v1/rpc/list_my_decks`, () =>
+      HttpResponse.json({ message: "boom" }, { status: 500 }),
+    ),
+  );
+  // ... render LoginView, trigger the import path, assert on the announcement
+  // and that no signOut occurred.
+});
+```
+
+Adapt the assertion shape to whatever pattern the file already uses.
+
+- [ ] **Step 4: Update `src/auth/AuthCallback.test.tsx`**
+
+The test stubs `supabase.from()` directly (around line 60). When the
+`onImport` path runs, it now calls `supabase.rpc('list_my_decks')` first.
+Extend the stub to intercept `rpc` as well:
+
+```tsx
+vi.spyOn(supabase, "rpc").mockImplementation((name: string) => {
+  if (name === "list_my_decks") {
+    return Promise.resolve({ data: [{ id: "d1" }], error: null }) as never;
+  }
+  throw new Error(`unmocked rpc: ${name}`);
+});
+```
+
+Adjust to whatever style the existing file uses (jest.fn vs vi.fn vs
+spyOn). The tests that currently exercise the
+`from('decks').select(...).eq('owner_id', ...)` branch now exercise the
+`rpc('list_my_decks')` branch instead.
+
+- [ ] **Step 5: Run the suite**
+
+```bash
+npm test -- --run
+```
+
+Expected: green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/auth/LoginView.tsx src/auth/AuthCallback.tsx src/auth/LoginView.test.tsx src/auth/AuthCallback.test.tsx
+git commit -m "refactor(auth): prefetch anon deck ids before stash"
+```
+
+---
+
+## Task 8: Final verification
+
+**No file changes — verification only.**
+
+- [ ] **Step 1: Full suite**
+
+```bash
+npm test -- --run
+```
+
+Expected: green.
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Build**
+
+```bash
+npm run build
+```
+
+Expected: success.
+
+- [ ] **Step 4: Apply the migration locally and smoke-test**
+
+```bash
+npx supabase db reset
+npm run dev
+```
+
+In the browser:
+- Sign in. HomeView should list your own decks.
+- Open one of your own decks → DeckView shows the edit affordance,
+  EditorView opens.
+- Open one of your own decks via someone else's session (or in an
+  incognito tab) — DeckView should still load (public-by-link), but the
+  edit affordance should be hidden, and navigating to `/edit/...`
+  should bounce to the read-only `/deck/$deckId`.
+- If `VITE_ANON_USERS_ENABLED` is on: create an anon deck, click
+  sign-in, complete OAuth, observe that decks import on return.
+
+If any step fails, fix inline and add a regression test before
+committing the fix.
+
+- [ ] **Step 5: Push (only if user explicitly asks)**
+
+This plan does not push or open a PR automatically. Wait for explicit
+direction from the user.
+
+---
+
+## Notes / clean-up reminders
+
+- `DeckRow` type stays in `src/decks/types.ts` — `mutations.ts`
+  `insert(...).select()` returns the full table row. Don't delete it.
+- `supabaseDefaultHandlers` in `src/test/msw.ts` keeps its
+  `GET /rest/v1/decks` and `GET /rest/v1/cards` defaults: the
+  `insertOrUpdate-with-Prefer: return=representation` round-trip uses
+  `POST` / `PATCH`, so the GET defaults are no longer hit by query
+  paths but are inert and harmless. Leave them — removing is out of
+  scope.
+- Don't push, don't open a PR. The user has standing direction not to
+  push without explicit instruction.

--- a/docs/superpowers/specs/2026-05-08-rls-rpc-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-08-rls-rpc-hardening-design.md
@@ -1,0 +1,607 @@
+# Harden RLS via RPC functions
+
+## Problem
+
+`decks_select_all` and `cards_select_all` use `using (true)`. Any
+authenticated principal — including anonymous JWTs from the recently
+merged anon-users feature — can `SELECT *` from `public.decks` and
+`public.cards`. One API call mints an anon JWT, then a caller can
+enumerate every deck and card in the database.
+
+The exposure has a second axis. The app's intended access model is:
+
+- **Deck listing is private** — only the owner sees their own decks on
+  HomeView.
+- **Deck viewing is public-by-UUID** — anyone with the deck id can read
+  it (share-by-link). Surfaced in `LoginView.tsx:172` as
+  "Anyone can view shared decks via link."
+
+These semantics live entirely inside the SQL RLS policies. Nothing in
+the TypeScript code, function names, or schema reflects them. A reader
+(human or LLM) inspecting `useDeck` cannot tell whether decks are meant
+to be private or public, and the `using (true)` policy is
+indistinguishable from a bug.
+
+A subtler issue: today's `select *` on `decks` returns `owner_id` to any
+link-holder. `DeckView` and `RequireOwner` use that field to decide
+whether to show the edit affordance / allow editing. Two fixes are
+possible — either keep `owner_id` on the wire (status quo, leaks the
+owner's UUID to anyone with a share link) or have the server compute
+the boolean and return that instead. We do the latter.
+
+## Solution
+
+Three changes, shipped together:
+
+1. **Tighten the SELECT policies on `decks` and `cards`** from
+   `using (true)` to owner-only. This closes the enumeration exposure
+   directly: a hostile caller doing `from('decks').select('id')` now
+   sees only their own rows, so anon JWTs can no longer enumerate.
+
+2. **Add SECURITY DEFINER RPC functions for the access patterns the
+   tightened policy doesn't support** — specifically, the
+   public-by-UUID reads required by share-by-link and the anon-import
+   resume flow. Three functions: `list_my_decks()` (owner-scoped),
+   `get_public_deck(deck_id)` (public-by-UUID, returns an `is_owner`
+   boolean computed from `auth.uid()`), `get_public_deck_cards(deck_id)`
+   (public-by-UUID). All three return explicit columns, not
+   `setof public.<table>`, so future columns added to the underlying
+   tables don't become silently public.
+
+3. **Make the public-by-UUID model legible in code.** Function names
+   carry "public" explicitly. SQL `comment on function` documents the
+   trust model at the database. JSDoc on the matching React hooks
+   mirrors it at the call site.
+
+Mutations (`insert` / `update` / `delete`) stay on the existing
+direct-table RLS policies, which already gate on `owner_id = auth.uid()`.
+
+### Why not `revoke select` from authenticated?
+
+The original issue proposed revoking direct SELECT entirely. That breaks
+`mutations.ts`. `useCreateDeck`, `useRenameDeck`, and `useSaveCard` all
+use `insert(...).select().maybeSingle()` /
+`update(...).select().maybeSingle()`, which PostgREST translates to
+`INSERT/UPDATE … RETURNING`. RETURNING is gated by the SELECT RLS
+policy and requires SELECT privilege at the table level. Revoking SELECT
+from `authenticated` would force every mutation to also become an RPC
+with a custom return type — a much larger surface.
+
+The tightened owner-only SELECT policy gives the same security posture
+(no cross-identity enumeration) while letting RETURNING keep working
+for the owner's own writes — the inserted/updated row is owned by
+`auth.uid()`, so it satisfies the SELECT policy at RETURNING time.
+
+## Scope
+
+In scope:
+
+- New migration: drop `decks_select_all` / `cards_select_all`, add
+  owner-only SELECT policies, create the three RPC functions, revoke
+  EXECUTE from PUBLIC, grant EXECUTE to `authenticated`.
+- `src/decks/queries.ts` refactor to call the RPCs.
+- `src/decks/queries.ts`: `decksKey` drops its `ownerId` argument and
+  becomes `() => ["decks"] as const`. `useDecks` drops its `ownerId`
+  parameter (server reads `auth.uid()`).
+- `src/decks/mutations.ts`: callers of `decksKey(...)` (lines 28, 49)
+  drop the argument.
+- `src/views/DeckView.tsx`: switch ownership check from
+  `session.user.id === deck.owner_id` to `deck.is_owner`.
+- `src/auth/RequireOwner.tsx`: switch from comparing `owner_id` to
+  reading `is_owner` directly.
+- `src/views/HomeView.tsx`: `useDecks()` no longer takes an arg.
+- `src/auth/anonImport.ts`: payload v2 stores `anonDeckIds: string[]`
+  instead of `anonUuid`; `tryResume` iterates via the public-deck RPCs.
+- `src/auth/LoginView.tsx` (line 128) and `src/auth/AuthCallback.tsx`
+  (line 103): both call sites fetch the anon's deck ids via
+  `list_my_decks` *before* stashing.
+- `src/auth/LoginView.tsx` (lines 40–47 and 84–91): two
+  `queryClient.fetchQuery` blocks switch from a custom direct-table
+  `queryFn` to the `list_my_decks` RPC, and from `decksKey(userId)` to
+  `decksKey()`.
+- New MSW RPC handler infrastructure in `src/test/msw.ts`. There is no
+  RPC handler scaffolding today.
+- Updates to existing test files that mock `from('decks')` /
+  `from('cards')` (full list under "Test impact" below).
+- JSDoc on `useDeck` / `useDeckCards` documenting the public-read model.
+
+Out of scope:
+
+- `is_public` column. All decks are public-by-link today; an `is_public`
+  column whose value is always `true` is YAGNI. If the app ever
+  introduces private decks, a follow-up migration adds the column with a
+  `default true`.
+- UI changes signaling the public-by-link model (separate decision per
+  user feedback).
+- Anon-user cleanup (separate handoff at
+  `docs/superpowers/handoffs/2026-05-08-anon-user-cleanup-notes.md`).
+- Mutation-side RLS. Existing policies already enforce
+  `owner_id = auth.uid()` on insert/update/delete; this work doesn't
+  touch them.
+- Public deck listing or discovery. There is no "list all public decks"
+  endpoint and none is added.
+
+## Migration
+
+A single new file under `supabase/migrations/`,
+`20260508000000_rls_rpc_hardening.sql`, containing:
+
+```sql
+-- Replace the universal-read SELECT policies with owner-only.
+-- Cross-identity reads (share-by-link, anon-import) go through the
+-- SECURITY DEFINER RPC functions defined below.
+drop policy if exists decks_select_all on public.decks;
+drop policy if exists cards_select_all on public.cards;
+
+create policy decks_select_owner on public.decks for select
+  using (owner_id = auth.uid());
+
+create policy cards_select_owner on public.cards for select
+  using (exists (
+    select 1 from public.decks d
+    where d.id = cards.deck_id and d.owner_id = auth.uid()
+  ));
+
+-- Owner-scoped: HomeView's deck list.
+-- Explicit return columns; do not use `setof public.decks` so a future
+-- column on `decks` doesn't become unintentionally readable here.
+create or replace function public.list_my_decks()
+returns table(
+  id          uuid,
+  name        text,
+  created_at  timestamptz,
+  updated_at  timestamptz
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select id, name, created_at, updated_at
+  from public.decks
+  where owner_id = auth.uid()
+  order by created_at desc
+$$;
+
+comment on function public.list_my_decks() is
+  'Owner-scoped read. Returns decks owned by the calling user.';
+
+-- Public read by UUID: DeckView, share-by-link, anon-import resume.
+-- Decks are intentionally public-by-link in this app — anyone with the
+-- deck id can read it. There is no ownership filter.
+--
+-- The `is_owner` flag is computed server-side from auth.uid() so the
+-- caller's user UUID never round-trips through the response. UI code
+-- gates the edit affordance on `is_owner` rather than comparing
+-- `owner_id` client-side.
+create or replace function public.get_public_deck(deck_id uuid)
+returns table(
+  id          uuid,
+  name        text,
+  created_at  timestamptz,
+  updated_at  timestamptz,
+  is_owner    boolean
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select
+    id,
+    name,
+    created_at,
+    updated_at,
+    -- coalesce so an unauthenticated caller (auth.uid() is null →
+    -- comparison is null) gets a concrete `false`, matching the
+    -- declared return type and the client TS type.
+    coalesce(owner_id = auth.uid(), false) as is_owner
+  from public.decks
+  where id = deck_id
+$$;
+
+comment on function public.get_public_deck(uuid) is
+  'Public read by UUID — anyone with the deck id can read it. Decks '
+  'are intentionally public-by-link. owner_id is NOT in the return '
+  'shape; is_owner is computed server-side instead.';
+
+create or replace function public.get_public_deck_cards(deck_id uuid)
+returns table(
+  id          uuid,
+  deck_id     uuid,
+  position    integer,
+  payload     jsonb,
+  created_at  timestamptz,
+  updated_at  timestamptz
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  -- Alias the table so column references in SELECT and WHERE are
+  -- unambiguous against the parameter `deck_id`. Column-vs-parameter
+  -- precedence works without aliasing today, but is brittle to future
+  -- edits (joins, aliases, #variable_conflict directives).
+  select c.id, c.deck_id, c.position, c.payload, c.created_at, c.updated_at
+  from public.cards c
+  where c.deck_id = get_public_deck_cards.deck_id
+  order by c.created_at asc
+$$;
+
+comment on function public.get_public_deck_cards(uuid) is
+  'Public read by UUID — returns cards for a deck readable by anyone '
+  'with the deck id. Same trust model as get_public_deck.';
+
+-- Postgres grants EXECUTE to PUBLIC by default on new functions.
+-- Revoke that and re-grant explicitly to `authenticated` only.
+revoke execute on function public.list_my_decks() from public;
+revoke execute on function public.get_public_deck(uuid) from public;
+revoke execute on function public.get_public_deck_cards(uuid) from public;
+
+grant execute on function public.list_my_decks() to authenticated;
+grant execute on function public.get_public_deck(uuid) to authenticated;
+grant execute on function public.get_public_deck_cards(uuid)
+  to authenticated;
+```
+
+Notes:
+
+- `security definer` + `set search_path = ''` is the Supabase-recommended
+  pattern. Functions execute as their owner (`postgres`/`supabase_admin`,
+  which is `BYPASSRLS`), so the function bodies bypass the new owner-only
+  policy. The function bodies enforce the access model explicitly:
+  `auth.uid()` filter for `list_my_decks`; no filter for the public-deck
+  reads.
+- `auth.uid()` reads from the request JWT and is unaffected by
+  `security definer`, so it correctly resolves to the *caller's*
+  identity.
+- `stable` (not `volatile`) so PostgREST treats them as cacheable read
+  RPCs. Bodies are pure SELECTs against tables.
+- The `anon` PostgREST role is intentionally not granted EXECUTE. The
+  app's "anon users" are actually `authenticated` (they hold a JWT);
+  the unauthenticated `anon` role has no use case here today.
+- All three functions return explicit columns. Adding a column to
+  `decks` or `cards` does not auto-leak via these RPCs.
+
+## Type changes
+
+Two new return-row types in `src/decks/types.ts`, replacing the
+existing `DeckRow` for read paths (mutation paths still use `DeckRow`
+because they go through direct-table operations):
+
+```ts
+// Returned by list_my_decks().
+export type DeckSummary = {
+  id: string;
+  name: string;
+  created_at: string;
+  updated_at: string;
+};
+
+// Returned by get_public_deck(). Adds is_owner so callers can gate UI
+// without learning the owner's UUID.
+export type PublicDeck = DeckSummary & {
+  is_owner: boolean;
+};
+
+// Returned by get_public_deck_cards(). Same shape as today's CardRow
+// (cards has no owner column).
+// CardRow stays.
+```
+
+`DeckRow` (with `owner_id`) is kept for `mutations.ts` since
+`insert(...).select()` returns the full table row, including `owner_id`.
+
+## Client refactor
+
+### `src/decks/queries.ts`
+
+```ts
+export const decksKey = () => ["decks"] as const;
+export const deckKey = (deckId: string | undefined) => ["deck", deckId] as const;
+export const deckCardsKey = (deckId: string | undefined) =>
+  ["deck-cards", deckId] as const;
+
+/**
+ * Decks owned by the current user — for the home view's deck list.
+ * Server-side: RPC list_my_decks reads auth.uid().
+ */
+export function useDecks() {
+  return useQuery<DeckSummary[]>({
+    queryKey: decksKey(),
+    queryFn: async () => {
+      const { data, error } = await supabase.rpc("list_my_decks");
+      if (error) throw error;
+      return data ?? [];
+    },
+  });
+}
+
+/**
+ * A single deck by id. PUBLIC READ — any caller with the deck id can
+ * read it. There is no ownership filter; this matches the share-by-link
+ * model. The returned row includes `is_owner`, computed server-side
+ * from auth.uid(), which UI uses to gate edit affordances. Mutations
+ * are still owner-gated by RLS on the underlying table.
+ */
+export function useDeck(deckId: string | undefined) {
+  return useQuery<PublicDeck | null>({
+    queryKey: deckKey(deckId),
+    enabled: Boolean(deckId),
+    queryFn: async () => {
+      if (!deckId) return null;
+      const { data, error } = await supabase
+        .rpc("get_public_deck", { deck_id: deckId })
+        .maybeSingle();
+      if (error) throw error;
+      return data ?? null;
+    },
+  });
+}
+
+/**
+ * Cards for a deck. Same PUBLIC READ semantics as useDeck.
+ */
+export function useDeckCards(deckId: string | undefined) {
+  return useQuery<Card[]>({
+    queryKey: deckCardsKey(deckId),
+    enabled: Boolean(deckId),
+    queryFn: async () => {
+      if (!deckId) return [];
+      const { data, error } = await supabase.rpc(
+        "get_public_deck_cards",
+        { deck_id: deckId },
+      );
+      if (error) throw error;
+      return ((data ?? []) as CardRow[]).map(rowToCard);
+    },
+  });
+}
+```
+
+### `src/decks/mutations.ts`
+
+Two call sites update to drop the now-removed `decksKey` argument:
+
+```ts
+// useCreateDeck onSuccess (was: decksKey(vars.ownerId))
+qc.invalidateQueries({ queryKey: decksKey() });
+
+// useRenameDeck onSuccess (was: decksKey(data.owner_id))
+qc.invalidateQueries({ queryKey: decksKey() });
+```
+
+`useDeleteDeck` already invalidates `["decks"]` directly and is
+unchanged. Mutation function bodies and `DeckRow` returns are
+unchanged.
+
+### `src/auth/LoginView.tsx` — `fetchQuery` calls
+
+Two `queryClient.fetchQuery` blocks (lines 40–47 and 84–91 today) use
+`decksKey(userId)` as the query key and a custom `queryFn` that does
+`from('decks').select('id').eq('owner_id', userId)` to count anon decks
+before deciding whether to show the import dialog. Both update to:
+
+```ts
+const decks = await queryClient.fetchQuery({
+  queryKey: decksKey(),
+  queryFn: async () => {
+    const { data, error } = await supabase.rpc("list_my_decks");
+    if (error) throw error;
+    return data ?? [];
+  },
+  staleTime: 0,
+});
+```
+
+This swaps both the query key (no `userId` argument) and the queryFn
+(uses the new RPC for consistency with `useDecks`, and the cache shape
+now matches `DeckSummary[]` instead of an ad-hoc `Array<{id}>`).
+
+### `src/views/HomeView.tsx`
+
+Drops local `ownerId` derivation for the `useDecks` call. `ownerId` is
+still derived from session for `createDeck.mutateAsync({ name, ownerId })`,
+because `useCreateDeck` still needs it as an INSERT input. Only the
+`useDecks(ownerId)` call site changes to `useDecks()`.
+
+### `src/views/DeckView.tsx`
+
+```ts
+// Was: const isOwner = session.status === "authenticated" && session.user.id === deck.owner_id;
+const isOwner = deck.is_owner;
+```
+
+The session check becomes redundant: `is_owner` is `false` for any
+caller who doesn't own the deck, including unauthenticated ones. The
+RPC body uses `coalesce(owner_id = auth.uid(), false)` so the
+unauthenticated case (where `auth.uid()` is null) returns a concrete
+SQL `false`, not null.
+
+### `src/auth/RequireOwner.tsx`
+
+```ts
+// Was: const ownerId = deckQuery.data?.owner_id;
+//      if (ownerId && ownerId !== userId) navigate({ to: "/deck/$deckId", params: { deckId } });
+//      if (ownerId !== userId) return null;
+const isOwner = deckQuery.data?.is_owner;
+// In the effect (existing sessionLoading + deckQuery.isLoading guard stays):
+if (isOwner === false) {
+  navigate({ to: "/deck/$deckId", params: { deckId } });
+}
+// In the render gate:
+if (isOwner !== true) return null;
+```
+
+The hook continues to use the `useDeck` result; only the comparison
+changes. The redirect target stays `/deck/$deckId` (the read-only
+view), preserving today's UX where a non-owner who lands on an editor
+URL gets bounced to the readable version of the same deck.
+
+### `src/auth/anonImport.ts`
+
+Payload becomes:
+
+```ts
+export type PendingAnonImport = {
+  version: 2;
+  anonDeckIds: string[];
+  importedDeckIds: string[];
+};
+```
+
+`stash` callers pass `anonDeckIds` directly. `readPending` returns null
+on `version !== 2`, clearing the entry. v1 payloads from the just-merged
+anon-users feature are silently dropped — acceptable because the feature
+is not enabled in production (`VITE_ANON_USERS_ENABLED` defaults off
+outside dev).
+
+`tryResume` iterates `anonDeckIds`:
+
+```ts
+for (const deckId of pending.anonDeckIds) {
+  if (pending.importedDeckIds.includes(deckId)) continue;
+
+  const { data: oldDeck, error: deckError } = await supabase
+    .rpc("get_public_deck", { deck_id: deckId })
+    .maybeSingle();
+  if (deckError) { stash(pending); return partial(); }
+  if (!oldDeck) {
+    // Anon deck was deleted between stash and resume. Mark as imported
+    // (nothing to copy) and continue.
+    pending.importedDeckIds.push(deckId);
+    imported += 1;
+    stash(pending);
+    continue;
+  }
+
+  const { data: oldCards, error: cardsError } = await supabase
+    .rpc("get_public_deck_cards", { deck_id: deckId });
+  if (cardsError) { stash(pending); return partial(); }
+
+  // Insert new deck + cards under the current (permanent) user, as today.
+}
+```
+
+Insert paths are unchanged — they go through direct-table RLS, which
+already enforces `owner_id = auth.uid()`.
+
+### `src/auth/LoginView.tsx` and `src/auth/AuthCallback.tsx`
+
+The `stash` call sites both run while the user is still authenticated
+as anon. Each call site fetches the anon's deck ids via the new
+`list_my_decks` RPC immediately before stashing:
+
+```ts
+// Was: stash({ version: 1, anonUuid, importedDeckIds: [] });
+const { data: anonDecks, error } = await supabase.rpc("list_my_decks");
+if (error) {
+  setAnnouncement("Couldn't fetch your decks for import.");
+  return;
+}
+const anonDeckIds = (anonDecks ?? []).map((d) => d.id);
+stash({ version: 2, anonDeckIds, importedDeckIds: [] });
+```
+
+If `list_my_decks` fails the import flow aborts before sign-out — the
+user stays anon and can retry. (Today's flow has no equivalent
+failure mode because the deck list isn't fetched up front.)
+
+## Test impact
+
+**Net-new MSW infrastructure** in `src/test/msw.ts`. Today the file has
+only REST handlers (`http.get('/rest/v1/decks')`, `http.post(...)`,
+etc., lines 18–39). RPC handler shape is `POST /rest/v1/rpc/<name>`
+with the RPC argument as the JSON body. The migration adds:
+
+- `POST /rest/v1/rpc/list_my_decks` → `DeckSummary[]`
+- `POST /rest/v1/rpc/get_public_deck` → `PublicDeck | null` (with
+  `Accept: application/vnd.pgrst.object+json` for `.maybeSingle()`)
+- `POST /rest/v1/rpc/get_public_deck_cards` → `CardRow[]`
+
+Existing GET handlers for `/rest/v1/decks`, `/rest/v1/cards` can stay
+(POST/PATCH from mutations still hit the table directly with
+`Prefer: return=representation`); they're no longer exercised by query
+paths but remain valid request shapes.
+
+**Test files mocking `from('decks')` / `from('cards')` SELECTs** that
+need updates to mock the new RPC paths instead:
+
+- `src/decks/queries.test.tsx`
+- `src/decks/mutations.test.tsx`
+- `src/views/HomeView.test.tsx`
+- `src/views/DeckView.test.tsx`
+- `src/views/EditorView.test.tsx`
+- `src/views/PrintView.test.tsx`
+- `src/views/BrowseApiModal.test.tsx`
+- `src/app/DeckBreadcrumb.test.tsx`
+- `src/auth/RequireOwner.test.tsx`
+- `src/auth/LoginView.test.tsx` — the `fetchQuery` blocks switch
+  queryFn to `list_my_decks` RPC, so any test stub of
+  `from('decks').select('id').eq('owner_id', userId)` becomes a stub
+  of the RPC instead.
+- `src/auth/AuthCallback.test.tsx` — stubs `supabase.from()` directly
+  (not via MSW). When `AuthCallback.tsx:39` switches to
+  `supabase.rpc('list_my_decks')`, the stub branch updates to mock
+  `supabase.rpc` instead.
+- `e2e/fixtures.ts` if it stubs deck reads at the network layer
+
+**`src/auth/anonImport.test.ts`** updates for the v2 payload shape and
+the new RPC fetch calls. The partial-resume coverage (per-deck
+iteration unit) is unchanged in shape and should keep passing after the
+mock surface swap.
+
+**New tests:**
+- v1 payloads in localStorage are silently discarded.
+- `LoginView` / `AuthCallback` abort if `list_my_decks` errors before
+  stash (announce + skip sign-out).
+- A `RequireOwner` test that confirms `is_owner === false` redirects
+  away.
+- Manual smoke (post-deploy): list / view / edit own decks; share-by-link
+  loads a deck owned by a different user with `is_owner === false` and
+  the edit affordance hidden; anon-import resume completes after sign-in.
+
+## Risks and considerations
+
+- **Existing data**: no schema changes, no data migration. The migration
+  swaps the SELECT policy and adds three RPCs.
+- **Mutations preserved**: `mutations.ts` uses
+  `insert(...).select().maybeSingle()` /
+  `update(...).select().maybeSingle()`, which compile to
+  `INSERT/UPDATE … RETURNING`. The owner-only SELECT policy permits
+  RETURNING for the owner's own writes. Mutation function bodies don't
+  change; only the two `decksKey(...)` invalidation calls update to drop
+  the argument.
+- **Browser cache**: TanStack Query cache key for `useDecks` changes
+  (no `ownerId`). On deploy, in-flight users see one extra refetch. No
+  data loss.
+- **`is_owner` correctness for anon callers**: the SECURITY DEFINER body
+  computes `coalesce(owner_id = auth.uid(), false)`. For anon JWT
+  callers, `auth.uid()` returns the anon user UUID; `is_owner` is true
+  iff the anon user owns the deck (rare but valid case during the
+  import-pending window). For unauthenticated callers (no JWT — would
+  use Supabase `anon` role), the function isn't granted EXECUTE so the
+  call 401s before reaching the body; even if that grant changed,
+  `coalesce(... , false)` ensures `is_owner` is a concrete `false` and
+  the TS `boolean` type is honored.
+- **Function ownership**: `security definer` functions execute as their
+  owner. Migrations run as `postgres`/`supabase_admin` (BYPASSRLS), so
+  the functions own that bypass capability. This is the intended
+  mechanism: `get_public_deck` would be blocked by the new owner-only
+  SELECT policy if it ran as the caller.
+- **Other call sites**: scan confirms no code outside `queries.ts`,
+  `mutations.ts`, `anonImport.ts`, `RequireOwner.tsx`, `DeckView.tsx`,
+  `HomeView.tsx`, `LoginView.tsx`, `AuthCallback.tsx` depends on
+  `decks.owner_id` from a read path. `LoginView.tsx:43`, `:87`, and
+  `AuthCallback.tsx:39` use `from('decks').select('id').eq('owner_id', ...)`
+  to count anon decks before showing the import dialog — these still
+  work under owner-only SELECT (the caller is the anon user, querying
+  their own rows).
+
+## Out-of-scope follow-ups
+
+- UI signal that decks are public-by-link (badge, copy, share button).
+- `is_public` column when private decks become a real feature.
+- Public-deck listing/discovery if ever needed.
+- Anon-user cleanup (separate handoff).

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -69,6 +69,24 @@ export async function seedDeck(page: Page, items: SeedItem[]): Promise<void> {
     updated_at: now,
   };
 
+  // RPC return shapes intentionally exclude owner_id; get_public_deck
+  // surfaces is_owner instead, computed server-side. See the
+  // 20260508000000_rls_rpc_hardening migration.
+  const publicDeckRow = {
+    id: TEST_DECK_ID,
+    name: "E2E Test Deck",
+    created_at: now,
+    updated_at: now,
+    is_owner: true,
+  };
+
+  const deckSummaryRow = {
+    id: TEST_DECK_ID,
+    name: "E2E Test Deck",
+    created_at: now,
+    updated_at: now,
+  };
+
   const cardRows = items.map((it, i) => ({
     id: it.id ?? `00000000-0000-4000-8000-${i.toString().padStart(12, "0")}`,
     deck_id: TEST_DECK_ID,
@@ -116,6 +134,18 @@ export async function seedDeck(page: Page, items: SeedItem[]): Promise<void> {
       `e2e fixture: unsupported ${method} on /rest/v1/cards. ` +
         "seedDeck currently mocks reads only; extend it before adding write-path specs.",
     );
+  });
+
+  await page.route("**/rest/v1/rpc/get_public_deck", async (route) => {
+    await route.fulfill({ json: publicDeckRow });
+  });
+
+  await page.route("**/rest/v1/rpc/get_public_deck_cards", async (route) => {
+    await route.fulfill({ json: cardRows });
+  });
+
+  await page.route("**/rest/v1/rpc/list_my_decks", async (route) => {
+    await route.fulfill({ json: [deckSummaryRow] });
   });
 
   await page.route("**/auth/v1/**", async (route) => {

--- a/src/app/DeckBreadcrumb.test.tsx
+++ b/src/app/DeckBreadcrumb.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
-import { makeDeckRow } from "../test/factories";
+import { makePublicDeck } from "../test/factories";
 import { server } from "../test/msw";
 import { DeckBreadcrumb } from "./DeckBreadcrumb";
 
@@ -51,9 +51,9 @@ describe("DeckBreadcrumb", () => {
   });
 
   it("renders just a Decks link on the deck root route", () => {
-    const deck = makeDeckRow.build();
+    const deck = makePublicDeck.build();
     mockPathname = `/deck/${deck.id}`;
-    server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([deck])));
+    server.use(http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(deck)));
     render(wrap(<DeckBreadcrumb />));
 
     expect(screen.getByRole("link", { name: "Decks" })).toHaveAttribute("href", "/");
@@ -62,9 +62,9 @@ describe("DeckBreadcrumb", () => {
   });
 
   it("renders the deck name as a link on the editor route", async () => {
-    const deck = makeDeckRow.build();
+    const deck = makePublicDeck.build();
     mockPathname = `/deck/${deck.id}/edit/new`;
-    server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([deck])));
+    server.use(http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(deck)));
     render(wrap(<DeckBreadcrumb />));
 
     const deckLink = await screen.findByRole("link", { name: deck.name });
@@ -73,9 +73,9 @@ describe("DeckBreadcrumb", () => {
   });
 
   it("renders the deck name as a link on the print route", async () => {
-    const deck = makeDeckRow.build();
+    const deck = makePublicDeck.build();
     mockPathname = `/deck/${deck.id}/print`;
-    server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([deck])));
+    server.use(http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(deck)));
     render(wrap(<DeckBreadcrumb />));
 
     const deckLink = await screen.findByRole("link", { name: deck.name });
@@ -83,12 +83,12 @@ describe("DeckBreadcrumb", () => {
   });
 
   it("shows an ellipsis while the deck query is pending", async () => {
-    const deck = makeDeckRow.build();
+    const deck = makePublicDeck.build();
     mockPathname = `/deck/${deck.id}/edit/new`;
     let resolve: ((res: Response) => void) | undefined;
     server.use(
-      http.get(
-        `${SB}/rest/v1/decks`,
+      http.post(
+        `${SB}/rest/v1/rpc/get_public_deck`,
         () =>
           new Promise<Response>((r) => {
             resolve = r;
@@ -100,13 +100,13 @@ describe("DeckBreadcrumb", () => {
     expect(await screen.findByText("…")).toBeInTheDocument();
     expect(screen.queryByText(deck.name)).not.toBeInTheDocument();
 
-    resolve?.(HttpResponse.json([deck]));
+    resolve?.(HttpResponse.json(deck));
     await screen.findByText(deck.name);
   });
 
   it("collapses to just Decks when the deck is not found", async () => {
     mockPathname = "/deck/missing/edit/new";
-    server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([])));
+    server.use(http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(null)));
     render(wrap(<DeckBreadcrumb />));
 
     await screen.findByRole("link", { name: "Decks" });
@@ -116,9 +116,9 @@ describe("DeckBreadcrumb", () => {
 
   it("sets the full deck name on title for a truncated link", async () => {
     const longName = "A Very Long Deck Name That Will Overflow Twenty Four Characters";
-    const deck = makeDeckRow.build({ name: longName });
+    const deck = makePublicDeck.build({ name: longName });
     mockPathname = `/deck/${deck.id}/edit/new`;
-    server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([deck])));
+    server.use(http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(deck)));
     render(wrap(<DeckBreadcrumb />));
 
     const link = await screen.findByRole("link", { name: longName });

--- a/src/auth/AuthCallback.test.tsx
+++ b/src/auth/AuthCallback.test.tsx
@@ -57,11 +57,8 @@ describe("AuthCallback", () => {
     setLocation({
       hash: "#error=invalid_request&error_code=identity_already_exists&error_description=Identity+is+already+linked+to+another+user",
     });
-    vi.spyOn(supabase, "from").mockReturnValue({
-      select: () => ({
-        eq: () => Promise.resolve({ data: [{ id: "d1" }, { id: "d2" }], error: null }),
-      }),
-    } as never);
+    vi.spyOn(supabase, "rpc").mockImplementation((() =>
+      Promise.resolve({ data: [{ id: "d1" }, { id: "d2" }], error: null })) as never);
     render(
       wrap(<AuthCallback />, {
         status: "authenticated",
@@ -80,9 +77,8 @@ describe("AuthCallback", () => {
   it("on import click: stashes pendingAnonImport, signs out, signInWithOAuth with stashed provider", async () => {
     setLocation({ hash: "#error_code=identity_already_exists", search: "?next=/" });
     window.localStorage.setItem("dndCards.lastProvider", "github");
-    vi.spyOn(supabase, "from").mockReturnValue({
-      select: () => ({ eq: () => Promise.resolve({ data: [{ id: "d1" }], error: null }) }),
-    } as never);
+    vi.spyOn(supabase, "rpc").mockImplementation((() =>
+      Promise.resolve({ data: [{ id: "d1" }], error: null })) as never);
     const signOutSpy = vi
       .spyOn(supabase.auth, "signOut")
       .mockResolvedValue({ error: null } as never);
@@ -98,18 +94,22 @@ describe("AuthCallback", () => {
       }),
     );
     await userEvent.click(await screen.findByRole("button", { name: /yes, import 1 deck$/i }));
+    await waitFor(() => expect(signOutSpy).toHaveBeenCalled());
     const stash = window.localStorage.getItem("dndCards.pendingAnonImport");
     expect(stash).not.toBeNull();
-    expect(JSON.parse(stash as string)).toMatchObject({ anonUuid: "anon-1", importedDeckIds: [] });
+    expect(JSON.parse(stash as string)).toMatchObject({
+      version: 2,
+      anonDeckIds: ["d1"],
+      importedDeckIds: [],
+    });
     expect(signOutSpy).toHaveBeenCalled();
     expect(oauthSpy).toHaveBeenCalledWith(expect.objectContaining({ provider: "github" }));
   });
 
   it("on dismiss (X / Esc): navigates without signOut or signInWithOAuth", async () => {
     setLocation({ hash: "#error_code=identity_already_exists" });
-    vi.spyOn(supabase, "from").mockReturnValue({
-      select: () => ({ eq: () => Promise.resolve({ data: [{ id: "d1" }], error: null }) }),
-    } as never);
+    vi.spyOn(supabase, "rpc").mockImplementation((() =>
+      Promise.resolve({ data: [{ id: "d1" }], error: null })) as never);
     const signOutSpy = vi
       .spyOn(supabase.auth, "signOut")
       .mockResolvedValue({ error: null } as never);
@@ -133,9 +133,8 @@ describe("AuthCallback", () => {
 
   it("on skip click: signs out and signInWithOAuth, no stash", async () => {
     setLocation({ hash: "#error_code=identity_already_exists" });
-    vi.spyOn(supabase, "from").mockReturnValue({
-      select: () => ({ eq: () => Promise.resolve({ data: [{ id: "d1" }], error: null }) }),
-    } as never);
+    vi.spyOn(supabase, "rpc").mockImplementation((() =>
+      Promise.resolve({ data: [{ id: "d1" }], error: null })) as never);
     const signOutSpy = vi
       .spyOn(supabase.auth, "signOut")
       .mockResolvedValue({ error: null } as never);
@@ -175,16 +174,21 @@ describe("AuthCallback", () => {
   it("when pendingAnonImport exists and session is non-anon: runs import then navigates", async () => {
     window.localStorage.setItem(
       "dndCards.pendingAnonImport",
-      JSON.stringify({ version: 1, anonUuid: "anon-1", importedDeckIds: [] }),
+      JSON.stringify({ version: 2, anonDeckIds: ["d1"], importedDeckIds: [] }),
     );
     setLocation({});
+    vi.spyOn(supabase, "rpc").mockImplementation(((name: string) => {
+      if (name === "get_public_deck") {
+        return {
+          maybeSingle: () => Promise.resolve({ data: { id: "d1", name: "Goblins" }, error: null }),
+        };
+      }
+      if (name === "get_public_deck_cards") {
+        return Promise.resolve({ data: [{ position: 0, payload: {} }], error: null });
+      }
+      return Promise.resolve({ data: [], error: null });
+    }) as never);
     vi.spyOn(supabase, "from").mockReturnValue({
-      select: () => ({
-        eq: (col: string) =>
-          col === "owner_id"
-            ? Promise.resolve({ data: [{ id: "d1", name: "Goblins" }], error: null })
-            : Promise.resolve({ data: [{ position: 0, payload: {} }], error: null }),
-      }),
       insert: () => ({
         select: () => ({
           single: () => Promise.resolve({ data: { id: "new-deck" }, error: null }),

--- a/src/auth/AuthCallback.test.tsx
+++ b/src/auth/AuthCallback.test.tsx
@@ -106,6 +106,39 @@ describe("AuthCallback", () => {
     expect(oauthSpy).toHaveBeenCalledWith(expect.objectContaining({ provider: "github" }));
   });
 
+  it("on import click: aborts before signOut and shows error when list_my_decks errors", async () => {
+    setLocation({ hash: "#error_code=identity_already_exists" });
+    // First call (deck count for the dialog) succeeds; second (prefetch) errors.
+    let callCount = 0;
+    vi.spyOn(supabase, "rpc").mockImplementation((() => {
+      callCount += 1;
+      if (callCount === 1) {
+        return Promise.resolve({ data: [{ id: "d1" }], error: null });
+      }
+      return Promise.resolve({ data: null, error: { message: "boom" } });
+    }) as never);
+    const signOutSpy = vi
+      .spyOn(supabase.auth, "signOut")
+      .mockResolvedValue({ error: null } as never);
+    const oauthSpy = vi
+      .spyOn(supabase.auth, "signInWithOAuth")
+      .mockResolvedValue({ data: {}, error: null } as never);
+
+    render(
+      wrap(<AuthCallback />, {
+        status: "authenticated",
+        user: { id: "anon-1", is_anonymous: true } as never,
+        session: {} as never,
+      }),
+    );
+    await userEvent.click(await screen.findByRole("button", { name: /yes, import 1 deck$/i }));
+
+    await waitFor(() => expect(screen.getByText(/couldn't start the import/i)).toBeInTheDocument());
+    expect(signOutSpy).not.toHaveBeenCalled();
+    expect(oauthSpy).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem("dndCards.pendingAnonImport")).toBeNull();
+  });
+
   it("on dismiss (X / Esc): navigates without signOut or signInWithOAuth", async () => {
     setLocation({ hash: "#error_code=identity_already_exists" });
     vi.spyOn(supabase, "rpc").mockImplementation((() =>

--- a/src/auth/AuthCallback.test.tsx
+++ b/src/auth/AuthCallback.test.tsx
@@ -12,7 +12,19 @@ const navigate = vi.fn();
 vi.mock("@tanstack/react-router", async () => {
   const actual =
     await vi.importActual<typeof import("@tanstack/react-router")>("@tanstack/react-router");
-  return { ...actual, useNavigate: () => navigate };
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+    Link: ({
+      children,
+      to,
+      ...rest
+    }: { children: ReactNode; to?: string } & Record<string, unknown>) => (
+      <a href={to as string} {...rest}>
+        {children}
+      </a>
+    ),
+  };
 });
 
 function wrap(ui: ReactNode, session: SessionState) {

--- a/src/auth/AuthCallback.tsx
+++ b/src/auth/AuthCallback.tsx
@@ -102,7 +102,8 @@ export function AuthCallback() {
     if (session.status !== "authenticated") return;
     const { data: anonDecks, error: listError } = await supabase.rpc("list_my_decks");
     if (listError) {
-      setAnnouncement("Couldn't fetch your decks for import.");
+      setErrorMessage("Couldn't start the import. Please try again.");
+      setPhase("error");
       return;
     }
     const anonDeckIds = (anonDecks ?? []).map((d: { id: string }) => d.id);

--- a/src/auth/AuthCallback.tsx
+++ b/src/auth/AuthCallback.tsx
@@ -36,7 +36,7 @@ export function AuthCallback() {
     const linkError = parseLinkError();
     if (linkError === "identity_already_exists" && session.user.is_anonymous) {
       void (async () => {
-        const { data } = await supabase.from("decks").select("id").eq("owner_id", session.user.id);
+        const { data } = await supabase.rpc("list_my_decks");
         if (cancelled) return;
         setDeckCount(data?.length ?? 0);
         setPhase("dialog");
@@ -100,7 +100,13 @@ export function AuthCallback() {
 
   const onImport = async () => {
     if (session.status !== "authenticated") return;
-    stash({ version: 1, anonUuid: session.user.id, importedDeckIds: [] });
+    const { data: anonDecks, error: listError } = await supabase.rpc("list_my_decks");
+    if (listError) {
+      setAnnouncement("Couldn't fetch your decks for import.");
+      return;
+    }
+    const anonDeckIds = (anonDecks ?? []).map((d: { id: string }) => d.id);
+    stash({ version: 2, anonDeckIds, importedDeckIds: [] });
     const next = readNextFromUrl();
     const redirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`;
     const provider = lastProvider();

--- a/src/auth/AuthCallback.tsx
+++ b/src/auth/AuthCallback.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { supabase } from "../api/supabase";
 import { pluralize } from "../lib/pluralize";
@@ -158,6 +158,9 @@ export function AuthCallback() {
     return (
       <section style={{ textAlign: "center", padding: "4rem" }}>
         <p>{errorMessage}</p>
+        <p>
+          <Link to="/login">Back to sign-in</Link>
+        </p>
       </section>
     );
   }

--- a/src/auth/LoginView.test.tsx
+++ b/src/auth/LoginView.test.tsx
@@ -261,7 +261,7 @@ describe("LoginView dev path conflict", () => {
     await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: "/" }));
     expect(setItemSpy).toHaveBeenCalledWith(
       "dndCards.pendingAnonImport",
-      expect.stringContaining("anon-1"),
+      expect.stringContaining('"anonDeckIds":["d1"]'),
     );
     expect(signOutSpy).toHaveBeenCalled();
     expect(signInSpy).toHaveBeenCalledWith({ email: "dev@local", password: "devpass" });

--- a/src/auth/LoginView.test.tsx
+++ b/src/auth/LoginView.test.tsx
@@ -231,6 +231,43 @@ describe("LoginView dev path conflict", () => {
     expect(screen.getByRole("button", { name: /yes, import 3 decks/i })).toBeInTheDocument();
   });
 
+  it("on import: aborts before signOut when list_my_decks errors on the prefetch", async () => {
+    vi.spyOn(supabase.auth, "updateUser").mockResolvedValue({
+      data: { user: null },
+      error: { message: "email already exists" },
+    } as never);
+    const signOutSpy = vi
+      .spyOn(supabase.auth, "signOut")
+      .mockResolvedValue({ error: null } as never);
+    // First call (the deck-count check that opens the dialog) succeeds;
+    // second call (the prefetch in onImportConfirm) fails.
+    let callCount = 0;
+    server.use(
+      http.post(`${SB_URL}/rest/v1/rpc/list_my_decks`, () => {
+        callCount += 1;
+        if (callCount === 1) return HttpResponse.json([{ id: "d1" }]);
+        return new HttpResponse(null, { status: 500 });
+      }),
+    );
+
+    render(
+      wrap(<LoginView />, {
+        status: "authenticated",
+        user: { id: "anon-1", is_anonymous: true } as never,
+        session: {} as never,
+      }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: /sign in as dev user/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /yes, import 1 deck$/i }));
+
+    // The dialog closes and pending resets, so the sign-in button is enabled again.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /sign in as dev user/i })).not.toBeDisabled(),
+    );
+    expect(signOutSpy).not.toHaveBeenCalled();
+    expect(callCount).toBe(2);
+  });
+
   it("on import: stashes pending, signs out, signs in to existing dev account, and navigates", async () => {
     vi.spyOn(supabase.auth, "updateUser").mockResolvedValue({
       data: { user: null },

--- a/src/auth/LoginView.test.tsx
+++ b/src/auth/LoginView.test.tsx
@@ -131,8 +131,8 @@ describe("LoginView OAuth branching", () => {
     } as never);
 
     server.use(
-      http.get(`${SB_URL}/rest/v1/decks`, () =>
-        HttpResponse.json([{ id: "d1", owner_id: "anon-1", name: "Goblins" }]),
+      http.post(`${SB_URL}/rest/v1/rpc/list_my_decks`, () =>
+        HttpResponse.json([{ id: "d1", name: "Goblins" }]),
       ),
     );
 
@@ -160,7 +160,7 @@ describe("LoginView OAuth branching", () => {
       data: { provider: "google", url: "https://example.com" },
       error: null,
     } as never);
-    server.use(http.get(`${SB_URL}/rest/v1/decks`, () => HttpResponse.json([])));
+    server.use(http.post(`${SB_URL}/rest/v1/rpc/list_my_decks`, () => HttpResponse.json([])));
 
     render(
       wrap(<LoginView />, {
@@ -209,7 +209,7 @@ describe("LoginView dev path conflict", () => {
       error: { message: "email already exists" },
     } as never);
     server.use(
-      http.get(`${SB_URL}/rest/v1/decks`, () =>
+      http.post(`${SB_URL}/rest/v1/rpc/list_my_decks`, () =>
         HttpResponse.json([{ id: "d1" }, { id: "d2" }, { id: "d3" }]),
       ),
     );
@@ -244,7 +244,9 @@ describe("LoginView dev path conflict", () => {
       error: null,
     } as never);
     const setItemSpy = vi.spyOn(Storage.prototype, "setItem");
-    server.use(http.get(`${SB_URL}/rest/v1/decks`, () => HttpResponse.json([{ id: "d1" }])));
+    server.use(
+      http.post(`${SB_URL}/rest/v1/rpc/list_my_decks`, () => HttpResponse.json([{ id: "d1" }])),
+    );
 
     render(
       wrap(<LoginView />, {
@@ -276,7 +278,9 @@ describe("LoginView dev path conflict", () => {
     const signInSpy = vi
       .spyOn(supabase.auth, "signInWithPassword")
       .mockResolvedValue({ data: { user: { id: "dev-1" }, session: {} }, error: null } as never);
-    server.use(http.get(`${SB_URL}/rest/v1/decks`, () => HttpResponse.json([{ id: "d1" }])));
+    server.use(
+      http.post(`${SB_URL}/rest/v1/rpc/list_my_decks`, () => HttpResponse.json([{ id: "d1" }])),
+    );
     window.localStorage.setItem(
       "dndCards.pendingAnonImport",
       JSON.stringify({ version: 1, anonUuid: "anon-old", importedDeckIds: [] }),
@@ -311,7 +315,9 @@ describe("LoginView dev path conflict", () => {
     const signInSpy = vi
       .spyOn(supabase.auth, "signInWithPassword")
       .mockResolvedValue({ data: { user: { id: "dev-1" }, session: {} }, error: null } as never);
-    server.use(http.get(`${SB_URL}/rest/v1/decks`, () => HttpResponse.json([{ id: "d1" }])));
+    server.use(
+      http.post(`${SB_URL}/rest/v1/rpc/list_my_decks`, () => HttpResponse.json([{ id: "d1" }])),
+    );
 
     render(
       wrap(<LoginView />, {
@@ -341,7 +347,7 @@ describe("LoginView dev path conflict", () => {
     const signInSpy = vi
       .spyOn(supabase.auth, "signInWithPassword")
       .mockResolvedValue({ data: { user: { id: "dev-1" }, session: {} }, error: null } as never);
-    server.use(http.get(`${SB_URL}/rest/v1/decks`, () => HttpResponse.json([])));
+    server.use(http.post(`${SB_URL}/rest/v1/rpc/list_my_decks`, () => HttpResponse.json([])));
 
     render(
       wrap(<LoginView />, {

--- a/src/auth/LoginView.tsx
+++ b/src/auth/LoginView.tsx
@@ -124,10 +124,15 @@ export function LoginView() {
 
   const onImportConfirm = async () => {
     if (!importPrompt) return;
-    const { anonUuid } = importPrompt;
     setImportPrompt(null);
     const next = readNextFromUrl();
-    stash({ version: 1, anonUuid, importedDeckIds: [] });
+    const { data: anonDecks, error: listError } = await supabase.rpc("list_my_decks");
+    if (listError) {
+      setAnnouncement("Couldn't fetch your decks for import.");
+      return;
+    }
+    const anonDeckIds = (anonDecks ?? []).map((d: { id: string }) => d.id);
+    stash({ version: 2, anonDeckIds, importedDeckIds: [] });
     await supabase.auth.signOut();
     const { data, error } = await supabase.auth.signInWithPassword({
       email: DEV_EMAIL,

--- a/src/auth/LoginView.tsx
+++ b/src/auth/LoginView.tsx
@@ -23,7 +23,6 @@ export function LoginView() {
   const [pending, setPending] = useState<"google" | "github" | "dev" | null>(null);
   const [importPrompt, setImportPrompt] = useState<{
     deckCount: number;
-    anonUuid: string;
   } | null>(null);
 
   const isAnon = session.status === "authenticated" && session.user.is_anonymous === true;
@@ -93,7 +92,7 @@ export function LoginView() {
         });
         const deckCount = decks.length;
         if (deckCount > 0) {
-          setImportPrompt({ deckCount, anonUuid: userId });
+          setImportPrompt({ deckCount });
           return;
         }
         await switchToExistingDevAccount(next);
@@ -128,7 +127,8 @@ export function LoginView() {
     const next = readNextFromUrl();
     const { data: anonDecks, error: listError } = await supabase.rpc("list_my_decks");
     if (listError) {
-      setAnnouncement("Couldn't fetch your decks for import.");
+      setAnnouncement("Couldn't start the import. Please try again.");
+      setPending(null);
       return;
     }
     const anonDeckIds = (anonDecks ?? []).map((d: { id: string }) => d.id);

--- a/src/auth/LoginView.tsx
+++ b/src/auth/LoginView.tsx
@@ -38,9 +38,10 @@ export function LoginView() {
 
       if (isAnon && userId) {
         const decks = await queryClient.fetchQuery({
-          queryKey: decksKey(userId),
+          queryKey: decksKey(),
           queryFn: async () => {
-            const { data } = await supabase.from("decks").select("id").eq("owner_id", userId);
+            const { data, error } = await supabase.rpc("list_my_decks");
+            if (error) throw error;
             return data ?? [];
           },
           staleTime: 0,
@@ -82,9 +83,10 @@ export function LoginView() {
         // OAuth identity_already_exists flow: if the anon has decks, prompt
         // to import them; otherwise switch silently.
         const decks = await queryClient.fetchQuery({
-          queryKey: decksKey(userId),
+          queryKey: decksKey(),
           queryFn: async () => {
-            const { data } = await supabase.from("decks").select("id").eq("owner_id", userId);
+            const { data, error } = await supabase.rpc("list_my_decks");
+            if (error) throw error;
             return data ?? [];
           },
           staleTime: 0,

--- a/src/auth/RequireOwner.test.tsx
+++ b/src/auth/RequireOwner.test.tsx
@@ -4,6 +4,7 @@ import { HttpResponse, http } from "msw";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { supabase } from "../api/supabase";
+import { AnnouncementProvider } from "../lib/ui/Announcement";
 import { makePublicDeck } from "../test/factories";
 import { server } from "../test/msw";
 import { signInTestUser } from "../test/signInTestUser";
@@ -22,7 +23,9 @@ function wrap(ui: ReactNode) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return (
     <QueryClientProvider client={client}>
-      <AuthProvider>{ui}</AuthProvider>
+      <AnnouncementProvider>
+        <AuthProvider>{ui}</AuthProvider>
+      </AnnouncementProvider>
     </QueryClientProvider>
   );
 }

--- a/src/auth/RequireOwner.test.tsx
+++ b/src/auth/RequireOwner.test.tsx
@@ -4,7 +4,7 @@ import { HttpResponse, http } from "msw";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { supabase } from "../api/supabase";
-import { makeDeckRow } from "../test/factories";
+import { makePublicDeck } from "../test/factories";
 import { server } from "../test/msw";
 import { signInTestUser } from "../test/signInTestUser";
 import { AuthProvider } from "./AuthProvider";
@@ -41,19 +41,17 @@ describe("RequireOwner", () => {
   });
 
   it("renders children when the session user owns the deck", async () => {
-    const user = await signInTestUser();
-    const deck = makeDeckRow.build({ owner_id: user.id });
-    server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([deck])));
+    await signInTestUser();
+    const deck = makePublicDeck.build({ is_owner: true });
+    server.use(http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(deck)));
     render(wrap(<RequireOwner deckId={deck.id}>protected</RequireOwner>));
     await waitFor(() => expect(screen.getByText("protected")).toBeInTheDocument());
   });
 
   it("redirects to /deck/$deckId (read-only) when authenticated but not the owner", async () => {
-    // Use the default Alice user (the MSW /auth/v1/user handler always returns Alice).
-    // The deck belongs to a different uuid so Alice is not the owner.
     await signInTestUser();
-    const deck = makeDeckRow.build({ owner_id: "someone-else" });
-    server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([deck])));
+    const deck = makePublicDeck.build({ is_owner: false });
+    server.use(http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(deck)));
     render(wrap(<RequireOwner deckId={deck.id}>protected</RequireOwner>));
     await waitFor(() =>
       expect(navigate).toHaveBeenCalledWith({ to: "/deck/$deckId", params: { deckId: deck.id } }),

--- a/src/auth/RequireOwner.tsx
+++ b/src/auth/RequireOwner.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "@tanstack/react-router";
 import { type ReactNode, useEffect } from "react";
 import { useDeck } from "../decks/queries";
+import { useSetNextAnnouncement } from "../lib/ui/Announcement";
 import { useSession } from "./useSession";
 
 type Props = { deckId: string; children: ReactNode };
@@ -9,6 +10,7 @@ export function RequireOwner({ deckId, children }: Props) {
   const session = useSession();
   const deckQuery = useDeck(deckId);
   const navigate = useNavigate();
+  const setAnnouncement = useSetNextAnnouncement();
 
   const sessionLoading = session.status === "loading";
   const userId = session.status === "authenticated" ? session.user.id : null;
@@ -23,9 +25,10 @@ export function RequireOwner({ deckId, children }: Props) {
       return;
     }
     if (isOwner === false) {
+      setAnnouncement("This deck is read-only — only the owner can edit.");
       navigate({ to: "/deck/$deckId", params: { deckId } });
     }
-  }, [sessionLoading, deckQuery.isLoading, userId, isOwner, deckId, navigate]);
+  }, [sessionLoading, deckQuery.isLoading, userId, isOwner, deckId, navigate, setAnnouncement]);
 
   if (sessionLoading || deckQuery.isLoading) return null;
   if (!userId) return null;

--- a/src/auth/RequireOwner.tsx
+++ b/src/auth/RequireOwner.tsx
@@ -12,7 +12,7 @@ export function RequireOwner({ deckId, children }: Props) {
 
   const sessionLoading = session.status === "loading";
   const userId = session.status === "authenticated" ? session.user.id : null;
-  const ownerId = deckQuery.data?.owner_id;
+  const isOwner = deckQuery.data?.is_owner;
 
   useEffect(() => {
     if (sessionLoading || deckQuery.isLoading) return;
@@ -22,13 +22,13 @@ export function RequireOwner({ deckId, children }: Props) {
       navigate({ to: "/login", search: { next } });
       return;
     }
-    if (ownerId && ownerId !== userId) {
+    if (isOwner === false) {
       navigate({ to: "/deck/$deckId", params: { deckId } });
     }
-  }, [sessionLoading, deckQuery.isLoading, userId, ownerId, deckId, navigate]);
+  }, [sessionLoading, deckQuery.isLoading, userId, isOwner, deckId, navigate]);
 
   if (sessionLoading || deckQuery.isLoading) return null;
   if (!userId) return null;
-  if (ownerId !== userId) return null;
+  if (isOwner !== true) return null;
   return <>{children}</>;
 }

--- a/src/auth/anonImport.test.ts
+++ b/src/auth/anonImport.test.ts
@@ -10,10 +10,10 @@ describe("anonImport storage", () => {
     expect(readPending()).toBeNull();
   });
 
-  it("round-trips a stashed payload", () => {
+  it("round-trips a v2 payload", () => {
     const payload: PendingAnonImport = {
-      version: 1,
-      anonUuid: "00000000-0000-0000-0000-000000000001",
+      version: 2,
+      anonDeckIds: ["d1", "d2"],
       importedDeckIds: [],
     };
     stash(payload);
@@ -21,7 +21,7 @@ describe("anonImport storage", () => {
   });
 
   it("clears the stashed payload", () => {
-    stash({ version: 1, anonUuid: "x", importedDeckIds: [] });
+    stash({ version: 2, anonDeckIds: ["d1"], importedDeckIds: [] });
     clear();
     expect(readPending()).toBeNull();
   });
@@ -31,18 +31,33 @@ describe("anonImport storage", () => {
     expect(readPending()).toBeNull();
   });
 
+  it("returns null on a stashed v1 payload (silently dropped)", () => {
+    window.localStorage.setItem(
+      "dndCards.pendingAnonImport",
+      JSON.stringify({
+        version: 1,
+        anonUuid: "00000000-0000-0000-0000-000000000001",
+        importedDeckIds: [],
+      }),
+    );
+    expect(readPending()).toBeNull();
+  });
+
   it("returns null on a stashed value with an unknown version", () => {
     window.localStorage.setItem(
       "dndCards.pendingAnonImport",
-      JSON.stringify({ version: 999, anonUuid: "x", importedDeckIds: [] }),
+      JSON.stringify({ version: 999, anonDeckIds: [], importedDeckIds: [] }),
     );
     expect(readPending()).toBeNull();
   });
 });
 
 type FakeSupabase = {
-  decks: { ownerId: string; id: string; name: string }[];
-  cards: { id: string; deck_id: string; position: number; payload: unknown }[];
+  deckById: Record<string, { id: string; name: string } | null>;
+  cardsByDeck: Record<
+    string,
+    Array<{ id: string; deck_id: string; position: number; payload: unknown }>
+  >;
   inserts: { decks: unknown[]; cards: unknown[] };
   insertResults?: { table: string; error: Error | null }[];
 };
@@ -51,34 +66,27 @@ function makeFakeSupabase(initial: FakeSupabase) {
   let insertCallCount = 0;
   return {
     state: initial,
+    rpc(name: string, params?: { deck_id?: string }) {
+      if (name === "get_public_deck") {
+        const id = params?.deck_id ?? "";
+        const row = initial.deckById[id] ?? null;
+        return {
+          maybeSingle: () => Promise.resolve({ data: row, error: null }),
+        };
+      }
+      if (name === "get_public_deck_cards") {
+        const id = params?.deck_id ?? "";
+        const rows = initial.cardsByDeck[id] ?? [];
+        return Promise.resolve({ data: rows, error: null });
+      }
+      throw new Error(`unmocked rpc: ${name}`);
+    },
     from(table: string) {
-      const state = initial;
       return {
-        select() {
-          return {
-            eq(_col: string, val: string) {
-              if (table === "decks") {
-                return Promise.resolve({
-                  data: state.decks
-                    .filter((d) => d.ownerId === val)
-                    .map((d) => ({ id: d.id, owner_id: d.ownerId, name: d.name })),
-                  error: null,
-                });
-              }
-              if (table === "cards") {
-                return Promise.resolve({
-                  data: state.cards.filter((c) => c.deck_id === val),
-                  error: null,
-                });
-              }
-              return Promise.resolve({ data: [], error: null });
-            },
-          };
-        },
         insert(rows: unknown) {
-          state.inserts[table as "decks" | "cards"].push(rows);
+          initial.inserts[table as "decks" | "cards"].push(rows);
           const callNum = insertCallCount++;
-          const resultConfig = state.insertResults?.[callNum];
+          const resultConfig = initial.insertResults?.[callNum];
           if (resultConfig?.error) {
             return {
               select: () => ({
@@ -109,11 +117,13 @@ describe("tryResume", () => {
     window.localStorage.clear();
   });
 
-  it("clones each anon-owned deck and its cards under the new user, then clears the key", async () => {
-    stash({ version: 1, anonUuid: "anon-1", importedDeckIds: [] });
+  it("clones each anon deck and its cards under the new user, then clears the key", async () => {
+    stash({ version: 2, anonDeckIds: ["d1"], importedDeckIds: [] });
     const fake = makeFakeSupabase({
-      decks: [{ ownerId: "anon-1", id: "d1", name: "Goblins" }],
-      cards: [{ id: "c1", deck_id: "d1", position: 0, payload: { kind: "item", name: "Sword" } }],
+      deckById: { d1: { id: "d1", name: "Goblins" } },
+      cardsByDeck: {
+        d1: [{ id: "c1", deck_id: "d1", position: 0, payload: { kind: "item", name: "Sword" } }],
+      },
       inserts: { decks: [], cards: [] },
     });
     await tryResume({ supabase: fake as never, currentUserId: "real-1" });
@@ -123,45 +133,62 @@ describe("tryResume", () => {
   });
 
   it("skips decks already in importedDeckIds (resumable)", async () => {
-    stash({ version: 1, anonUuid: "anon-1", importedDeckIds: ["d1"] });
+    stash({ version: 2, anonDeckIds: ["d1", "d2"], importedDeckIds: ["d1"] });
     const fake = makeFakeSupabase({
-      decks: [
-        { ownerId: "anon-1", id: "d1", name: "Done" },
-        { ownerId: "anon-1", id: "d2", name: "Pending" },
-      ],
-      cards: [{ id: "c2", deck_id: "d2", position: 0, payload: {} }],
+      deckById: {
+        d1: { id: "d1", name: "Done" },
+        d2: { id: "d2", name: "Pending" },
+      },
+      cardsByDeck: { d2: [{ id: "c2", deck_id: "d2", position: 0, payload: {} }] },
       inserts: { decks: [], cards: [] },
     });
     await tryResume({ supabase: fake as never, currentUserId: "real-1" });
     expect(fake.state.inserts.decks).toHaveLength(1);
   });
 
-  it("treats zero-rows as already-imported and clears the key without inserting", async () => {
-    stash({ version: 1, anonUuid: "missing-anon", importedDeckIds: [] });
+  it("skips a deck that was deleted between stash and resume", async () => {
+    stash({ version: 2, anonDeckIds: ["missing"], importedDeckIds: [] });
     const fake = makeFakeSupabase({
-      decks: [],
-      cards: [],
+      deckById: { missing: null },
+      cardsByDeck: {},
       inserts: { decks: [], cards: [] },
     });
-    await tryResume({ supabase: fake as never, currentUserId: "real-1" });
+    const result = await tryResume({ supabase: fake as never, currentUserId: "real-1" });
     expect(fake.state.inserts.decks).toHaveLength(0);
+    expect(result).toEqual({ kind: "completed", importedCount: 1 });
+    expect(readPending()).toBeNull();
+  });
+
+  it("treats an empty anonDeckIds list as already-completed and clears the key", async () => {
+    stash({ version: 2, anonDeckIds: [], importedDeckIds: [] });
+    const fake = makeFakeSupabase({
+      deckById: {},
+      cardsByDeck: {},
+      inserts: { decks: [], cards: [] },
+    });
+    const result = await tryResume({ supabase: fake as never, currentUserId: "real-1" });
+    expect(result).toEqual({ kind: "completed", importedCount: 0 });
     expect(readPending()).toBeNull();
   });
 
   it("is a no-op when there is no pending import", async () => {
-    const fake = makeFakeSupabase({ decks: [], cards: [], inserts: { decks: [], cards: [] } });
+    const fake = makeFakeSupabase({
+      deckById: {},
+      cardsByDeck: {},
+      inserts: { decks: [], cards: [] },
+    });
     const result = await tryResume({ supabase: fake as never, currentUserId: "real-1" });
     expect(result).toEqual({ kind: "noop" });
   });
 
   it("returns partial and re-stashes when deck insert fails mid-loop", async () => {
-    stash({ version: 1, anonUuid: "anon-1", importedDeckIds: [] });
+    stash({ version: 2, anonDeckIds: ["d1", "d2"], importedDeckIds: [] });
     const fake = makeFakeSupabase({
-      decks: [
-        { ownerId: "anon-1", id: "d1", name: "First" },
-        { ownerId: "anon-1", id: "d2", name: "Second" },
-      ],
-      cards: [],
+      deckById: {
+        d1: { id: "d1", name: "First" },
+        d2: { id: "d2", name: "Second" },
+      },
+      cardsByDeck: {},
       inserts: { decks: [], cards: [] },
       insertResults: [
         { table: "decks", error: null },

--- a/src/auth/anonImport.ts
+++ b/src/auth/anonImport.ts
@@ -3,8 +3,8 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 const STORAGE_KEY = "dndCards.pendingAnonImport";
 
 export type PendingAnonImport = {
-  version: 1;
-  anonUuid: string;
+  version: 2;
+  anonDeckIds: string[];
   importedDeckIds: string[];
 };
 
@@ -21,7 +21,7 @@ export function readPending(): PendingAnonImport | null {
   if (!raw) return null;
   try {
     const parsed = JSON.parse(raw) as { version?: number };
-    if (parsed.version !== 1) return null;
+    if (parsed.version !== 2) return null;
     return parsed as PendingAnonImport;
   } catch {
     return null;
@@ -40,27 +40,39 @@ export async function tryResume(args: {
 }): Promise<ResumeResult> {
   const pending = readPending();
   if (!pending) return { kind: "noop" };
-
-  const { data: anonDecks, error: deckError } = await args.supabase
-    .from("decks")
-    .select("id, name")
-    .eq("owner_id", pending.anonUuid);
-  if (deckError) throw deckError;
-  if (!anonDecks || anonDecks.length === 0) {
+  if (pending.anonDeckIds.length === 0) {
     clear();
     return { kind: "completed", importedCount: 0 };
   }
 
-  const total = anonDecks.length;
+  const total = pending.anonDeckIds.length;
   let imported = pending.importedDeckIds.length;
   args.onProgress?.(imported, total);
 
-  for (const deck of anonDecks as Array<{ id: string; name: string }>) {
-    if (pending.importedDeckIds.includes(deck.id)) continue;
+  for (const deckId of pending.anonDeckIds) {
+    if (pending.importedDeckIds.includes(deckId)) continue;
+
+    const { data: oldDeck, error: deckError } = await args.supabase
+      .rpc("get_public_deck", { deck_id: deckId })
+      .maybeSingle();
+    if (deckError) {
+      stash(pending);
+      return { kind: "partial", importedCount: imported, total };
+    }
+    if (!oldDeck) {
+      // Anon deck deleted between stash and resume — mark as imported and continue.
+      pending.importedDeckIds.push(deckId);
+      imported += 1;
+      stash(pending);
+      args.onProgress?.(imported, total);
+      continue;
+    }
+
+    const oldDeckRow = oldDeck as { id: string; name: string };
 
     const { data: newDeck, error: insertDeckError } = await args.supabase
       .from("decks")
-      .insert({ owner_id: args.currentUserId, name: deck.name })
+      .insert({ owner_id: args.currentUserId, name: oldDeckRow.name })
       .select()
       .single();
     if (insertDeckError) {
@@ -68,17 +80,17 @@ export async function tryResume(args: {
       return { kind: "partial", importedCount: imported, total };
     }
 
-    const { data: cards, error: cardsError } = await args.supabase
-      .from("cards")
-      .select("position, payload")
-      .eq("deck_id", deck.id);
+    const { data: cards, error: cardsError } = await args.supabase.rpc("get_public_deck_cards", {
+      deck_id: deckId,
+    });
     if (cardsError) {
       stash(pending);
       return { kind: "partial", importedCount: imported, total };
     }
 
-    if (cards && cards.length > 0) {
-      const rows = (cards as Array<{ position: number; payload: unknown }>).map((c) => ({
+    const cardRows = (cards ?? []) as Array<{ position: number; payload: unknown }>;
+    if (cardRows.length > 0) {
+      const rows = cardRows.map((c) => ({
         deck_id: (newDeck as { id: string }).id,
         position: c.position,
         payload: c.payload,
@@ -90,7 +102,7 @@ export async function tryResume(args: {
       }
     }
 
-    pending.importedDeckIds.push(deck.id);
+    pending.importedDeckIds.push(deckId);
     imported += 1;
     stash(pending);
     args.onProgress?.(imported, total);

--- a/src/decks/mutations.ts
+++ b/src/decks/mutations.ts
@@ -24,7 +24,7 @@ export function useCreateDeck() {
       if (!data) throw new Error("useCreateDeck: insert returned no row");
       return data as DeckRow;
     },
-    onSuccess: (_data, vars) => {
+    onSuccess: () => {
       qc.invalidateQueries({ queryKey: decksKey() });
     },
   });

--- a/src/decks/mutations.ts
+++ b/src/decks/mutations.ts
@@ -25,7 +25,7 @@ export function useCreateDeck() {
       return data as DeckRow;
     },
     onSuccess: (_data, vars) => {
-      qc.invalidateQueries({ queryKey: decksKey(vars.ownerId) });
+      qc.invalidateQueries({ queryKey: decksKey() });
     },
   });
 }
@@ -46,7 +46,7 @@ export function useRenameDeck() {
     },
     onSuccess: (data) => {
       qc.invalidateQueries({ queryKey: deckKey(data.id) });
-      qc.invalidateQueries({ queryKey: decksKey(data.owner_id) });
+      qc.invalidateQueries({ queryKey: decksKey() });
     },
   });
 }

--- a/src/decks/queries.test.tsx
+++ b/src/decks/queries.test.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
-import { makeCardRow, makeDeckRow } from "../test/factories";
+import { makeCardRow, makeDeckRow, makeDeckSummary } from "../test/factories";
 import { server } from "../test/msw";
 import { useDeck, useDeckCards, useDecks } from "./queries";
 
@@ -17,17 +17,12 @@ function wrapper() {
 }
 
 describe("useDecks", () => {
-  it("returns the user's decks", async () => {
-    const decks = [makeDeckRow.build(), makeDeckRow.build()];
-    server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json(decks)));
-    const { result } = renderHook(() => useDecks("user-id"), { wrapper: wrapper() });
+  it("returns the user's decks via list_my_decks RPC", async () => {
+    const decks = [makeDeckSummary.build(), makeDeckSummary.build()];
+    server.use(http.post(`${SB}/rest/v1/rpc/list_my_decks`, () => HttpResponse.json(decks)));
+    const { result } = renderHook(() => useDecks(), { wrapper: wrapper() });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(decks);
-  });
-
-  it("is disabled when ownerId is undefined", async () => {
-    const { result } = renderHook(() => useDecks(undefined), { wrapper: wrapper() });
-    expect(result.current.fetchStatus).toBe("idle");
   });
 });
 

--- a/src/decks/queries.test.tsx
+++ b/src/decks/queries.test.tsx
@@ -44,9 +44,13 @@ describe("useDeck", () => {
 });
 
 describe("useDeckCards", () => {
-  it("returns cards for the given deck, mapped to the Card type", async () => {
+  it("returns cards for a deck via get_public_deck_cards RPC", async () => {
     const [firstRow, secondRow] = [makeCardRow.build(), makeCardRow.build()];
-    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json([firstRow, secondRow])));
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () =>
+        HttpResponse.json([firstRow, secondRow]),
+      ),
+    );
     const { result } = renderHook(() => useDeckCards("deck-id"), { wrapper: wrapper() });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     const cards = result.current.data ?? [];

--- a/src/decks/queries.test.tsx
+++ b/src/decks/queries.test.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import { describe, expect, it } from "vitest";
-import { makeCardRow, makeDeckRow, makeDeckSummary } from "../test/factories";
+import { makeCardRow, makeDeckSummary, makePublicDeck } from "../test/factories";
 import { server } from "../test/msw";
 import { useDeck, useDeckCards, useDecks } from "./queries";
 
@@ -27,16 +27,16 @@ describe("useDecks", () => {
 });
 
 describe("useDeck", () => {
-  it("returns a single deck by id", async () => {
-    const deck = makeDeckRow.build();
-    server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([deck])));
+  it("returns a PublicDeck via get_public_deck RPC", async () => {
+    const deck = makePublicDeck.build({ is_owner: true });
+    server.use(http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(deck)));
     const { result } = renderHook(() => useDeck(deck.id), { wrapper: wrapper() });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(deck);
   });
 
   it("returns null when the deck doesn't exist", async () => {
-    server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([])));
+    server.use(http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(null)));
     const { result } = renderHook(() => useDeck("missing"), { wrapper: wrapper() });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toBeNull();

--- a/src/decks/queries.ts
+++ b/src/decks/queries.ts
@@ -2,25 +2,23 @@ import { useQuery } from "@tanstack/react-query";
 import { supabase } from "../api/supabase";
 import type { Card } from "../cards/types";
 import { rowToCard } from "./rowMappers";
-import type { CardRow, DeckRow } from "./types";
+import type { CardRow, DeckRow, DeckSummary } from "./types";
 
-export const decksKey = (ownerId: string | undefined) => ["decks", ownerId] as const;
+export const decksKey = () => ["decks"] as const;
 export const deckKey = (deckId: string | undefined) => ["deck", deckId] as const;
 export const deckCardsKey = (deckId: string | undefined) => ["deck-cards", deckId] as const;
 
-export function useDecks(ownerId: string | undefined) {
-  return useQuery<DeckRow[]>({
-    queryKey: decksKey(ownerId),
-    enabled: Boolean(ownerId),
+/**
+ * Decks owned by the current user — for the home view's deck list.
+ * Server-side: RPC list_my_decks reads auth.uid().
+ */
+export function useDecks() {
+  return useQuery<DeckSummary[]>({
+    queryKey: decksKey(),
     queryFn: async () => {
-      if (!ownerId) return [];
-      const { data, error } = await supabase
-        .from("decks")
-        .select("*")
-        .eq("owner_id", ownerId)
-        .order("created_at", { ascending: false });
+      const { data, error } = await supabase.rpc("list_my_decks");
       if (error) throw error;
-      return data ?? [];
+      return (data ?? []) as DeckSummary[];
     },
   });
 }

--- a/src/decks/queries.ts
+++ b/src/decks/queries.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { supabase } from "../api/supabase";
 import type { Card } from "../cards/types";
 import { rowToCard } from "./rowMappers";
-import type { CardRow, DeckRow, DeckSummary } from "./types";
+import type { CardRow, DeckSummary, PublicDeck } from "./types";
 
 export const decksKey = () => ["decks"] as const;
 export const deckKey = (deckId: string | undefined) => ["deck", deckId] as const;
@@ -23,21 +23,26 @@ export function useDecks() {
   });
 }
 
+/**
+ * A single deck by id. PUBLIC READ — any caller with the deck id can
+ * read it. There is no ownership filter; this matches the share-by-link
+ * model. The returned row includes `is_owner`, computed server-side
+ * from auth.uid(), which UI uses to gate edit affordances. Mutations
+ * are still owner-gated by RLS on the underlying table.
+ */
 export function useDeck(deckId: string | undefined) {
-  return useQuery<DeckRow | null>({
+  return useQuery<PublicDeck | null>({
     queryKey: deckKey(deckId),
     enabled: Boolean(deckId),
     queryFn: async () => {
       if (!deckId) return null;
       const { data, error } = await supabase
-        .from("decks")
-        .select("*")
-        .eq("id", deckId)
+        .rpc("get_public_deck", { deck_id: deckId })
         .maybeSingle();
       if (error) throw error;
       // Return null (not undefined) on miss: TanStack Query v5 throws if a
       // queryFn returns undefined.
-      return data ?? null;
+      return (data ?? null) as PublicDeck | null;
     },
   });
 }

--- a/src/decks/queries.ts
+++ b/src/decks/queries.ts
@@ -47,17 +47,16 @@ export function useDeck(deckId: string | undefined) {
   });
 }
 
+/**
+ * Cards for a deck. Same PUBLIC READ semantics as useDeck.
+ */
 export function useDeckCards(deckId: string | undefined) {
   return useQuery<Card[]>({
     queryKey: deckCardsKey(deckId),
     enabled: Boolean(deckId),
     queryFn: async () => {
       if (!deckId) return [];
-      const { data, error } = await supabase
-        .from("cards")
-        .select("*")
-        .eq("deck_id", deckId)
-        .order("created_at", { ascending: true });
+      const { data, error } = await supabase.rpc("get_public_deck_cards", { deck_id: deckId });
       if (error) throw error;
       return ((data ?? []) as CardRow[]).map(rowToCard);
     },

--- a/src/decks/types.ts
+++ b/src/decks/types.ts
@@ -16,3 +16,17 @@ export type CardRow = {
   created_at: string;
   updated_at: string;
 };
+
+// Returned by list_my_decks() RPC.
+export type DeckSummary = {
+  id: string;
+  name: string;
+  created_at: string;
+  updated_at: string;
+};
+
+// Returned by get_public_deck(deck_id) RPC. Adds is_owner so callers
+// can gate UI without learning the owner's UUID.
+export type PublicDeck = DeckSummary & {
+  is_owner: boolean;
+};

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -1,10 +1,10 @@
 import { faker } from "@faker-js/faker";
 import { Factory } from "fishery";
 import type { AbilityCard, ItemCard, SpellCard } from "../cards/types";
-import type { CardRow, DeckRow } from "../decks/types";
+import type { CardRow, DeckRow, DeckSummary, PublicDeck } from "../decks/types";
 
 // Re-export DB row types for tests that want them via this barrel.
-export type { CardRow, DeckRow };
+export type { CardRow, DeckRow, DeckSummary, PublicDeck };
 
 export const makeDeckRow = Factory.define<DeckRow>(() => {
   const now = faker.date.recent().toISOString();
@@ -68,5 +68,26 @@ export const makeCardRow = Factory.define<CardRow>(() => {
     payload: makeItemPayload.build(),
     created_at: now,
     updated_at: now,
+  };
+});
+
+export const makeDeckSummary = Factory.define<DeckSummary>(() => {
+  const now = faker.date.recent().toISOString();
+  return {
+    id: faker.string.uuid(),
+    name: faker.lorem.words({ min: 2, max: 4 }),
+    created_at: now,
+    updated_at: now,
+  };
+});
+
+export const makePublicDeck = Factory.define<PublicDeck>(() => {
+  const now = faker.date.recent().toISOString();
+  return {
+    id: faker.string.uuid(),
+    name: faker.lorem.words({ min: 2, max: 4 }),
+    created_at: now,
+    updated_at: now,
+    is_owner: false,
   };
 });

--- a/src/views/DeckView.test.tsx
+++ b/src/views/DeckView.test.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { supabase } from "../api/supabase";
 import { AuthProvider } from "../auth/AuthProvider";
-import { makeCardRow, makeDeckRow } from "../test/factories";
+import { makeCardRow, makePublicDeck } from "../test/factories";
 import { server } from "../test/msw";
 import { signInTestUser } from "../test/signInTestUser";
 import { DeckView } from "./DeckView";
@@ -51,10 +51,10 @@ describe("DeckView (logged-out)", () => {
   });
 
   it("renders cards but no edit/new/delete controls", async () => {
-    const deck = makeDeckRow.build();
+    const deck = makePublicDeck.build({ is_owner: false });
     const card = makeCardRow.build({ deck_id: deck.id });
     server.use(
-      http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([deck])),
+      http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(deck)),
       http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json([card])),
     );
     render(wrap(<DeckView deckId={deck.id} />));
@@ -69,7 +69,7 @@ describe("DeckView (logged-out)", () => {
   });
 
   it("renders a not-found message when the deck doesn't exist", async () => {
-    server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([])));
+    server.use(http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(null)));
     render(wrap(<DeckView deckId="missing" />));
     await waitFor(() =>
       expect(screen.getByText(/this deck no longer exists/i)).toBeInTheDocument(),
@@ -83,12 +83,12 @@ describe("DeckView (owner)", () => {
   });
 
   it("shows edit + delete controls and deletes a card on click", async () => {
-    const user = await signInTestUser();
-    const deck = makeDeckRow.build({ owner_id: user.id });
+    await signInTestUser();
+    const deck = makePublicDeck.build({ is_owner: true });
     const card = makeCardRow.build({ deck_id: deck.id });
     const onDelete = vi.fn();
     server.use(
-      http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([deck])),
+      http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(deck)),
       http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json([card])),
       http.delete(`${SB}/rest/v1/cards`, () => {
         onDelete();

--- a/src/views/DeckView.test.tsx
+++ b/src/views/DeckView.test.tsx
@@ -55,7 +55,7 @@ describe("DeckView (logged-out)", () => {
     const card = makeCardRow.build({ deck_id: deck.id });
     server.use(
       http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(deck)),
-      http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json([card])),
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json([card])),
     );
     render(wrap(<DeckView deckId={deck.id} />));
     await waitFor(() => expect(screen.getByText(card.payload.name)).toBeInTheDocument());
@@ -89,7 +89,7 @@ describe("DeckView (owner)", () => {
     const onDelete = vi.fn();
     server.use(
       http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(deck)),
-      http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json([card])),
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json([card])),
       http.delete(`${SB}/rest/v1/cards`, () => {
         onDelete();
         return HttpResponse.json([]);

--- a/src/views/DeckView.tsx
+++ b/src/views/DeckView.tsx
@@ -1,6 +1,5 @@
 import { Link } from "@tanstack/react-router";
 import { useState } from "react";
-import { useSession } from "../auth/useSession";
 import { serializeDeck } from "../decks/io";
 import { useDeleteCard, useRenameDeck } from "../decks/mutations";
 import { useDeck, useDeckCards } from "../decks/queries";
@@ -17,7 +16,6 @@ import styles from "./DeckView.module.css";
 type Props = { deckId: string };
 
 export function DeckView({ deckId }: Props) {
-  const session = useSession();
   const deckQuery = useDeck(deckId);
   const cardsQuery = useDeckCards(deckId);
   const renameDeck = useRenameDeck();
@@ -29,7 +27,7 @@ export function DeckView({ deckId }: Props) {
 
   const deck = deckQuery.data;
   const cards = cardsQuery.data ?? [];
-  const isOwner = session.status === "authenticated" && session.user.id === deck.owner_id;
+  const isOwner = deck.is_owner;
 
   const handleExport = () => {
     downloadText(`${deck.name}.json`, serializeDeck({ version: 1, cards }));

--- a/src/views/EditorView.test.tsx
+++ b/src/views/EditorView.test.tsx
@@ -30,7 +30,7 @@ describe("EditorView", () => {
   });
 
   it("renders 'Card not found' when cardId is missing from server", async () => {
-    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json([])));
+    server.use(http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json([])));
     render(wrap(<EditorView deckId="d1" cardId="missing" />));
     await waitFor(() => expect(screen.getByText(/card not found/i)).toBeInTheDocument());
   });
@@ -69,7 +69,7 @@ describe("EditorView", () => {
     const card = makeCardRow.build({ id: "c1", deck_id: "d1" });
     const onPatch = vi.fn();
     server.use(
-      http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json([card])),
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json([card])),
       http.patch(`${SB}/rest/v1/cards`, async ({ request }) => {
         onPatch(await request.json());
         return HttpResponse.json([card]);
@@ -94,7 +94,9 @@ describe("EditorView", () => {
 
   it("does NOT show the import hint when editing an existing card", async () => {
     const card = makeCardRow.build({ id: "c1", deck_id: "d1" });
-    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json([card])));
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json([card])),
+    );
     render(wrap(<EditorView deckId="d1" cardId="c1" />));
     await screen.findByRole("button", { name: /save/i });
     expect(screen.queryByTestId("import-hint")).not.toBeInTheDocument();
@@ -128,7 +130,9 @@ describe("EditorView", () => {
 
   it("shows '1 card' counts label when body fits", async () => {
     const card = makeCardRow.build({ id: "c1", deck_id: "d1" });
-    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json([card])));
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json([card])),
+    );
     render(wrap(<EditorView deckId="d1" cardId="c1" />));
     expect(await screen.findByText("1 card")).toBeInTheDocument();
   });
@@ -138,7 +142,9 @@ describe("EditorView", () => {
     vi.spyOn(paginateModule, "paginateBody").mockImplementation(({ body }) =>
       body === "" ? [""] : ["chunk-a", "chunk-b", "chunk-c"],
     );
-    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json([card])));
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json([card])),
+    );
     render(wrap(<EditorView deckId="d1" cardId="c1" />));
     expect(await screen.findByRole("button", { name: /next preview page/i })).toBeInTheDocument();
     expect(screen.getByText("3 cards")).toBeInTheDocument();
@@ -152,7 +158,9 @@ describe("EditorView", () => {
       callCount += 1;
       return callCount === 1 ? ["chunk-a", "chunk-b", "chunk-c"] : ["chunk-x", "chunk-y"];
     });
-    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json([card])));
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json([card])),
+    );
     render(wrap(<EditorView deckId="d1" cardId="c1" />));
     expect(
       await screen.findByText("3 cards (4 per page) | 2 cards (2 per page)"),

--- a/src/views/HomeView.test.tsx
+++ b/src/views/HomeView.test.tsx
@@ -66,7 +66,7 @@ describe("HomeView", () => {
   it("shows the user's decks when authenticated", async () => {
     await signInTestUser();
     const decks = [makeDeckRow.build(), makeDeckRow.build()];
-    server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json(decks)));
+    server.use(http.post(`${SB}/rest/v1/rpc/list_my_decks`, () => HttpResponse.json(decks)));
     render(wrap(<HomeView />));
     for (const d of decks) {
       await waitFor(() => expect(screen.getByText(d.name)).toBeInTheDocument());
@@ -75,7 +75,7 @@ describe("HomeView", () => {
 
   it("shows an empty-state CTA when authenticated with no decks", async () => {
     await signInTestUser();
-    server.use(http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([])));
+    server.use(http.post(`${SB}/rest/v1/rpc/list_my_decks`, () => HttpResponse.json([])));
     render(wrap(<HomeView />));
     await waitFor(() =>
       expect(screen.getByRole("button", { name: /create your first deck/i })).toBeInTheDocument(),
@@ -86,7 +86,7 @@ describe("HomeView", () => {
     await signInTestUser();
     const inserted = makeDeckRow.build({ name: "Untitled deck" });
     server.use(
-      http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([])),
+      http.post(`${SB}/rest/v1/rpc/list_my_decks`, () => HttpResponse.json([])),
       http.post(`${SB}/rest/v1/decks`, () => HttpResponse.json([inserted], { status: 201 })),
     );
     render(wrap(<HomeView />));
@@ -104,7 +104,7 @@ describe("HomeView", () => {
     const created = makeDeckRow.build({ name: "my-deck" });
     const insertedRows: unknown[] = [];
     server.use(
-      http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([])),
+      http.post(`${SB}/rest/v1/rpc/list_my_decks`, () => HttpResponse.json([])),
       http.post(`${SB}/rest/v1/decks`, () => HttpResponse.json([created], { status: 201 })),
       http.post(`${SB}/rest/v1/cards`, async ({ request }) => {
         insertedRows.push(await request.json());
@@ -153,7 +153,7 @@ describe("HomeView", () => {
     const deck = makeDeckRow.build();
     const onDelete = vi.fn();
     server.use(
-      http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([deck])),
+      http.post(`${SB}/rest/v1/rpc/list_my_decks`, () => HttpResponse.json([deck])),
       http.delete(`${SB}/rest/v1/decks`, () => {
         onDelete();
         return HttpResponse.json([]);
@@ -190,7 +190,7 @@ describe("HomeView with anon user", () => {
   it("opens the FirstDeckDialog after an anonymous user creates their first deck", async () => {
     const inserted = makeDeckRow.build({ name: "Untitled deck", owner_id: "anon-1" });
     server.use(
-      http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([])),
+      http.post(`${SB}/rest/v1/rpc/list_my_decks`, () => HttpResponse.json([])),
       http.post(`${SB}/rest/v1/decks`, () => HttpResponse.json([inserted], { status: 201 })),
     );
     renderAsAnon();
@@ -207,7 +207,7 @@ describe("HomeView with anon user", () => {
     window.localStorage.setItem("dndCards.firstDeckExplainerSeen", "1");
     const inserted = makeDeckRow.build({ name: "Untitled deck", owner_id: "anon-1" });
     server.use(
-      http.get(`${SB}/rest/v1/decks`, () => HttpResponse.json([])),
+      http.post(`${SB}/rest/v1/rpc/list_my_decks`, () => HttpResponse.json([])),
       http.post(`${SB}/rest/v1/decks`, () => HttpResponse.json([inserted], { status: 201 })),
     );
     renderAsAnon();

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -17,7 +17,7 @@ export function HomeView() {
   const session = useSession();
   const navigate = useNavigate();
   const ownerId = session.status === "authenticated" ? session.user.id : undefined;
-  const decks = useDecks(ownerId);
+  const decks = useDecks();
   const createDeck = useCreateDeck();
   const deleteDeck = useDeleteDeck();
   const saveCard = useSaveCard();

--- a/src/views/PrintView.test.tsx
+++ b/src/views/PrintView.test.tsx
@@ -18,21 +18,27 @@ function wrap(ui: ReactNode) {
 describe("<PrintView>", () => {
   test("renders one page at 4-up for up to 4 cards", async () => {
     const cards = makeCardRow.buildList(3);
-    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json(cards)));
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+    );
     render(wrap(<PrintView deckId="d1" />));
     await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
   });
 
   test("renders two pages when there are 5 cards at 4-up", async () => {
     const cards = makeCardRow.buildList(5);
-    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json(cards)));
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+    );
     render(wrap(<PrintView deckId="d1" />));
     await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(2));
   });
 
   test("switches to 2-up and repaginates accordingly", async () => {
     const cards = makeCardRow.buildList(3);
-    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json(cards)));
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+    );
     render(wrap(<PrintView deckId="d1" />));
     await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
     await userEvent.selectOptions(screen.getByRole("combobox", { name: /cards per page/i }), "2");
@@ -41,7 +47,9 @@ describe("<PrintView>", () => {
 
   test("2-up pages carry the landscape layout class", async () => {
     const cards = makeCardRow.buildList(2);
-    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json(cards)));
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+    );
     render(wrap(<PrintView deckId="d1" />));
     await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
     await userEvent.selectOptions(screen.getByRole("combobox", { name: /cards per page/i }), "2");
@@ -56,7 +64,9 @@ describe("<PrintView>", () => {
     vi.spyOn(paginateModule, "paginateBody").mockImplementation(({ body }) =>
       body === "" ? [""] : ["chunk-a", "chunk-b", "chunk-c"],
     );
-    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json([card])));
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json([card])),
+    );
     render(wrap(<PrintView deckId="d1" />));
     await waitFor(() => {
       const indicators = screen.getAllByTestId("card-pagination");
@@ -68,7 +78,9 @@ describe("<PrintView>", () => {
 
   test("does not emit back pages when the toggle is off", async () => {
     const cards = makeCardRow.buildList(4);
-    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json(cards)));
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+    );
     render(wrap(<PrintView deckId="d1" />));
     await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
     expect(document.querySelectorAll('[data-page-side="back"]')).toHaveLength(0);
@@ -76,7 +88,9 @@ describe("<PrintView>", () => {
 
   test("emits one back page per front page when the toggle is on", async () => {
     const cards = makeCardRow.buildList(5);
-    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json(cards)));
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+    );
     render(wrap(<PrintView deckId="d1" />));
     await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(2));
     await userEvent.click(screen.getByRole("switch", { name: /print backs/i }));
@@ -87,7 +101,9 @@ describe("<PrintView>", () => {
 
   test("places back tiles in the horizontally-mirrored slot order at 4-up", async () => {
     const cards = makeCardRow.buildList(4);
-    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json(cards)));
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+    );
     render(wrap(<PrintView deckId="d1" />));
     await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
     await userEvent.click(screen.getByRole("switch", { name: /print backs/i }));
@@ -106,7 +122,9 @@ describe("<PrintView>", () => {
 
   test("partial last front page produces a back page with only the populated slots filled", async () => {
     const cards = makeCardRow.buildList(3);
-    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json(cards)));
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+    );
     render(wrap(<PrintView deckId="d1" />));
     await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
     await userEvent.click(screen.getByRole("switch", { name: /print backs/i }));
@@ -118,7 +136,9 @@ describe("<PrintView>", () => {
 
   test("shows the long-edge duplex tip at 4-up when backs are on", async () => {
     const cards = makeCardRow.buildList(2);
-    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json(cards)));
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+    );
     render(wrap(<PrintView deckId="d1" />));
     await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
     // Toggle off: tip absent
@@ -130,7 +150,9 @@ describe("<PrintView>", () => {
 
   test("tip switches to short-edge when layout changes to 2-up", async () => {
     const cards = makeCardRow.buildList(2);
-    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json(cards)));
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+    );
     render(wrap(<PrintView deckId="d1" />));
     await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
     await userEvent.click(screen.getByRole("switch", { name: /print backs/i }));

--- a/supabase/migrations/20260508000000_rls_rpc_hardening.sql
+++ b/supabase/migrations/20260508000000_rls_rpc_hardening.sql
@@ -68,7 +68,7 @@ create or replace function public.get_public_deck_cards(deck_id uuid)
 returns table(
   id          uuid,
   deck_id     uuid,
-  position    integer,
+  "position"  integer,
   payload     jsonb,
   created_at  timestamptz,
   updated_at  timestamptz

--- a/supabase/migrations/20260508000000_rls_rpc_hardening.sql
+++ b/supabase/migrations/20260508000000_rls_rpc_hardening.sql
@@ -1,0 +1,98 @@
+-- Replace the universal-read SELECT policies with owner-only.
+-- Cross-identity reads (share-by-link, anon-import) go through the
+-- SECURITY DEFINER RPC functions defined below.
+drop policy if exists decks_select_all on public.decks;
+drop policy if exists cards_select_all on public.cards;
+
+create policy decks_select_owner on public.decks for select
+  using (owner_id = auth.uid());
+
+create policy cards_select_owner on public.cards for select
+  using (exists (
+    select 1 from public.decks d
+    where d.id = cards.deck_id and d.owner_id = auth.uid()
+  ));
+
+-- Owner-scoped: HomeView's deck list.
+create or replace function public.list_my_decks()
+returns table(
+  id          uuid,
+  name        text,
+  created_at  timestamptz,
+  updated_at  timestamptz
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select id, name, created_at, updated_at
+  from public.decks
+  where owner_id = auth.uid()
+  order by created_at desc
+$$;
+
+comment on function public.list_my_decks() is
+  'Owner-scoped read. Returns decks owned by the calling user.';
+
+-- Public read by UUID.
+create or replace function public.get_public_deck(deck_id uuid)
+returns table(
+  id          uuid,
+  name        text,
+  created_at  timestamptz,
+  updated_at  timestamptz,
+  is_owner    boolean
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select
+    id,
+    name,
+    created_at,
+    updated_at,
+    coalesce(owner_id = auth.uid(), false) as is_owner
+  from public.decks
+  where id = deck_id
+$$;
+
+comment on function public.get_public_deck(uuid) is
+  'Public read by UUID — anyone with the deck id can read it. Decks '
+  'are intentionally public-by-link. owner_id is NOT in the return '
+  'shape; is_owner is computed server-side instead.';
+
+create or replace function public.get_public_deck_cards(deck_id uuid)
+returns table(
+  id          uuid,
+  deck_id     uuid,
+  position    integer,
+  payload     jsonb,
+  created_at  timestamptz,
+  updated_at  timestamptz
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select c.id, c.deck_id, c.position, c.payload, c.created_at, c.updated_at
+  from public.cards c
+  where c.deck_id = get_public_deck_cards.deck_id
+  order by c.created_at asc
+$$;
+
+comment on function public.get_public_deck_cards(uuid) is
+  'Public read by UUID — returns cards for a deck readable by anyone '
+  'with the deck id. Same trust model as get_public_deck.';
+
+revoke execute on function public.list_my_decks() from public;
+revoke execute on function public.get_public_deck(uuid) from public;
+revoke execute on function public.get_public_deck_cards(uuid) from public;
+
+grant execute on function public.list_my_decks() to authenticated;
+grant execute on function public.get_public_deck(uuid) to authenticated;
+grant execute on function public.get_public_deck_cards(uuid)
+  to authenticated;

--- a/supabase/tests/rls.test.sql
+++ b/supabase/tests/rls.test.sql
@@ -1,6 +1,6 @@
 -- supabase/tests/rls.test.sql
 begin;
-select plan(7);
+select plan(13);
 
 -- Helpers: create two test users in auth.users.
 insert into auth.users (id, email) values
@@ -20,6 +20,19 @@ select lives_ok(
     '{"kind":"item","name":"x","body":"","headerTags":[],"footerTags":[],"source":"custom","createdAt":"2026-04-26T00:00:00Z","updatedAt":"2026-04-26T00:00:00Z"}'::jsonb
   )$$,
   'owner can insert card into own deck'
+);
+
+-- Owner sees own deck via list_my_decks and is_owner=true via get_public_deck.
+select is(
+  (select count(*)::int from public.list_my_decks() where id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+  1,
+  'owner sees own deck via list_my_decks'
+);
+
+select is(
+  (select is_owner from public.get_public_deck('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')),
+  true,
+  'get_public_deck reports is_owner=true for the owner'
 );
 
 -- Switch to Bob.
@@ -53,20 +66,46 @@ select is(
   'non-owner DELETE on a deck affects 0 rows'
 );
 
--- Public read access works for any role.
-set local role anon;
-
+-- Owner-only SELECT: non-owner sees no rows via direct SELECT on either table.
 select is(
   (select count(*)::int from public.decks where id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
-  1,
-  'anon can SELECT decks'
+  0,
+  'non-owner cannot direct-SELECT decks'
 );
 
 select is(
   (select count(*)::int from public.cards where deck_id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
-  1,
-  'anon can SELECT cards'
+  0,
+  'non-owner cannot direct-SELECT cards'
 );
+
+-- Public-by-link: non-owner can read via SECURITY DEFINER RPCs given the UUID.
+select is(
+  (select count(*)::int from public.get_public_deck('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')),
+  1,
+  'non-owner can read deck via get_public_deck RPC'
+);
+
+select is(
+  (select is_owner from public.get_public_deck('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')),
+  false,
+  'get_public_deck reports is_owner=false for non-owner'
+);
+
+select is(
+  (select count(*)::int from public.get_public_deck_cards('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')),
+  1,
+  'non-owner can read cards via get_public_deck_cards RPC'
+);
+
+-- list_my_decks is owner-scoped: Bob sees nothing.
+select is(
+  (select count(*)::int from public.list_my_decks()),
+  0,
+  'non-owner sees 0 rows in list_my_decks'
+);
+
+set local role anon;
 
 select throws_ok(
   $$insert into public.decks (owner_id, name) values ('11111111-1111-1111-1111-111111111111', 'spam')$$,


### PR DESCRIPTION
### What are the relevant tickets?

Closes #49.

### Description

Replaces the universal-read RLS posture on `decks` and `cards` with owner-only SELECT policies plus three SECURITY DEFINER RPC functions that encode the intended access model: owner-private deck listing, public-by-UUID deck viewing.

**Before:** `decks_select_all` and `cards_select_all` used `using (true)`. Any authenticated principal — including the anon-users JWTs from #48 — could `SELECT *` from either table and enumerate every deck and card.

**After:**
- `decks_select_owner` / `cards_select_owner` policies restrict direct SELECT to rows the caller owns.
- Three RPCs handle the access patterns the tightened policies don't allow:
  - `list_my_decks()` — HomeView's deck list, owner-scoped via `auth.uid()`.
  - `get_public_deck(deck_id)` — share-by-link reads. No ownership filter; anyone with the UUID can read.
  - `get_public_deck_cards(deck_id)` — same trust model for the deck's cards.
- `get_public_deck` returns `is_owner` (computed server-side as `coalesce(owner_id = auth.uid(), false)`) instead of leaking `owner_id`. UI gates the edit affordance on this boolean.
- All three RPCs use explicit `returns table(...)` shapes so future columns added to `decks`/`cards` don't auto-leak.
- Mutations stay on direct-table operations — owner-only SELECT permits `INSERT/UPDATE … RETURNING` for owner rows.

**Client refactor:**
- `src/decks/queries.ts` calls the RPCs; `decksKey()` is now a no-arg helper; `useDeck` returns `PublicDeck` (with `is_owner`).
- `DeckView` and `RequireOwner` consume `deck.is_owner` instead of comparing `session.user.id === deck.owner_id`.
- `src/auth/anonImport.ts` switches to a v2 localStorage payload (`anonDeckIds: string[]` instead of `anonUuid`). Iterating by deck ID via the public RPCs removes the need for a fourth, anon-scoped RPC and the associated trust-boundary concerns.
- `LoginView` and `AuthCallback` prefetch deck IDs via `list_my_decks` before stashing (the anon's deck list isn't loaded at either call site).

### How can this be tested?

**Manual smoke (post-deploy):**
- Sign in as the dev user → HomeView lists your decks. Open one → DeckView shows the edit affordance and the editor opens.
- Open the same deck via a different browser session (or signed out) → DeckView still loads (public-by-link), but the edit affordance is hidden, and navigating to `/deck/X/edit/Y` directly bounces to `/deck/X` with the announcement *"This deck is read-only — only the owner can edit."*
- With `VITE_ANON_USERS_ENABLED=true`: create an anon deck, click sign-in, complete OAuth — the deck imports on return. If `list_my_decks` errors during the prefetch, both `LoginView` and `AuthCallback` abort before sign-out and surface a recoverable error.

**Test coverage:**
- `src/decks/queries.test.tsx` — RPC handlers replace REST GETs for read paths.
- `src/decks/mutations.test.tsx` — unchanged behavior (mutations still hit the table directly).
- `src/views/DeckView.test.tsx`, `EditorView.test.tsx`, `PrintView.test.tsx`, `BrowseApiModal.test.tsx`, `HomeView.test.tsx`, `app/DeckBreadcrumb.test.tsx` — RPC mocks for read-paths; `is_owner` drives owner-gated UI assertions.
- `src/auth/RequireOwner.test.tsx` — owner / non-owner scenarios via `is_owner`; new `AnnouncementProvider` wrap.
- `src/auth/anonImport.test.ts` — v2 payload + new fake supabase with `rpc()` and `from()` shapes.
- `src/auth/LoginView.test.tsx` and `src/auth/AuthCallback.test.tsx` — error-path coverage for `list_my_decks` failures during the import prefetch.

End-to-end DB verification: `npx supabase db reset` applies the migration cleanly and curl smoke tests confirm an anon JWT cannot enumerate via direct SELECT, while `get_public_deck(uuid)` returns the deck with `is_owner: false`.

### Additional Context

- **`is_public` column deferred.** All decks are public-by-link today; an `is_public` column whose value is always `true` is YAGNI. If/when private decks become a real feature, a follow-up migration adds the column with `default true`.
- **`"position"` is quoted** in `get_public_deck_cards`'s `returns table(...)` because it's a SQL reserved word. The body is unaffected.
- **Supabase default privileges** grant EXECUTE to the `anon` PostgREST role on functions in the `public` schema. The migration's `revoke ... from public` doesn't strip those grants — but this is functionally correct: it lets unauthenticated browser visitors view shared decks (intended share-by-link behavior). Anon callers can't enumerate (direct SELECT is RLS-blocked) and `is_owner` resolves to `false` for them via the `coalesce`.
- **Reviewed in three rounds at the spec stage** plus two rounds of implementation review (security + UX, both rounds). Spec lives at `docs/superpowers/specs/2026-05-08-rls-rpc-hardening-design.md`; plan at `docs/superpowers/plans/2026-05-08-rls-rpc-hardening.md`.