### PR TITLE
fix(auth): guard AuthCallback against re-entrant deck import

### DIFF
--- a/src/auth/AuthCallback.test.tsx
+++ b/src/auth/AuthCallback.test.tsx
@@ -250,4 +250,69 @@ describe("AuthCallback", () => {
     await waitFor(() => expect(navigate).toHaveBeenCalled());
     expect(window.localStorage.getItem("dndCards.pendingAnonImport")).toBeNull();
   });
+
+  it("does not re-enter tryResume when session re-renders mid-import", async () => {
+    // Regression for the post-OAuth-callback double-import: supabase-js can
+    // fire onAuthStateChange twice back-to-back (e.g., INITIAL_SESSION then
+    // SIGNED_IN). AuthProvider rebuilds the session object on each event, so
+    // AuthCallback's effect re-runs. Without a guard, a second tryResume
+    // races with the first and every imported deck is duplicated.
+    window.localStorage.setItem(
+      "dndCards.pendingAnonImport",
+      JSON.stringify({ version: 2, anonDeckIds: ["d1"], importedDeckIds: [] }),
+    );
+    setLocation({});
+
+    let resolveDeck: (v: { data: unknown; error: unknown }) => void = () => {};
+    const deckPromise = new Promise<{ data: unknown; error: unknown }>((r) => {
+      resolveDeck = r;
+    });
+
+    vi.spyOn(supabase, "rpc").mockImplementation(((name: string) => {
+      if (name === "get_public_deck") {
+        return { maybeSingle: () => deckPromise };
+      }
+      if (name === "get_public_deck_cards") {
+        return Promise.resolve({ data: [], error: null });
+      }
+      return Promise.resolve({ data: [], error: null });
+    }) as never);
+
+    const insertSpy = vi.fn(() => ({
+      select: () => ({
+        single: () => Promise.resolve({ data: { id: "new-deck" }, error: null }),
+      }),
+    }));
+    vi.spyOn(supabase, "from").mockReturnValue({ insert: insertSpy } as never);
+
+    const session1: SessionState = {
+      status: "authenticated",
+      user: { id: "real-1", is_anonymous: false, email: "x@y.z" } as never,
+      session: {} as never,
+    };
+    const session2: SessionState = {
+      status: "authenticated",
+      user: { id: "real-1", is_anonymous: false, email: "x@y.z" } as never,
+      session: {} as never,
+    };
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const Tree = ({ session }: { session: SessionState }) => (
+      <QueryClientProvider client={client}>
+        <AnnouncementProvider>
+          <SessionContext.Provider value={session}>
+            <AuthCallback />
+          </SessionContext.Provider>
+        </AnnouncementProvider>
+      </QueryClientProvider>
+    );
+
+    const { rerender } = render(<Tree session={session1} />);
+    rerender(<Tree session={session2} />);
+
+    resolveDeck({ data: { id: "d1", name: "Goblins" }, error: null });
+
+    await waitFor(() => expect(navigate).toHaveBeenCalled());
+    expect(insertSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/auth/AuthCallback.tsx
+++ b/src/auth/AuthCallback.tsx
@@ -99,9 +99,6 @@ export function AuthCallback() {
       window.localStorage.removeItem("dndCards.lastProvider");
     }
     navigate({ to: readNextFromUrl() });
-    return () => {
-      cancelled = true;
-    };
   }, [session, navigate, setAnnouncement]);
 
   const onImport = async () => {

--- a/src/auth/AuthCallback.tsx
+++ b/src/auth/AuthCallback.tsx
@@ -1,5 +1,5 @@
 import { Link, useNavigate } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { supabase } from "../api/supabase";
 import { pluralize } from "../lib/pluralize";
 import { useSetNextAnnouncement } from "../lib/ui/Announcement";
@@ -28,6 +28,12 @@ export function AuthCallback() {
   const [deckCount, setDeckCount] = useState(0);
   const [progress, setProgress] = useState({ imported: 0, total: 0 });
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  // Guards against re-entrant tryResume: supabase-js can fire multiple
+  // onAuthStateChange events back-to-back on OAuth-callback hash detection
+  // (e.g., INITIAL_SESSION then SIGNED_IN). Each event re-renders the session
+  // object, re-runs this effect, and would otherwise start a parallel
+  // tryResume that races with the first — duplicating every imported deck.
+  const importStartedRef = useRef(false);
 
   useEffect(() => {
     if (session.status !== "authenticated") return;
@@ -54,18 +60,21 @@ export function AuthCallback() {
 
     const pending = readPending();
     if (pending && !session.user.is_anonymous) {
+      if (importStartedRef.current) return;
+      importStartedRef.current = true;
       setPhase("importing");
+      // Import deliberately runs to completion without a cancellation flag:
+      // the ref guards against re-entry, and a re-rendered effect must not
+      // tell the in-flight IIFE to skip its navigate() call.
       void (async () => {
         try {
           const result = await tryResume({
             supabase,
             currentUserId: session.user.id,
             onProgress: (imported, total) => {
-              if (cancelled) return;
               setProgress({ imported, total });
             },
           });
-          if (cancelled) return;
           if (result.kind === "completed" && result.importedCount > 0) {
             setAnnouncement(`Imported ${pluralize(result.importedCount, "deck")}`);
           } else if (result.kind === "partial") {
@@ -76,16 +85,13 @@ export function AuthCallback() {
           window.localStorage.removeItem("dndCards.lastProvider");
           navigate({ to: readNextFromUrl() });
         } catch {
-          if (cancelled) return;
           setAnnouncement(
             "Couldn't finish importing your decks. We'll try again next time you sign in.",
           );
           navigate({ to: readNextFromUrl() });
         }
       })();
-      return () => {
-        cancelled = true;
-      };
+      return;
     }
 
     if (!session.user.is_anonymous) {

--- a/src/auth/ImportAccountDialog.tsx
+++ b/src/auth/ImportAccountDialog.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { pluralize } from "../lib/pluralize";
 import { Button } from "../lib/ui/Button";
 import { DialogHeader } from "../lib/ui/DialogHeader";
@@ -13,7 +14,21 @@ type Props = {
 };
 
 export function ImportAccountDialog({ isOpen, deckCount, onImport, onSkip, onCancel }: Props) {
+  // Both onImport and onSkip kick off network work + a redirect. A fast
+  // double-click before the parent unmounts the dialog would otherwise fire
+  // two parallel imports — disable both buttons after either one is pressed.
+  const [pressed, setPressed] = useState(false);
   if (!isOpen) return null;
+  const handleImport = () => {
+    if (pressed) return;
+    setPressed(true);
+    onImport();
+  };
+  const handleSkip = () => {
+    if (pressed) return;
+    setPressed(true);
+    onSkip();
+  };
   return (
     <DialogShell
       isOpen={isOpen}
@@ -40,10 +55,10 @@ export function ImportAccountDialog({ isOpen, deckCount, onImport, onSkip, onCan
             </p>
           </div>
           <div className={styles.actions}>
-            <button type="button" className={styles.skip} onClick={onSkip}>
+            <button type="button" className={styles.skip} onClick={handleSkip} disabled={pressed}>
               Skip — leave decks behind
             </button>
-            <Button variant="primary" onPress={onImport}>
+            <Button variant="primary" onPress={handleImport} isDisabled={pressed}>
               Yes, import {pluralize(deckCount, "deck")}
             </Button>
           </div>


### PR DESCRIPTION
### What are the relevant tickets?

Reported in chat after #52 merged: anon → Google sign-in produced two copies of every imported deck.

### Description (What does it do?)

Adds a `useRef`-backed re-entry guard to `AuthCallback`'s import path so `tryResume` runs exactly once per mount, regardless of how many `onAuthStateChange` events supabase-js fires after parsing the OAuth-callback URL hash.

**Root cause.** With redirect-style OAuth, `/auth/callback` loads with `#access_token=…`. supabase-js parses the hash and fires `onAuthStateChange` — often twice back-to-back (e.g., `INITIAL_SESSION` then `SIGNED_IN`, or `SIGNED_IN` then `TOKEN_REFRESHED`). `AuthProvider` calls `setState({ status, user, session })` for each event, so `useSession` returns a new object reference each time. `AuthCallback`'s `useEffect([session, …])` re-runs and (without a guard) starts a parallel `tryResume`. Both calls read the same untouched stash (`importedDeckIds: []`) and both call `from("decks").insert(...)` before the first writes the imported-id back to localStorage — so every deck ends up duplicated in the new account.

**Fix.** Component-level `importStartedRef`. The effect bails out of the import branch on any subsequent render where `importStartedRef.current === true`. Also drops the `cancelled` flag from the import IIFE: a re-rendered effect's cleanup must not flip `cancelled` and short-circuit the in-flight navigate. The dialog branch still uses `cancelled` since the user can navigate away mid-fetch from that path.

### How can this be tested?

Manual: anon → create a deck → sign in with Google (same Google identity already attached to another account) → click "Yes, import 1 deck" → after second Google sign-in completes, check that the new account has exactly one copy of the deck (not two).

New regression test in `src/auth/AuthCallback.test.tsx`: holds the `get_public_deck` RPC promise unresolved, calls `rerender` with a new session object reference (simulates the second `onAuthStateChange` event), then resolves the promise. Asserts `from("decks").insert` was called exactly once. Verified that the test fails on `main` (assertion: expected 1 call, got 2).

### Additional Context

The double Google sign-in itself (one for `linkIdentity`, then a second for `signInWithOAuth` after sign-out) is structural to the current "try to link first" design — we have to authenticate with Google to discover that the identity is already taken. That's a separate UX question and not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)