### PR TITLE
feat(cards): markdown editor toolbar

### DIFF
--- a/docs/superpowers/plans/2026-05-08-markdown-editor-toolbar.md
+++ b/docs/superpowers/plans/2026-05-08-markdown-editor-toolbar.md
@@ -1,0 +1,846 @@
+# Markdown Editor Toolbar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a four-button markdown toolbar (Bold / Italic / Bullet list / Numbered list) above the body textarea in `CardEditor`, plus `Cmd/Ctrl+B` and `Cmd/Ctrl+I` keyboard shortcuts when the textarea has focus.
+
+**Architecture:** Drop in `@github/markdown-toolbar-element` — a ~5KB web component library that handles selection wrap/unwrap, multi-line list toggling, and undo preservation via `document.execCommand("insertText")`. We supply icon buttons styled to match `IconButton`, wire ARIA semantics (`role="toolbar"`, roving tabindex, `aria-label`s), and add a small textarea-scoped `onKeyDown` handler that fires the bold/italic buttons via refs.
+
+**Tech Stack:** React 19, TypeScript (`jsx: "react-jsx"`), `@github/markdown-toolbar-element`, `@iconify/react` + `@iconify-icons/lucide`, Vitest + Testing Library (jsdom), Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-05-08-markdown-editor-toolbar-design.md`
+
+---
+
+## Sequencing
+
+1. Install the library (Task 1) — gates everything else.
+2. JSX intrinsics + Textarea ref forwarding + icons (Tasks 2–4) — independent foundations.
+3. `MarkdownToolbar` component, TDD (Task 5).
+4. Wire it into `CardEditor` with the keyboard handler, TDD (Task 6).
+5. Playwright behavior coverage (Task 7) — the only place we exercise real `execCommand`.
+
+Frequent commits between tasks. Run `npm test` and `npm run typecheck` (and `npm run lint`) before each commit; they're already pre-approved.
+
+---
+
+## Task 1: Install `@github/markdown-toolbar-element`
+
+> **Approval needed.** This task adds a new dependency. Stop and confirm with the user before running `npm install` (per project memory).
+
+**Files:**
+- Modify: `package.json`
+- Modify: `package-lock.json`
+
+- [ ] **Step 1: Confirm with the user that adding the dependency is approved.**
+
+The user must say "go ahead" / "approved" / "yes" or equivalent before running install. Do not run install on standing approval — `npm install <new package>` is specifically excluded from the standing dev-loop approval per the user's memory.
+
+- [ ] **Step 2: Install the package.**
+
+Run: `npm install --save @github/markdown-toolbar-element`
+
+Expected: dependency added to `dependencies` (not `devDependencies` — it ships in the runtime bundle).
+
+- [ ] **Step 3: Confirm install.**
+
+Run: `npm ls @github/markdown-toolbar-element`
+Expected: prints a single matching version, no peer-dep warnings on react/react-dom.
+
+- [ ] **Step 4: Sanity-check the build still passes.**
+
+Run: `npm run typecheck && npm test`
+Expected: PASS. (No source changes yet, so this just verifies the install didn't break anything.)
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore(deps): add @github/markdown-toolbar-element"
+```
+
+---
+
+## Task 2: Declare JSX intrinsics for the web components
+
+**Files:**
+- Create: `src/types/jsx-markdown-toolbar.d.ts`
+
+The library registers four custom elements (`<markdown-toolbar>`, `<md-bold>`, `<md-italic>`, `<md-unordered-list>`, `<md-ordered-list>`) but doesn't ship JSX type augmentations. The project's tsconfig is on `"jsx": "react-jsx"`, so intrinsics must be declared on `React.JSX.IntrinsicElements` via module augmentation — the global `JSX` namespace doesn't apply.
+
+- [ ] **Step 1: Create the declaration file.**
+
+```ts
+// src/types/jsx-markdown-toolbar.d.ts
+import type { DetailedHTMLProps, HTMLAttributes } from "react";
+
+type MarkdownToolbarAttrs = DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> & {
+  for?: string;
+};
+
+type MdButtonAttrs = DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+
+declare module "react" {
+  namespace JSX {
+    interface IntrinsicElements {
+      "markdown-toolbar": MarkdownToolbarAttrs;
+      "md-bold": MdButtonAttrs;
+      "md-italic": MdButtonAttrs;
+      "md-unordered-list": MdButtonAttrs;
+      "md-ordered-list": MdButtonAttrs;
+    }
+  }
+}
+```
+
+The `for` attribute is added explicitly because the web component reads the lowercase HTML attribute (React passes unknown lowercase props verbatim on intrinsics). `className`, `ref`, `tabIndex`, and `aria-*` attributes are all type-correct via `DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>`.
+
+- [ ] **Step 2: Verify the types load.**
+
+Run: `npm run typecheck`
+Expected: PASS. The new file is under `src/`, which is in `tsconfig.app.json`'s `include`, so it's picked up automatically.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add src/types/jsx-markdown-toolbar.d.ts
+git commit -m "feat(types): JSX intrinsics for @github/markdown-toolbar-element"
+```
+
+---
+
+## Task 3: Forward ref on `Textarea`
+
+**Files:**
+- Modify: `src/lib/ui/Textarea.tsx`
+
+`CardEditor` will hold a `bodyRef` so future toolbar wiring can reach the textarea's DOM node. No existing call site passes a `ref`, so this change is unobservable to consumers.
+
+- [ ] **Step 1: Replace the function component with a `forwardRef` version.**
+
+Current contents (`src/lib/ui/Textarea.tsx`):
+
+```tsx
+import type { TextareaHTMLAttributes } from "react";
+import styles from "./Textarea.module.css";
+
+export type TextareaProps = Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "className"> & {
+  className?: string;
+};
+
+export function Textarea({ className, ...rest }: TextareaProps) {
+  return <textarea {...rest} className={[styles.textarea, className].filter(Boolean).join(" ")} />;
+}
+```
+
+Replace with:
+
+```tsx
+import { type TextareaHTMLAttributes, forwardRef } from "react";
+import styles from "./Textarea.module.css";
+
+export type TextareaProps = Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "className"> & {
+  className?: string;
+};
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...rest }, ref) => (
+    <textarea
+      ref={ref}
+      {...rest}
+      className={[styles.textarea, className].filter(Boolean).join(" ")}
+    />
+  ),
+);
+Textarea.displayName = "Textarea";
+```
+
+- [ ] **Step 2: Verify nothing regressed.**
+
+Run: `npm run typecheck && npm test`
+Expected: PASS. No call site passes `ref`, so behavior is unchanged. `CardEditor.test.tsx` continues to pass.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add src/lib/ui/Textarea.tsx
+git commit -m "refactor(ui): forward ref on Textarea"
+```
+
+---
+
+## Task 4: Add four toolbar icons
+
+**Files:**
+- Create: `src/lib/ui/icons/BoldIcon.tsx`
+- Create: `src/lib/ui/icons/ItalicIcon.tsx`
+- Create: `src/lib/ui/icons/BulletListIcon.tsx`
+- Create: `src/lib/ui/icons/NumberedListIcon.tsx`
+
+All four follow the existing pattern (see `src/lib/ui/icons/PencilIcon.tsx`): `@iconify/react` + a Lucide icon datafile from `@iconify-icons/lucide`, default `size={16}`, baked-in `aria-hidden="true"`. The Lucide set is already a project dependency — no new packages.
+
+- [ ] **Step 1: Create `BoldIcon.tsx`.**
+
+```tsx
+// src/lib/ui/icons/BoldIcon.tsx
+import { Icon } from "@iconify/react";
+import boldIcon from "@iconify-icons/lucide/bold";
+
+export function BoldIcon({ size = 16 }: { size?: number }) {
+  return <Icon icon={boldIcon} width={size} height={size} aria-hidden="true" />;
+}
+```
+
+- [ ] **Step 2: Create `ItalicIcon.tsx`.**
+
+```tsx
+// src/lib/ui/icons/ItalicIcon.tsx
+import { Icon } from "@iconify/react";
+import italicIcon from "@iconify-icons/lucide/italic";
+
+export function ItalicIcon({ size = 16 }: { size?: number }) {
+  return <Icon icon={italicIcon} width={size} height={size} aria-hidden="true" />;
+}
+```
+
+- [ ] **Step 3: Create `BulletListIcon.tsx`.**
+
+```tsx
+// src/lib/ui/icons/BulletListIcon.tsx
+import { Icon } from "@iconify/react";
+import listIcon from "@iconify-icons/lucide/list";
+
+export function BulletListIcon({ size = 16 }: { size?: number }) {
+  return <Icon icon={listIcon} width={size} height={size} aria-hidden="true" />;
+}
+```
+
+- [ ] **Step 4: Create `NumberedListIcon.tsx`.**
+
+```tsx
+// src/lib/ui/icons/NumberedListIcon.tsx
+import { Icon } from "@iconify/react";
+import listOrderedIcon from "@iconify-icons/lucide/list-ordered";
+
+export function NumberedListIcon({ size = 16 }: { size?: number }) {
+  return <Icon icon={listOrderedIcon} width={size} height={size} aria-hidden="true" />;
+}
+```
+
+- [ ] **Step 5: Confirm the icons resolve and typecheck.**
+
+Run: `npm run typecheck`
+Expected: PASS. (Trust that lucide ships these four — `bold`, `italic`, `list`, `list-ordered` are standard Lucide icon names. If a typecheck error mentions a missing module, the icon name is wrong; correct it before continuing.)
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add src/lib/ui/icons/BoldIcon.tsx src/lib/ui/icons/ItalicIcon.tsx \
+        src/lib/ui/icons/BulletListIcon.tsx src/lib/ui/icons/NumberedListIcon.tsx
+git commit -m "feat(ui): bold/italic/list icons for markdown toolbar"
+```
+
+---
+
+## Task 5: `MarkdownToolbar` component (TDD)
+
+**Files:**
+- Create: `src/cards/MarkdownToolbar.tsx`
+- Create: `src/cards/MarkdownToolbar.module.css`
+- Create: `src/cards/MarkdownToolbar.test.tsx`
+
+### What the tests assert (and what they don't)
+
+Unit tests stay structural: roles, labels, the `for=`-to-`id` link, roving-tabindex initialization. They do **not** click the buttons — `<md-*>` calls `document.execCommand("insertText")` whose return-value semantics are inconsistent in jsdom across versions, so behavior assertions live in Playwright (Task 7).
+
+- [ ] **Step 1: Write the failing test file.**
+
+```tsx
+// src/cards/MarkdownToolbar.test.tsx
+import { render, screen } from "@testing-library/react";
+import { useId } from "react";
+import { describe, expect, test } from "vitest";
+import { MarkdownToolbar } from "./MarkdownToolbar";
+
+function Harness() {
+  const id = useId();
+  return (
+    <>
+      <MarkdownToolbar htmlFor={id} />
+      <textarea id={id} aria-label="body" defaultValue="" />
+    </>
+  );
+}
+
+describe("<MarkdownToolbar>", () => {
+  test("renders four buttons with accessible labels", () => {
+    render(<Harness />);
+    expect(screen.getByRole("button", { name: /bold/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /italic/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /bullet list/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /numbered list/i })).toBeInTheDocument();
+  });
+
+  test("bold and italic buttons advertise their keyboard shortcut", () => {
+    render(<Harness />);
+    expect(screen.getByRole("button", { name: /bold/i })).toHaveAccessibleName(/⌘B/);
+    expect(screen.getByRole("button", { name: /italic/i })).toHaveAccessibleName(/⌘I/);
+  });
+
+  test("toolbar is labelled and has role=toolbar", () => {
+    render(<Harness />);
+    const toolbar = screen.getByRole("toolbar", { name: /formatting/i });
+    expect(toolbar.tagName.toLowerCase()).toBe("markdown-toolbar");
+  });
+
+  test("toolbar's for= matches a real textarea id (the library targets that field)", () => {
+    render(<Harness />);
+    const toolbar = screen.getByRole("toolbar", { name: /formatting/i });
+    const targetId = toolbar.getAttribute("for");
+    expect(targetId).toBeTruthy();
+    expect(document.getElementById(targetId as string)?.tagName.toLowerCase()).toBe("textarea");
+  });
+
+  test("first button has tabindex=0, others tabindex=-1 (roving-tabindex init)", () => {
+    render(<Harness />);
+    const bold = screen.getByRole("button", { name: /bold/i });
+    const italic = screen.getByRole("button", { name: /italic/i });
+    const bullet = screen.getByRole("button", { name: /bullet list/i });
+    const numbered = screen.getByRole("button", { name: /numbered list/i });
+    expect(bold).toHaveAttribute("tabindex", "0");
+    expect(italic).toHaveAttribute("tabindex", "-1");
+    expect(bullet).toHaveAttribute("tabindex", "-1");
+    expect(numbered).toHaveAttribute("tabindex", "-1");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails.**
+
+Run: `npm test -- MarkdownToolbar`
+Expected: FAIL — module not found (`./MarkdownToolbar`).
+
+- [ ] **Step 3: Create the CSS module.**
+
+```css
+/* src/cards/MarkdownToolbar.module.css */
+.toolbar {
+  display: flex;
+  gap: var(--space-1);
+  margin-top: var(--space-1);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  user-select: none;
+  transition:
+    background 0.12s,
+    color 0.12s;
+}
+
+.button:hover {
+  background: var(--color-surface-2);
+  color: var(--color-text);
+}
+
+.button:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.button > svg {
+  width: 1rem;
+  height: 1rem;
+}
+```
+
+These tokens already exist in `src/index.css` (verified against `IconButton.module.css`, which uses the same set). No new tokens.
+
+- [ ] **Step 4: Create the component.**
+
+```tsx
+// src/cards/MarkdownToolbar.tsx
+import "@github/markdown-toolbar-element";
+import type { RefObject } from "react";
+import { BoldIcon } from "../lib/ui/icons/BoldIcon";
+import { BulletListIcon } from "../lib/ui/icons/BulletListIcon";
+import { ItalicIcon } from "../lib/ui/icons/ItalicIcon";
+import { NumberedListIcon } from "../lib/ui/icons/NumberedListIcon";
+import styles from "./MarkdownToolbar.module.css";
+
+type Props = {
+  htmlFor: string;
+  boldRef?: RefObject<HTMLElement | null>;
+  italicRef?: RefObject<HTMLElement | null>;
+};
+
+export function MarkdownToolbar({ htmlFor, boldRef, italicRef }: Props) {
+  return (
+    <markdown-toolbar
+      for={htmlFor}
+      role="toolbar"
+      aria-label="Formatting"
+      className={styles.toolbar}
+    >
+      <md-bold
+        ref={boldRef}
+        tabIndex={0}
+        className={styles.button}
+        aria-label="Bold (⌘B)"
+      >
+        <BoldIcon />
+      </md-bold>
+      <md-italic
+        ref={italicRef}
+        tabIndex={-1}
+        className={styles.button}
+        aria-label="Italic (⌘I)"
+      >
+        <ItalicIcon />
+      </md-italic>
+      <md-unordered-list
+        tabIndex={-1}
+        className={styles.button}
+        aria-label="Bullet list"
+      >
+        <BulletListIcon />
+      </md-unordered-list>
+      <md-ordered-list
+        tabIndex={-1}
+        className={styles.button}
+        aria-label="Numbered list"
+      >
+        <NumberedListIcon />
+      </md-ordered-list>
+    </markdown-toolbar>
+  );
+}
+```
+
+Notes for the implementer:
+- `import "@github/markdown-toolbar-element"` is a side-effect import; it registers the custom elements on the global `customElements` registry. Importing it once anywhere in the app is enough, but co-locating the import with the only consumer keeps the dependency surface explicit.
+- Each `BoldIcon` / `ItalicIcon` / etc. already sets `aria-hidden="true"` internally (see existing `PencilIcon`), so we don't repeat it at the call site.
+- `<md-bold>` and friends register themselves with `role="button"`. Do **not** wrap them with a real `<button>` — that produces nested interactives (an a11y violation) and `<md-bold>` already exposes the right semantics on its own.
+- `tabIndex={0}` on the first button, `tabIndex={-1}` on the others — without these, the library's roving-tabindex behavior never gets a starting point and the toolbar is unreachable by keyboard.
+
+- [ ] **Step 5: Run the tests; verify they pass.**
+
+Run: `npm test -- MarkdownToolbar`
+Expected: PASS — all five tests green.
+
+- [ ] **Step 6: Lint and typecheck.**
+
+Run: `npm run lint && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add src/cards/MarkdownToolbar.tsx src/cards/MarkdownToolbar.module.css \
+        src/cards/MarkdownToolbar.test.tsx
+git commit -m "feat(cards): MarkdownToolbar component"
+```
+
+---
+
+## Task 6: Wire `MarkdownToolbar` into `CardEditor` with `Cmd+B/I` shortcuts (TDD)
+
+**Files:**
+- Modify: `src/cards/CardEditor.tsx`
+- Modify: `src/cards/CardEditor.test.tsx`
+
+### Test-first: extend `CardEditor.test.tsx`
+
+The existing tests (`Type, Name, and Icon controls share a row container`, etc.) keep passing. New tests cover the keyboard handler and toolbar presence in the editor.
+
+- [ ] **Step 1: Add new tests to `src/cards/CardEditor.test.tsx`.**
+
+Add this block inside the existing `describe("<CardEditor>", () => { ... })` (alongside the other tests, before the closing `})`):
+
+```tsx
+  test("renders the markdown toolbar above the body field", () => {
+    const card = itemCardFactory.build();
+    render(<Harness initial={card} />);
+
+    const toolbar = screen.getByRole("toolbar", { name: /formatting/i });
+    const body = screen.getByLabelText(/body/i);
+
+    // Toolbar's for= attribute targets the body textarea.
+    expect(toolbar.getAttribute("for")).toBe(body.getAttribute("id"));
+  });
+
+  test("Cmd+B on the body textarea clicks the Bold toolbar button", async () => {
+    const card = itemCardFactory.build();
+    render(<Harness initial={card} />);
+
+    const body = screen.getByLabelText(/body/i);
+    const bold = screen.getByRole("button", { name: /bold/i });
+    const clickSpy = vi.spyOn(bold, "click");
+
+    body.focus();
+    await userEvent.keyboard("{Meta>}b{/Meta}");
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("Ctrl+B on the body textarea clicks the Bold toolbar button (non-mac)", async () => {
+    const card = itemCardFactory.build();
+    render(<Harness initial={card} />);
+
+    const body = screen.getByLabelText(/body/i);
+    const bold = screen.getByRole("button", { name: /bold/i });
+    const clickSpy = vi.spyOn(bold, "click");
+
+    body.focus();
+    await userEvent.keyboard("{Control>}b{/Control}");
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("Cmd+I on the body textarea clicks the Italic toolbar button", async () => {
+    const card = itemCardFactory.build();
+    render(<Harness initial={card} />);
+
+    const body = screen.getByLabelText(/body/i);
+    const italic = screen.getByRole("button", { name: /italic/i });
+    const clickSpy = vi.spyOn(italic, "click");
+
+    body.focus();
+    await userEvent.keyboard("{Meta>}i{/Meta}");
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("Cmd+Shift+B does not trigger Bold (modifier guard)", async () => {
+    const card = itemCardFactory.build();
+    render(<Harness initial={card} />);
+
+    const body = screen.getByLabelText(/body/i);
+    const bold = screen.getByRole("button", { name: /bold/i });
+    const clickSpy = vi.spyOn(bold, "click");
+
+    body.focus();
+    await userEvent.keyboard("{Meta>}{Shift>}b{/Shift}{/Meta}");
+
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
+  test("Cmd+B on the body textarea calls preventDefault", () => {
+    const card = itemCardFactory.build();
+    render(<Harness initial={card} />);
+
+    const body = screen.getByLabelText(/body/i);
+    body.focus();
+
+    // Use a raw KeyboardEvent so we can inspect defaultPrevented after dispatch.
+    const event = new KeyboardEvent("keydown", {
+      key: "b",
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    body.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+```
+
+The `userEvent.keyboard` `{Meta>}…{/Meta}` syntax sets `metaKey` on the dispatched events. `userEvent`'s click spy on the toolbar button proves the keyboard handler reached the right ref; the integration with the library itself is covered by Playwright in Task 7.
+
+- [ ] **Step 2: Run the new tests; verify they fail.**
+
+Run: `npm test -- CardEditor`
+Expected: FAIL — `screen.getByRole("toolbar", …)` not found, plus the Cmd+B tests fail because the handler doesn't exist yet.
+
+- [ ] **Step 3: Wire up `CardEditor.tsx`.**
+
+Apply these edits to `src/cards/CardEditor.tsx`:
+
+**Imports** — add `useRef` to the existing `react` import and add the `MarkdownToolbar` import:
+
+```tsx
+import { type ChangeEvent, type KeyboardEvent, useId, useRef } from "react";
+```
+
+```tsx
+import { MarkdownToolbar } from "./MarkdownToolbar";
+```
+
+**Inside `CardEditor`**, after the existing `idBase`/`ids` block, add:
+
+```tsx
+  const bodyRef = useRef<HTMLTextAreaElement>(null);
+  const boldRef = useRef<HTMLElement>(null);
+  const italicRef = useRef<HTMLElement>(null);
+
+  const onBodyKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (!(e.metaKey || e.ctrlKey) || e.shiftKey || e.altKey) return;
+    const k = e.key.toLowerCase();
+    if (k === "b") {
+      e.preventDefault();
+      boldRef.current?.click();
+    } else if (k === "i") {
+      e.preventDefault();
+      italicRef.current?.click();
+    }
+  };
+```
+
+**Replace the existing body `<label>`** (currently around lines 125–145, the block starting `<label className={styles.field} htmlFor={ids.body}>`) with:
+
+```tsx
+      <label className={styles.field} htmlFor={ids.body}>
+        <span className={styles.label}>Body</span>
+        <MarkdownToolbar htmlFor={ids.body} boldRef={boldRef} italicRef={italicRef} />
+        <Textarea
+          ref={bodyRef}
+          id={ids.body}
+          aria-describedby={ids.bodyHelp}
+          value={card.body}
+          onChange={handle("body")}
+          onKeyDown={onBodyKeyDown}
+          rows={8}
+        />
+        <span id={ids.bodyHelp} className={styles.help}>
+          Supports{" "}
+          <Link
+            href="https://www.markdownguide.org/cheat-sheet/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Markdown
+          </Link>{" "}
+          — bold, italic, lists, tables.
+        </span>
+      </label>
+```
+
+The only differences from the existing block: `<MarkdownToolbar>` inserted between the label `<span>` and the `<Textarea>`, plus `ref={bodyRef}` and `onKeyDown={onBodyKeyDown}` on the `<Textarea>`. The help text is unchanged.
+
+- [ ] **Step 4: Run all CardEditor tests.**
+
+Run: `npm test -- CardEditor`
+Expected: PASS — both the new tests and the existing tests (including `"Type, Name, and Icon controls share a row container"`) all green.
+
+- [ ] **Step 5: Sanity-check the broader suite.**
+
+Run: `npm test`
+Expected: PASS — full unit suite green.
+
+- [ ] **Step 6: Lint and typecheck.**
+
+Run: `npm run lint && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 7: Manual smoke test in the dev server.**
+
+Run `npm run dev`, open a card editor, and verify:
+- The toolbar row appears above the body textarea, aligned with its left edge.
+- Hover over each button shows the focus/hover state from the CSS.
+- `Cmd+B` (or `Ctrl+B` on non-mac) with text selected wraps it in `**…**`.
+- `Cmd+I` wraps it in `_…_`.
+- Clicking each button does not steal focus from the textarea.
+- Browser-native `Cmd+Z` undoes a single toolbar action in one keystroke.
+
+If any of these fail, fix before committing. (Visual nits like icon size, gap, or button color can be tuned now — this is the "tune against the existing editor visuals" beat from the spec.)
+
+- [ ] **Step 8: Commit.**
+
+```bash
+git add src/cards/CardEditor.tsx src/cards/CardEditor.test.tsx
+git commit -m "feat(cards): wire markdown toolbar + Cmd/Ctrl+B/I into CardEditor"
+```
+
+---
+
+## Task 7: Playwright behavior coverage
+
+**Files:**
+- Create: `e2e/editor-markdown.spec.ts`
+
+This is the only place we exercise `document.execCommand` for real. The existing pattern (`e2e/editor-pagination.spec.ts`) shows how to stand up a deck with `seedDeck` and navigate to the editor route.
+
+- [ ] **Step 1: Create the spec file.**
+
+```ts
+// e2e/editor-markdown.spec.ts
+import { expect, test } from "@playwright/test";
+import { seedDeck, TEST_DECK_ID } from "./fixtures";
+
+const cardId = "00000000-0000-4000-8000-200000000001";
+
+test.beforeEach(async ({ page }) => {
+  await seedDeck(page, [
+    {
+      id: cardId,
+      name: "Markdown Test Item",
+      body: "",
+      headerTags: ["Wondrous item"],
+      footerTags: [],
+    },
+  ]);
+  await page.goto(`/deck/${TEST_DECK_ID}/edit/${cardId}`);
+});
+
+test("toolbar Bold wraps and unwraps the selection", async ({ page }) => {
+  const body = page.getByLabel(/body/i);
+  await body.fill("hello world");
+
+  // Select "hello".
+  await body.evaluate((el: HTMLTextAreaElement) => {
+    el.setSelectionRange(0, "hello".length);
+  });
+
+  await page.getByRole("button", { name: /bold/i }).click();
+  await expect(body).toHaveValue("**hello** world");
+
+  // Re-select "hello" (now inside the **…** wrapper, offsets shifted by 2).
+  await body.evaluate((el: HTMLTextAreaElement) => {
+    el.setSelectionRange(2, 2 + "hello".length);
+  });
+  await page.getByRole("button", { name: /bold/i }).click();
+  await expect(body).toHaveValue("hello world");
+});
+
+test("Cmd/Meta+B wraps the selection in bold", async ({ page }) => {
+  const body = page.getByLabel(/body/i);
+  await body.fill("abc");
+  await body.evaluate((el: HTMLTextAreaElement) => el.setSelectionRange(0, 3));
+
+  await body.focus();
+  await page.keyboard.press("Meta+b");
+
+  await expect(body).toHaveValue("**abc**");
+});
+
+test("Cmd/Meta+I wraps the selection in italics", async ({ page }) => {
+  const body = page.getByLabel(/body/i);
+  await body.fill("abc");
+  await body.evaluate((el: HTMLTextAreaElement) => el.setSelectionRange(0, 3));
+
+  await body.focus();
+  await page.keyboard.press("Meta+i");
+
+  // The library uses `_` for italics by default.
+  await expect(body).toHaveValue("_abc_");
+});
+
+test("Bullet list toggles a `- ` prefix on each selected line", async ({ page }) => {
+  const body = page.getByLabel(/body/i);
+  await body.fill("one\ntwo\nthree");
+  await body.evaluate((el: HTMLTextAreaElement) =>
+    el.setSelectionRange(0, el.value.length),
+  );
+
+  await page.getByRole("button", { name: /bullet list/i }).click();
+  await expect(body).toHaveValue("- one\n- two\n- three");
+
+  // Re-select the whole value (its length grew by 6) and toggle off.
+  await body.evaluate((el: HTMLTextAreaElement) =>
+    el.setSelectionRange(0, el.value.length),
+  );
+  await page.getByRole("button", { name: /bullet list/i }).click();
+  await expect(body).toHaveValue("one\ntwo\nthree");
+});
+
+test("Numbered list toggles `1. `/`2. `/`3. ` prefixes on selected lines", async ({ page }) => {
+  const body = page.getByLabel(/body/i);
+  await body.fill("one\ntwo\nthree");
+  await body.evaluate((el: HTMLTextAreaElement) =>
+    el.setSelectionRange(0, el.value.length),
+  );
+
+  await page.getByRole("button", { name: /numbered list/i }).click();
+  await expect(body).toHaveValue("1. one\n2. two\n3. three");
+});
+
+test("undo collapses a toolbar action into a single Cmd+Z", async ({ page }) => {
+  const body = page.getByLabel(/body/i);
+  await body.fill("hello world");
+  await body.evaluate((el: HTMLTextAreaElement) =>
+    el.setSelectionRange("hello ".length, "hello ".length + "world".length),
+  );
+
+  await page.getByRole("button", { name: /bold/i }).click();
+  await expect(body).toHaveValue("hello **world**");
+
+  await body.focus();
+  await page.keyboard.press("Meta+z");
+  await expect(body).toHaveValue("hello world");
+
+  // One more undo begins peeling the typed text.
+  await page.keyboard.press("Meta+z");
+  await expect(body).not.toHaveValue("hello world");
+});
+
+test("clicking a toolbar button keeps focus on the textarea", async ({ page }) => {
+  const body = page.getByLabel(/body/i);
+  await body.fill("abc");
+  await body.focus();
+
+  await page.getByRole("button", { name: /bold/i }).click();
+
+  const focused = await page.evaluate(() => document.activeElement?.tagName.toLowerCase());
+  expect(focused).toBe("textarea");
+});
+```
+
+A few things worth knowing:
+- `seedDeck` from `e2e/fixtures.ts` mocks the Supabase REST routes, sets a fake auth session in `localStorage`, and accepts `id` on each item — using a stable `id` here lets us address the editor route directly via `/deck/${TEST_DECK_ID}/edit/${cardId}`.
+- `seedDeck` mocks reads only. These tests never hit a write path: every assertion uses the textarea's local React state via `toHaveValue(...)`, never an API write. The fixture would throw if a write was attempted, which is the correct guardrail.
+- `page.keyboard.press("Meta+b")` issues the modifier; on the project's existing Playwright config (default Chromium), Meta is the right key to test. Adding Control coverage is overkill for e2e — the unit test in Task 6 already proves the handler accepts both.
+- The library uses `**…**` for bold and `_…_` for italics by default (these defaults come straight from the published web component; verify the italic value during implementation if needed and adjust if the library's output differs).
+
+- [ ] **Step 2: Run the e2e suite.**
+
+Run: `npm run test:e2e -- editor-markdown`
+Expected: PASS — all seven tests green. If italic output differs from `_abc_`, replace the expected value with whatever the library actually emits — assert on real behavior, not a guess.
+
+- [ ] **Step 3: Run the full e2e suite to confirm nothing else regressed.**
+
+Run: `npm run test:e2e`
+Expected: PASS.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add e2e/editor-markdown.spec.ts
+git commit -m "test(e2e): markdown toolbar formatting + Cmd-B/I shortcuts"
+```
+
+---
+
+## Wrap-up checklist
+
+After Task 7 completes, the worktree should contain seven commits, in order:
+
+1. `chore(deps): add @github/markdown-toolbar-element`
+2. `feat(types): JSX intrinsics for @github/markdown-toolbar-element`
+3. `refactor(ui): forward ref on Textarea`
+4. `feat(ui): bold/italic/list icons for markdown toolbar`
+5. `feat(cards): MarkdownToolbar component`
+6. `feat(cards): wire markdown toolbar + Cmd/Ctrl+B/I into CardEditor`
+7. `test(e2e): markdown toolbar formatting + Cmd-B/I shortcuts`
+
+Run a final `npm run lint && npm run typecheck && npm test && npm run test:e2e` before declaring done. The PR description should link to the spec at `docs/superpowers/specs/2026-05-08-markdown-editor-toolbar-design.md`.
+
+---
+
+## Out of scope (do not implement)
+
+Same as the spec — re-stated here so the implementer doesn't drift:
+
+- `Cmd+Shift+8` / `Cmd+Shift+7` list shortcuts.
+- Active-state highlighting on toolbar buttons (e.g., Bold lights up when the caret is inside `**…**`).
+- Buttons for link, image, code, header, quote, task list, mention, ref. The library supports them; we don't render them.
+- Live preview, WYSIWYG, or any rich-text model.
+- A general-purpose `MarkdownEditor` primitive in `src/lib/ui/`.

--- a/docs/superpowers/specs/2026-05-08-markdown-editor-toolbar-design.md
+++ b/docs/superpowers/specs/2026-05-08-markdown-editor-toolbar-design.md
@@ -73,7 +73,7 @@ The library uses `document.execCommand("insertText")` internally with a fallback
 
 ### TypeScript intrinsics
 
-The package doesn't ship JSX type augmentations. We declare them once in `src/types/jsx-markdown-toolbar.d.ts`:
+The package doesn't ship JSX type augmentations. We declare them once in `src/types/jsx-markdown-toolbar.d.ts`. Project tsconfig is on `"jsx": "react-jsx"`, so intrinsics resolve from `React.JSX.IntrinsicElements`, not the global `JSX.IntrinsicElements`. Augment via module declaration on `react`:
 
 ```ts
 import type { DetailedHTMLProps, HTMLAttributes } from "react";
@@ -83,7 +83,7 @@ type MarkdownToolbarAttrs = DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLE
 };
 type MdButtonAttrs = DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
 
-declare global {
+declare module "react" {
   namespace JSX {
     interface IntrinsicElements {
       "markdown-toolbar": MarkdownToolbarAttrs;
@@ -96,7 +96,7 @@ declare global {
 }
 ```
 
-(Project tsconfig uses the classic JSX namespace; if it switches to `react-jsx`, the same shape lives under `React.JSX` instead.)
+`for` is added explicitly (the web component reads the lowercase attribute; React passes unknown lowercase props verbatim on intrinsics). `className` is type-correct on these declarations and React 18 translates it to `class` on the DOM. `ref` typed as `RefObject<HTMLElement>` works — React attaches it to the underlying DOM node.
 
 ### `MarkdownToolbar.tsx`
 
@@ -117,25 +117,35 @@ type Props = {
 
 export function MarkdownToolbar({ htmlFor, boldRef, italicRef }: Props) {
   return (
-    <markdown-toolbar for={htmlFor} className={styles.toolbar}>
-      <md-bold ref={boldRef} className={styles.button} aria-label="Bold (⌘B)">
-        <BoldIcon />
+    <markdown-toolbar
+      for={htmlFor}
+      role="toolbar"
+      aria-label="Formatting"
+      className={styles.toolbar}
+    >
+      <md-bold ref={boldRef} tabIndex={0} className={styles.button} aria-label="Bold (⌘B)">
+        <BoldIcon aria-hidden="true" />
       </md-bold>
-      <md-italic ref={italicRef} className={styles.button} aria-label="Italic (⌘I)">
-        <ItalicIcon />
+      <md-italic ref={italicRef} tabIndex={-1} className={styles.button} aria-label="Italic (⌘I)">
+        <ItalicIcon aria-hidden="true" />
       </md-italic>
-      <md-unordered-list className={styles.button} aria-label="Bullet list">
-        <BulletListIcon />
+      <md-unordered-list tabIndex={-1} className={styles.button} aria-label="Bullet list">
+        <BulletListIcon aria-hidden="true" />
       </md-unordered-list>
-      <md-ordered-list className={styles.button} aria-label="Numbered list">
-        <NumberedListIcon />
+      <md-ordered-list tabIndex={-1} className={styles.button} aria-label="Numbered list">
+        <NumberedListIcon aria-hidden="true" />
       </md-ordered-list>
     </markdown-toolbar>
   );
 }
 ```
 
-Use `className`, not `class` — React 18 still translates `className` → `class` for custom-element JSX intrinsics typed as `HTMLElement`. The `DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>` type already includes `className`.
+A few details worth calling out:
+
+- **`tabIndex={0}` on the first button, `tabIndex={-1}` on the rest.** The library implements roving tabindex (arrow keys move focus among buttons it sees as part of the toolbar) but it does *not* initialize the first button into the tab order. Without these explicit attributes, a keyboard-only user cannot reach the toolbar at all.
+- **`role="toolbar"` + `aria-label="Formatting"` on `<markdown-toolbar>`.** Required by WAI-ARIA's Toolbar pattern; the library doesn't set them.
+- **`aria-hidden="true"` on each icon `<svg>`.** Prevents double-announcement alongside the button's `aria-label`.
+- **`className`, not `class`.** React 18 translates `className` → `class` on the DOM for custom-element JSX intrinsics typed as `HTMLElement`.
 
 ### `MarkdownToolbar.module.css`
 
@@ -154,26 +164,25 @@ Use `className`, not `class` — React 18 still translates `className` → `clas
   justify-content: center;
   width: 2rem;
   height: 2rem;
-  border: 1px solid var(--color-border-strong);
+  background: transparent;
+  border: 1px solid transparent;
   border-radius: var(--radius-md);
-  background: var(--color-surface);
-  color: var(--color-text);
+  color: var(--color-text-muted);
   cursor: pointer;
   user-select: none;
+  transition:
+    background 0.12s,
+    color 0.12s;
 }
 
 .button:hover {
-  background: var(--color-surface-hover);
+  background: var(--color-surface-2);
+  color: var(--color-text);
 }
 
 .button:focus-visible {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
-}
-
-.button[aria-disabled="true"] {
-  opacity: 0.5;
-  pointer-events: none;
 }
 
 .button > svg {
@@ -243,11 +252,13 @@ Web components register via the `customElements` registry, which jsdom supports.
 
 - **`MarkdownToolbar.test.tsx`** —
   - Renders four buttons; each has the expected `aria-label` (`getByRole("button", { name: /bold/i })`, etc.).
-  - The `<markdown-toolbar>` element has the right `for` attribute pointing at the linked textarea id.
-  - Clicking a button does not throw (the library's `execCommand` path will exercise jsdom's behavior; jsdom does not implement `execCommand`, so the library's fallback runs — that's fine, we're only asserting the React/DOM glue here, not formatting behavior).
+  - The `<markdown-toolbar>` element has the right `for` attribute, and the value matches a textarea `id` rendered in the same harness — easy to regress when `useId` is rewired.
+  - The first `md-*` button has `tabIndex="0"`, the others `"-1"` (roving-tabindex initialization).
+  - **Do not click the buttons in unit tests.** The library calls `document.execCommand`, whose return-value semantics in jsdom are inconsistent across versions. Behavior assertions live in Playwright; unit tests assert structure and DOM glue only.
 
 - **`CardEditor.test.tsx`** — extend.
-  - `Cmd+B` keystroke on the body textarea calls `boldRef.current.click()`. Spy on the click via `userEvent` + `addEventListener`, assert dispatched.
+  - `Cmd+B` keystroke on the body textarea calls the bold button's click. Spy by replacing `boldRef.current.click` with a `vi.fn()` (or attaching a listener directly to the ref'd node), assert called once.
+  - The handler calls `event.preventDefault()` (assert via the synthetic event spy) — without it, the browser may swallow the keystroke for its own bookmarks/menu actions.
   - `Cmd+I` similarly.
   - `Cmd+Shift+B` does not trigger bold (modifier guard).
 

--- a/docs/superpowers/specs/2026-05-08-markdown-editor-toolbar-design.md
+++ b/docs/superpowers/specs/2026-05-08-markdown-editor-toolbar-design.md
@@ -1,0 +1,313 @@
+# Markdown editor toolbar
+
+## Problem
+
+Card bodies render as Markdown (`renderBody.ts` → `marked` → DOMPurify), but the editor body field is a plain `<textarea>` with no formatting affordances. Authoring `**bold**`, `_italic_`, and `- bullet` lists by hand is fine for power users but a friction tax for everyone else, and the lack of `Cmd+B` / `Cmd+I` is a small but constant surprise.
+
+## Goal
+
+Add a small toolbar above the body field with Bold / Italic / Bullet list / Numbered list buttons, plus `Cmd/Ctrl+B` and `Cmd/Ctrl+I` shortcuts when the textarea is focused. The editor stays a plain textarea — no WYSIWYG, no shortcut-driven inline transforms while typing. Browser-native undo (Cmd+Z) must continue to work one toolbar click at a time.
+
+## Scope
+
+In:
+
+- Toolbar with four buttons: Bold, Italic, Bullet list, Numbered list.
+- Keyboard: `Cmd/Ctrl+B` for bold, `Cmd/Ctrl+I` for italic, fired when the body textarea has focus.
+- Toggle semantics: clicking a button (or pressing the shortcut) on already-formatted text removes the formatting.
+- Multi-line list toggling: list buttons act on every line touched by the selection.
+- Native undo preserved via `document.execCommand("insertText", …)`, with a graceful fallback if `insertText` is unsupported.
+
+Out:
+
+- Shortcuts for lists (`Cmd+Shift+8`, `Cmd+Shift+7`).
+- Enter-continues-list / Enter-on-empty-list-line-exits behavior.
+- Link, table, code-block, heading, checklist, or blockquote affordances.
+- A general-purpose `MarkdownEditor` primitive in `src/lib/ui/`. The toolbar lives next to its only consumer for now (per `src/lib/ui/README.md` extraction rules).
+- WYSIWYG, live-preview-as-you-type inline transforms, or any rich-text model. The textarea remains plain text.
+
+## UX
+
+- A row of four square `IconButton`s sits directly above the body `Textarea`, aligned with its left edge. Tooltips / `aria-label`s: "Bold", "Italic", "Bullet list", "Numbered list".
+- Clicking a button does not steal focus from the textarea (`onMouseDown` `preventDefault`; the action fires on click). After the action, the textarea retains focus and the selection is set to whatever range the helper computed.
+- Inline buttons (Bold/Italic) on a selection wrap or unwrap the selection. With no selection they insert empty markers (`****`, `__`) and place the caret between them.
+- List buttons (Bullet/Numbered) operate on the lines touched by the selection (or the caret line if collapsed). If any line lacks the prefix, the button adds the prefix to all of them. If every line already has the prefix, it strips them. The post-edit selection spans the same line range so the button is repeatable.
+- `Cmd/Ctrl+B` and `Cmd/Ctrl+I` mirror the inline buttons and `preventDefault` on the keyboard event so the browser's default chrome bolding doesn't fire.
+- The "Supports Markdown — bold, italic, lists, tables." help line under the textarea is unchanged.
+
+## Architecture
+
+```
+src/cards/
+  markdown/
+    commands.ts          — pure helpers; describe edits, no DOM
+    commands.test.ts     — Vitest, exhaustive table per helper
+    MarkdownToolbar.tsx  — 4 IconButtons; emits onCommand(name)
+    MarkdownToolbar.module.css
+    MarkdownToolbar.test.tsx
+  CardEditor.tsx         — adds ref, onKeyDown, MarkdownToolbar
+src/lib/ui/icons/        — 4 new SVG icons (bold, italic, bullet-list, numbered-list)
+e2e/
+  editor-markdown.spec.ts — Playwright; real execCommand, undo preservation
+```
+
+Two concerns kept separate:
+
+1. **What the edit is** — a pure function over `(value, selectionStart, selectionEnd, kind)` returning a description of the textarea mutation. Lives in `commands.ts`. Trivial to unit-test.
+2. **How the edit is applied to the DOM** — preserves browser undo via `execCommand("insertText")`. Lives inside `CardEditor` (or a tiny `applyEdit` helper colocated with it).
+
+### Helper API
+
+```ts
+// src/cards/markdown/commands.ts
+
+export type EditorState = {
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+};
+
+export type Edit = {
+  // Range of `state.value` to replace (`[replaceStart, replaceEnd)`).
+  replaceStart: number;
+  replaceEnd: number;
+  // Text to insert in that range.
+  replacement: string;
+  // Selection on the post-edit value. (i.e. on
+  // value.slice(0, replaceStart) + replacement + value.slice(replaceEnd))
+  selectionStart: number;
+  selectionEnd: number;
+};
+
+export function toggleWrap(state: EditorState, marker: "**" | "_"): Edit;
+export function togglePrefix(state: EditorState, kind: "bullet" | "numbered"): Edit;
+
+// Test helper. Component code does not call this on the happy path —
+// it's only used by the fallback when execCommand is unavailable.
+export function applyEdit(value: string, edit: Edit): string;
+```
+
+#### `toggleWrap` rules
+
+Let `m` = the marker (`**` or `_`). Let `[s, e)` be the current selection on `value`.
+
+1. **Selection wrapped (markers inside selection):** `e - s >= 2 * m.length`, `value.slice(s, e)` starts with `m`, and ends with `m`. Strip both — emit an `Edit` that replaces `[s, e)` with `value.slice(s + m.length, e - m.length)` and sets the post-edit selection to `[s, s + (e - s) - 2 * m.length]`. (The length guard prevents `**` selected → no-op.)
+2. **Selection wrapped (markers outside selection):** `value.slice(s - m.length, s) === m && value.slice(e, e + m.length) === m`. Strip — emit an `Edit` that replaces `[s - m.length, e + m.length)` with `value.slice(s, e)` and sets the post-edit selection to `[s - m.length, e - m.length]`.
+3. **Empty selection (`s === e`):** insert `m + m` at `s`; place caret between markers. `replaceStart = replaceEnd = s`, `replacement = m + m`, post-edit selection `[s + m.length, s + m.length]`.
+4. **Otherwise:** wrap. Replace `[s, e)` with `m + value.slice(s, e) + m`; selection covers the inner text on the post-edit value.
+
+Case 1 takes precedence over case 2 when both match (defensive — should not normally co-occur).
+
+#### `togglePrefix` rules
+
+1. Determine the line range touched by `[s, e)`: line `L1` is the line containing `s`, line `L2` is the line containing `e`. (If `s === e` and the caret sits at the end of a line, that's the line.) Edge case: if the selection ends exactly on a line break (`e` is at column 0 of `L2`) and `L2 > L1`, treat the range as `[L1, L2 - 1]` (don't include the empty line below the selection).
+2. For each line in the range, check whether it already has the prefix:
+   - Bullet: `^- ` (literal hyphen + space at start of line, ignoring leading whitespace).
+   - Numbered: `^\d+\.\s+`.
+3. **Strip mode:** if every line in the range matches its prefix pattern, strip the prefix from each. The replacement string is the lines, each with its prefix removed, rejoined with `\n`.
+4. **Add mode:** otherwise, prefix each line:
+   - Bullet: `- ` prepended.
+   - Numbered: `1. `, `2. `, `3. `, … in order.
+5. Replace the full block (`[startOfL1, endOfL2)`) with the new text. Post-edit selection covers the same line block (`[startOfL1, startOfL1 + replacement.length]`).
+
+Mixed input (some lines bulleted, some not) follows case 4 — adds the prefix to all of them. This matches the standard editor convention and is what Google Docs / Notion / VS Code's markdown-list toggle do.
+
+Numbered toggle does **not** attempt to stitch into surrounding numbered lists. If the user toggles `1. 2. 3.` next to an existing `4. 5.` block, the result is two separate lists; that's `marked`'s problem, not ours, and the rendered card will still order correctly per the source numbers.
+
+#### `applyEdit` (fallback / test helper)
+
+```ts
+export function applyEdit(value: string, edit: Edit): string {
+  return value.slice(0, edit.replaceStart) + edit.replacement + value.slice(edit.replaceEnd);
+}
+```
+
+Used by `commands.test.ts` to assert resulting strings, and by the runtime fallback path described below.
+
+### DOM application — `applyEditToTextarea`
+
+```ts
+export function applyEditToTextarea(
+  textarea: HTMLTextAreaElement,
+  edit: Edit,
+  fallback: (nextValue: string) => void,
+): void {
+  textarea.focus();
+  textarea.setSelectionRange(edit.replaceStart, edit.replaceEnd);
+
+  const supported =
+    typeof document.queryCommandSupported === "function" &&
+    document.queryCommandSupported("insertText");
+
+  let ok = false;
+  if (supported) {
+    ok = document.execCommand("insertText", false, edit.replacement);
+  }
+  if (!ok) {
+    fallback(applyEdit(textarea.value, edit));
+  }
+  textarea.setSelectionRange(edit.selectionStart, edit.selectionEnd);
+}
+```
+
+`execCommand("insertText")` on a focused textarea dispatches a real `input` event. React's `onChange` runs against that event, so `card.body` flows through the existing `onChange` path with no special handling. The browser also records the edit on its native undo stack — Cmd+Z reverses one toolbar click at a time.
+
+The fallback path (`document.execCommand` missing or returning false) calls the parent's `onChange` directly with the post-edit value. Native undo collapses to one entry across the click in that path; that's the documented degradation.
+
+`execCommand` is deprecated, but MDN explicitly carves out the undo-buffer use case and recommends `queryCommandSupported` for feature detection (which is what we do). Every shipping browser still implements `insertText` for `<textarea>`s; this is the same approach used by GitHub, GitLab, Reddit, Slack's compose box, etc.
+
+### `MarkdownToolbar`
+
+```tsx
+type Command = "bold" | "italic" | "bullet" | "numbered";
+
+type Props = {
+  onCommand: (cmd: Command) => void;
+};
+```
+
+Renders four `IconButton`s in a row. Each button:
+
+- Has an explicit `aria-label` ("Bold", "Italic", "Bullet list", "Numbered list").
+- Calls `onMouseDown` with `e.preventDefault()` so clicking does not move focus off the textarea.
+- Calls `onCommand(cmd)` on `onPress` (RAC convention).
+
+The component knows nothing about the textarea, the value, or the command helpers. It only emits an event.
+
+### `CardEditor` wiring
+
+```tsx
+const bodyRef = useRef<HTMLTextAreaElement>(null);
+
+const runCommand = (cmd: Command) => {
+  const ta = bodyRef.current;
+  if (!ta) return;
+  const state: EditorState = {
+    value: ta.value,
+    selectionStart: ta.selectionStart,
+    selectionEnd: ta.selectionEnd,
+  };
+  const edit =
+    cmd === "bold"     ? toggleWrap(state, "**")
+  : cmd === "italic"   ? toggleWrap(state, "_")
+  : cmd === "bullet"   ? togglePrefix(state, "bullet")
+  :                      togglePrefix(state, "numbered");
+  applyEditToTextarea(ta, edit, (nextValue) =>
+    onChange({ ...card, body: nextValue, updatedAt: nowIso() }),
+  );
+};
+
+const onBodyKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+  if (!(e.metaKey || e.ctrlKey) || e.shiftKey || e.altKey) return;
+  if (e.key === "b" || e.key === "B") {
+    e.preventDefault();
+    runCommand("bold");
+  } else if (e.key === "i" || e.key === "I") {
+    e.preventDefault();
+    runCommand("italic");
+  }
+};
+```
+
+`onKeyDown` flows through the existing `...rest` spread on the `Textarea` primitive. `ref` does not — the primitive is a plain function component today (`src/lib/ui/Textarea.tsx`). Wrap it in `forwardRef<HTMLTextAreaElement, TextareaProps>` so `bodyRef` reaches the underlying `<textarea>`. No other call site is affected.
+
+The toolbar sits above the textarea inside the body field's `<label>`:
+
+```tsx
+<label className={styles.field} htmlFor={ids.body}>
+  <span className={styles.label}>Body</span>
+  <MarkdownToolbar onCommand={runCommand} />
+  <Textarea
+    ref={bodyRef}
+    id={ids.body}
+    aria-describedby={ids.bodyHelp}
+    value={card.body}
+    onChange={handle("body")}
+    onKeyDown={onBodyKeyDown}
+    rows={8}
+  />
+  <span id={ids.bodyHelp} className={styles.help}>…</span>
+</label>
+```
+
+### Icons
+
+Four new SVGs under `src/lib/ui/icons/` — `bold.tsx`, `italic.tsx`, `bullet-list.tsx`, `numbered-list.tsx` — matching the existing icon pattern (24×24 stroke icons). Sourced from the same set as the other editor icons; final visual choice tuned during implementation.
+
+### Styling
+
+`MarkdownToolbar.module.css` is short:
+
+```css
+.toolbar {
+  display: flex;
+  gap: var(--space-1);
+  margin-top: var(--space-1);
+}
+```
+
+No new tokens required. Buttons inherit `IconButton`'s focus ring, hover state, and disabled state.
+
+## Testing
+
+### Vitest (jsdom)
+
+- **`commands.test.ts`** — the bulk of the coverage. Table-driven tests for every branch of `toggleWrap` and `togglePrefix`:
+  - `toggleWrap`:
+    - Empty value, empty selection → `****`, caret between.
+    - Selection plain text → wrap.
+    - Selection includes markers (`**foo**`) → strip.
+    - Selection between markers (`foo` with `**` immediately around) → strip.
+    - Multi-line selection wraps the whole range as one (single pair of markers).
+    - Selection at start / end of value (no out-of-bounds when probing for outer markers).
+    - `_` italic marker behaves identically to `**`.
+  - `togglePrefix`:
+    - Single-line caret, no prefix → adds prefix.
+    - Single-line caret, has prefix → strips.
+    - Multi-line selection, none prefixed → adds to all.
+    - Multi-line selection, all prefixed → strips from all.
+    - Multi-line selection, mixed → adds to all.
+    - Numbered renumbers from `1.` regardless of any source numbering.
+    - Selection ending exactly on a newline doesn't pull in the next line.
+    - Empty value (caret at 0) — adds prefix on the current empty line, no crash.
+- **`MarkdownToolbar.test.tsx`** — renders, `getByRole("button", { name: "Bold" })` etc. exist, `userEvent.click(boldButton)` calls `onCommand` with `"bold"`. `onMouseDown.preventDefault` is exercised implicitly by `userEvent`.
+- **`CardEditor.test.tsx`** — extend. `Cmd+B` keystroke on the body textarea triggers the bold command path; assert via the `onChange` it receives. Does **not** assert on the result of DOM mutation (that's Playwright's job — execCommand isn't real here).
+
+### Playwright (`e2e/editor-markdown.spec.ts`)
+
+Real Chromium; this is where the DOM-mutating behavior is verified end-to-end.
+
+- Load the editor for a card.
+- **Toolbar bold:** type "hello world", select "hello", click Bold. Textarea reads `**hello** world`. Click Bold again — back to `hello world`.
+- **Keyboard bold:** type "abc", select "abc", press Cmd+B. Reads `**abc**`.
+- **Italic:** same pair of cases for `Cmd+I` / italic button.
+- **Bullet multi-line:** type three lines, select all, click Bullet. All three lines get `- ` prefix. Click again — prefixes gone.
+- **Numbered multi-line:** same setup, click Numbered. Lines read `1. one\n2. two\n3. three`.
+- **Undo preservation:** type "hello world", select "world", click Bold (now `hello **world**`). Press Cmd+Z (or `keyboard.press("Meta+z")` / `Control+z` per platform). Textarea reverts to `hello world`. Press Cmd+Z again — typed text begins to undo character by character.
+- **Focus retention:** click a toolbar button; `document.activeElement` is still the textarea.
+
+## Edge cases
+
+- **execCommand returns false / unsupported.** Fallback path (`onChange` with computed value); Cmd+Z then collapses the toolbar click into one undo entry. Documented behavior.
+- **Selection at value boundary** when checking for outer markers (case 2 of `toggleWrap`). Helper guards `s - m.length >= 0` and `e + m.length <= value.length` before slicing.
+- **Multi-byte characters in selection.** JS string indices are UTF-16 code units, which is what `selectionStart`/`selectionEnd` already use. No special handling needed.
+- **Numbered list >9 items.** `1. … 10. … 11.` — works fine; helper just counts.
+- **Caret at end of an empty line** when toggling a list. Treated as a line of zero characters; gets `- ` (or `1. `) prepended; caret remains after the prefix. (The `replacement` ends with the prefix, and post-edit selection is at `replaceStart + replacement.length`.)
+- **A line that is whitespace-only** (e.g., spaces). Gets prefixed in add mode; the prefix-detection regex on strip mode requires the prefix at the start of the line content (not before the leading whitespace), so a line like `   - foo` strips to `   foo`. We anchor the strip regex to `^[ \t]*(- |\d+\.\s+)?` and re-emit the leading whitespace.
+- **Selection of just the marker characters** (e.g., user selects `**` and presses Cmd+B). `e - s === 2` fails the case-1 length guard, so the helper falls through to case 4 (wrap), producing `****`. Acceptable and matches what GitHub does.
+
+## Risks
+
+- **`execCommand` removal in some future browser.** Mitigated by feature detection + fallback. The fallback is functionally correct; only the granularity of native undo degrades.
+- **`Textarea` `forwardRef` change.** Shared primitive change, but unobservable to existing call sites — they pass no `ref`, and `forwardRef` is type-compatible with the current `(props) => JSX` shape.
+- **Keyboard shortcut conflict with browser bookmarks bar (`Cmd+B`).** `preventDefault` on the textarea-scoped handler is sufficient; Chrome/Firefox/Safari all let the page swallow `Cmd+B` when fired on a focused editable element.
+- **Toolbar icons not yet picked.** Visual choice is small but real; expect a brief tuning step during implementation. Spec doesn't gate on it.
+
+## Out of scope
+
+- Cmd+Shift+8 / Cmd+Shift+7 list shortcuts.
+- Enter-continues-list / Enter-on-empty-list-line-exits.
+- Live preview, WYSIWYG, or any rich-text model.
+- Link, table, code-block, heading, checklist, blockquote affordances.
+- A `MarkdownEditor` primitive in `src/lib/ui/`. Re-evaluate if a second consumer ever appears.
+- A migration that auto-formats existing cards.

--- a/docs/superpowers/specs/2026-05-08-markdown-editor-toolbar-design.md
+++ b/docs/superpowers/specs/2026-05-08-markdown-editor-toolbar-design.md
@@ -6,217 +6,210 @@ Card bodies render as Markdown (`renderBody.ts` → `marked` → DOMPurify), but
 
 ## Goal
 
-Add a small toolbar above the body field with Bold / Italic / Bullet list / Numbered list buttons, plus `Cmd/Ctrl+B` and `Cmd/Ctrl+I` shortcuts when the textarea is focused. The editor stays a plain textarea — no WYSIWYG, no shortcut-driven inline transforms while typing. Browser-native undo (Cmd+Z) must continue to work one toolbar click at a time.
+Add a small toolbar above the body field with Bold / Italic / Bullet list / Numbered list buttons, plus `Cmd/Ctrl+B` and `Cmd/Ctrl+I` shortcuts when the textarea is focused. The editor stays a plain textarea — no WYSIWYG, no shortcut-driven inline transforms while typing. Browser-native undo (Cmd+Z) must continue to work one toolbar action at a time.
+
+## Approach
+
+Use [`@github/markdown-toolbar-element`](https://github.com/github/markdown-toolbar-element), the ~5KB web component GitHub uses on its own PR/issue textareas. It handles the parts that are easy to get wrong: selection wrap/unwrap, multi-line list toggling, mixed-prefix renumbering, edge cases around line boundaries, and undo preservation via `document.execCommand("insertText")`. We supply the icon buttons, the styling, and a small textarea-scoped keyboard handler for `Cmd/Ctrl+B/I`.
+
+This collapses what would have been ~300 lines of helper logic + tests into a thin styling and wiring layer, and outsources the edge cases to a battle-tested implementation.
 
 ## Scope
 
 In:
 
-- Toolbar with four buttons: Bold, Italic, Bullet list, Numbered list.
+- Toolbar above the body field with four buttons: Bold, Italic, Bullet list, Numbered list.
 - Keyboard: `Cmd/Ctrl+B` for bold, `Cmd/Ctrl+I` for italic, fired when the body textarea has focus.
-- Toggle semantics: clicking a button (or pressing the shortcut) on already-formatted text removes the formatting.
-- Multi-line list toggling: list buttons act on every line touched by the selection.
-- Native undo preserved via `document.execCommand("insertText", …)`, with a graceful fallback if `insertText` is unsupported.
+- Toggle semantics, multi-line list handling, undo preservation: inherited from the library.
+- Styling matches the rest of the editor (focus ring, hover state, screen tokens).
 
 Out:
 
-- Shortcuts for lists (`Cmd+Shift+8`, `Cmd+Shift+7`).
-- Enter-continues-list / Enter-on-empty-list-line-exits behavior.
-- Link, table, code-block, heading, checklist, or blockquote affordances.
-- A general-purpose `MarkdownEditor` primitive in `src/lib/ui/`. The toolbar lives next to its only consumer for now (per `src/lib/ui/README.md` extraction rules).
-- WYSIWYG, live-preview-as-you-type inline transforms, or any rich-text model. The textarea remains plain text.
+- Shortcuts for lists (`Cmd+Shift+8/7`).
+- Active-state highlighting on toolbar buttons (e.g., Bold lights up when caret is inside `**…**`).
+- Buttons for link, image, code, header, quote, task list, mention, ref. The library supports them; we don't render them.
+- Live preview, WYSIWYG, or any rich-text model. The textarea stays plain text.
+- A general-purpose `MarkdownEditor` primitive in `src/lib/ui/`. The toolbar lives next to its only consumer for now.
 
 ## UX
 
-- A row of four square `IconButton`s sits directly above the body `Textarea`, aligned with its left edge. Tooltips / `aria-label`s: "Bold", "Italic", "Bullet list", "Numbered list".
-- Clicking a button does not steal focus from the textarea (`onMouseDown` `preventDefault`; the action fires on click). After the action, the textarea retains focus and the selection is set to whatever range the helper computed.
-- Inline buttons (Bold/Italic) on a selection wrap or unwrap the selection. With no selection they insert empty markers (`****`, `__`) and place the caret between them.
-- List buttons (Bullet/Numbered) operate on the lines touched by the selection (or the caret line if collapsed). If any line lacks the prefix, the button adds the prefix to all of them. If every line already has the prefix, it strips them. The post-edit selection spans the same line range so the button is repeatable.
-- `Cmd/Ctrl+B` and `Cmd/Ctrl+I` mirror the inline buttons and `preventDefault` on the keyboard event so the browser's default chrome bolding doesn't fire.
+- A row of four buttons sits directly above the body `Textarea`, aligned with its left edge.
+- Each button shows an icon (24×24 stroke icons matching the existing `src/lib/ui/icons/` set) and has an explicit `aria-label` that includes the shortcut where applicable: "Bold (⌘B)", "Italic (⌘I)", "Bullet list", "Numbered list".
+- Clicking a button does not steal focus from the textarea (the library handles this internally).
+- Inline buttons (Bold/Italic) on a selection wrap or unwrap; on no selection, insert empty markers and place the caret between them. List buttons toggle the line(s) the selection touches.
+- `Cmd/Ctrl+B` and `Cmd/Ctrl+I` mirror the inline buttons.
 - The "Supports Markdown — bold, italic, lists, tables." help line under the textarea is unchanged.
 
 ## Architecture
 
 ```
 src/cards/
-  markdown/
-    commands.ts          — pure helpers; describe edits, no DOM
-    commands.test.ts     — Vitest, exhaustive table per helper
-    MarkdownToolbar.tsx  — 4 IconButtons; emits onCommand(name)
-    MarkdownToolbar.module.css
-    MarkdownToolbar.test.tsx
-  CardEditor.tsx         — adds ref, onKeyDown, MarkdownToolbar
-src/lib/ui/icons/        — 4 new SVG icons (bold, italic, bullet-list, numbered-list)
+  MarkdownToolbar.tsx        — renders <markdown-toolbar> + four <md-*> children
+  MarkdownToolbar.module.css — styles for <md-bold>, <md-italic>, etc.
+  MarkdownToolbar.test.tsx
+  CardEditor.tsx             — renders <MarkdownToolbar>; adds Cmd+B/I handler on textarea
+src/lib/ui/
+  Textarea.tsx               — wrap in forwardRef so CardEditor can hold a ref
+  icons/                     — 4 new SVG icons (bold, italic, bullet-list, numbered-list)
+src/types/
+  jsx-markdown-toolbar.d.ts  — JSX intrinsic declarations for the web components
 e2e/
-  editor-markdown.spec.ts — Playwright; real execCommand, undo preservation
+  editor-markdown.spec.ts    — Playwright; real execCommand, undo preservation
 ```
 
-Two concerns kept separate:
+### Dependency
 
-1. **What the edit is** — a pure function over `(value, selectionStart, selectionEnd, kind)` returning a description of the textarea mutation. Lives in `commands.ts`. Trivial to unit-test.
-2. **How the edit is applied to the DOM** — preserves browser undo via `execCommand("insertText")`. Lives inside `CardEditor` (or a tiny `applyEdit` helper colocated with it).
-
-### Helper API
-
-```ts
-// src/cards/markdown/commands.ts
-
-export type EditorState = {
-  value: string;
-  selectionStart: number;
-  selectionEnd: number;
-};
-
-export type Edit = {
-  // Range of `state.value` to replace (`[replaceStart, replaceEnd)`).
-  replaceStart: number;
-  replaceEnd: number;
-  // Text to insert in that range.
-  replacement: string;
-  // Selection on the post-edit value. (i.e. on
-  // value.slice(0, replaceStart) + replacement + value.slice(replaceEnd))
-  selectionStart: number;
-  selectionEnd: number;
-};
-
-export function toggleWrap(state: EditorState, marker: "**" | "_"): Edit;
-export function togglePrefix(state: EditorState, kind: "bullet" | "numbered"): Edit;
-
-// Test helper. Component code does not call this on the happy path —
-// it's only used by the fallback when execCommand is unavailable.
-export function applyEdit(value: string, edit: Edit): string;
+```
+npm install --save @github/markdown-toolbar-element
 ```
 
-#### `toggleWrap` rules
-
-Let `m` = the marker (`**` or `_`). Let `[s, e)` be the current selection on `value`.
-
-1. **Selection wrapped (markers inside selection):** `e - s >= 2 * m.length`, `value.slice(s, e)` starts with `m`, and ends with `m`. Strip both — emit an `Edit` that replaces `[s, e)` with `value.slice(s + m.length, e - m.length)` and sets the post-edit selection to `[s, s + (e - s) - 2 * m.length]`. (The length guard prevents `**` selected → no-op.)
-2. **Selection wrapped (markers outside selection):** `value.slice(s - m.length, s) === m && value.slice(e, e + m.length) === m`. Strip — emit an `Edit` that replaces `[s - m.length, e + m.length)` with `value.slice(s, e)` and sets the post-edit selection to `[s - m.length, e - m.length]`.
-3. **Empty selection (`s === e`):** insert `m + m` at `s`; place caret between markers. `replaceStart = replaceEnd = s`, `replacement = m + m`, post-edit selection `[s + m.length, s + m.length]`.
-4. **Otherwise:** wrap. Replace `[s, e)` with `m + value.slice(s, e) + m`; selection covers the inner text on the post-edit value.
-
-Case 1 takes precedence over case 2 when both match (defensive — should not normally co-occur).
-
-#### `togglePrefix` rules
-
-1. Determine the line range touched by `[s, e)`: line `L1` is the line containing `s`, line `L2` is the line containing `e`. (If `s === e` and the caret sits at the end of a line, that's the line.) Edge case: if the selection ends exactly on a line break (`e` is at column 0 of `L2`) and `L2 > L1`, treat the range as `[L1, L2 - 1]` (don't include the empty line below the selection).
-2. For each line in the range, check whether it already has the prefix:
-   - Bullet: `^- ` (literal hyphen + space at start of line, ignoring leading whitespace).
-   - Numbered: `^\d+\.\s+`.
-3. **Strip mode:** if every line in the range matches its prefix pattern, strip the prefix from each. The replacement string is the lines, each with its prefix removed, rejoined with `\n`.
-4. **Add mode:** otherwise, prefix each line:
-   - Bullet: `- ` prepended.
-   - Numbered: `1. `, `2. `, `3. `, … in order.
-5. Replace the full block (`[startOfL1, endOfL2)`) with the new text. Post-edit selection covers the same line block (`[startOfL1, startOfL1 + replacement.length]`).
-
-Mixed input (some lines bulleted, some not) follows case 4 — adds the prefix to all of them. This matches the standard editor convention and is what Google Docs / Notion / VS Code's markdown-list toggle do.
-
-Numbered toggle does **not** attempt to stitch into surrounding numbered lists. If the user toggles `1. 2. 3.` next to an existing `4. 5.` block, the result is two separate lists; that's `marked`'s problem, not ours, and the rendered card will still order correctly per the source numbers.
-
-#### `applyEdit` (fallback / test helper)
-
-```ts
-export function applyEdit(value: string, edit: Edit): string {
-  return value.slice(0, edit.replaceStart) + edit.replacement + value.slice(edit.replaceEnd);
-}
-```
-
-Used by `commands.test.ts` to assert resulting strings, and by the runtime fallback path described below.
-
-### DOM application — `applyEditToTextarea`
-
-```ts
-export function applyEditToTextarea(
-  textarea: HTMLTextAreaElement,
-  edit: Edit,
-  fallback: (nextValue: string) => void,
-): void {
-  textarea.focus();
-  textarea.setSelectionRange(edit.replaceStart, edit.replaceEnd);
-
-  const supported =
-    typeof document.queryCommandSupported === "function" &&
-    document.queryCommandSupported("insertText");
-
-  let ok = false;
-  if (supported) {
-    ok = document.execCommand("insertText", false, edit.replacement);
-  }
-  if (!ok) {
-    fallback(applyEdit(textarea.value, edit));
-  }
-  textarea.setSelectionRange(edit.selectionStart, edit.selectionEnd);
-}
-```
-
-`execCommand("insertText")` on a focused textarea dispatches a real `input` event. React's `onChange` runs against that event, so `card.body` flows through the existing `onChange` path with no special handling. The browser also records the edit on its native undo stack — Cmd+Z reverses one toolbar click at a time.
-
-The fallback path (`document.execCommand` missing or returning false) calls the parent's `onChange` directly with the post-edit value. Native undo collapses to one entry across the click in that path; that's the documented degradation.
-
-`execCommand` is deprecated, but MDN explicitly carves out the undo-buffer use case and recommends `queryCommandSupported` for feature detection (which is what we do). Every shipping browser still implements `insertText` for `<textarea>`s; this is the same approach used by GitHub, GitLab, Reddit, Slack's compose box, etc.
-
-### `MarkdownToolbar`
+The package registers four custom elements as a side effect on import: `markdown-toolbar`, `md-bold`, `md-italic`, `md-unordered-list`, `md-ordered-list` (and others we don't render). Import once at the top of `MarkdownToolbar.tsx`:
 
 ```tsx
-type Command = "bold" | "italic" | "bullet" | "numbered";
-
-type Props = {
-  onCommand: (cmd: Command) => void;
-};
+import "@github/markdown-toolbar-element";
 ```
 
-Renders four `IconButton`s in a row. Each button:
+The library uses `document.execCommand("insertText")` internally with a fallback to direct `value` assignment, so native undo is preserved without us doing anything.
 
-- Has an explicit `aria-label` ("Bold", "Italic", "Bullet list", "Numbered list").
-- Calls `onMouseDown` with `e.preventDefault()` so clicking does not move focus off the textarea.
-- Calls `onCommand(cmd)` on `onPress` (RAC convention).
+### TypeScript intrinsics
 
-The component knows nothing about the textarea, the value, or the command helpers. It only emits an event.
+The package doesn't ship JSX type augmentations. We declare them once in `src/types/jsx-markdown-toolbar.d.ts`:
 
-### `CardEditor` wiring
+```ts
+import type { DetailedHTMLProps, HTMLAttributes } from "react";
+
+type MarkdownToolbarAttrs = DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> & {
+  for?: string;
+};
+type MdButtonAttrs = DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "markdown-toolbar": MarkdownToolbarAttrs;
+      "md-bold": MdButtonAttrs;
+      "md-italic": MdButtonAttrs;
+      "md-unordered-list": MdButtonAttrs;
+      "md-ordered-list": MdButtonAttrs;
+    }
+  }
+}
+```
+
+(Project tsconfig uses the classic JSX namespace; if it switches to `react-jsx`, the same shape lives under `React.JSX` instead.)
+
+### `MarkdownToolbar.tsx`
+
+```tsx
+import "@github/markdown-toolbar-element";
+import { forwardRef } from "react";
+import { BoldIcon } from "../lib/ui/icons/bold";
+import { ItalicIcon } from "../lib/ui/icons/italic";
+import { BulletListIcon } from "../lib/ui/icons/bullet-list";
+import { NumberedListIcon } from "../lib/ui/icons/numbered-list";
+import styles from "./MarkdownToolbar.module.css";
+
+type Props = {
+  htmlFor: string;
+  boldRef?: React.RefObject<HTMLElement>;
+  italicRef?: React.RefObject<HTMLElement>;
+};
+
+export function MarkdownToolbar({ htmlFor, boldRef, italicRef }: Props) {
+  return (
+    <markdown-toolbar for={htmlFor} className={styles.toolbar}>
+      <md-bold ref={boldRef} className={styles.button} aria-label="Bold (⌘B)">
+        <BoldIcon />
+      </md-bold>
+      <md-italic ref={italicRef} className={styles.button} aria-label="Italic (⌘I)">
+        <ItalicIcon />
+      </md-italic>
+      <md-unordered-list className={styles.button} aria-label="Bullet list">
+        <BulletListIcon />
+      </md-unordered-list>
+      <md-ordered-list className={styles.button} aria-label="Numbered list">
+        <NumberedListIcon />
+      </md-ordered-list>
+    </markdown-toolbar>
+  );
+}
+```
+
+Use `className`, not `class` — React 18 still translates `className` → `class` for custom-element JSX intrinsics typed as `HTMLElement`. The `DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>` type already includes `className`.
+
+### `MarkdownToolbar.module.css`
+
+`<md-bold>` and friends register themselves with `role="button"` but ship with no default styling — they render as inline elements with no border, padding, or focus ring. Our CSS gives them the same look as `IconButton`, using existing screen tokens. Sketch:
+
+```css
+.toolbar {
+  display: flex;
+  gap: var(--space-1);
+  margin-top: var(--space-1);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text);
+  cursor: pointer;
+  user-select: none;
+}
+
+.button:hover {
+  background: var(--color-surface-hover);
+}
+
+.button:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.button[aria-disabled="true"] {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.button > svg {
+  width: 1rem;
+  height: 1rem;
+}
+```
+
+Final tuning during implementation against the existing editor visuals. No new tokens needed.
+
+### `CardEditor.tsx` wiring
+
+The body field section becomes:
 
 ```tsx
 const bodyRef = useRef<HTMLTextAreaElement>(null);
-
-const runCommand = (cmd: Command) => {
-  const ta = bodyRef.current;
-  if (!ta) return;
-  const state: EditorState = {
-    value: ta.value,
-    selectionStart: ta.selectionStart,
-    selectionEnd: ta.selectionEnd,
-  };
-  const edit =
-    cmd === "bold"     ? toggleWrap(state, "**")
-  : cmd === "italic"   ? toggleWrap(state, "_")
-  : cmd === "bullet"   ? togglePrefix(state, "bullet")
-  :                      togglePrefix(state, "numbered");
-  applyEditToTextarea(ta, edit, (nextValue) =>
-    onChange({ ...card, body: nextValue, updatedAt: nowIso() }),
-  );
-};
+const boldRef = useRef<HTMLElement>(null);
+const italicRef = useRef<HTMLElement>(null);
 
 const onBodyKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
   if (!(e.metaKey || e.ctrlKey) || e.shiftKey || e.altKey) return;
-  if (e.key === "b" || e.key === "B") {
+  const k = e.key.toLowerCase();
+  if (k === "b") {
     e.preventDefault();
-    runCommand("bold");
-  } else if (e.key === "i" || e.key === "I") {
+    boldRef.current?.click();
+  } else if (k === "i") {
     e.preventDefault();
-    runCommand("italic");
+    italicRef.current?.click();
   }
 };
-```
 
-`onKeyDown` flows through the existing `...rest` spread on the `Textarea` primitive. `ref` does not — the primitive is a plain function component today (`src/lib/ui/Textarea.tsx`). Wrap it in `forwardRef<HTMLTextAreaElement, TextareaProps>` so `bodyRef` reaches the underlying `<textarea>`. No other call site is affected.
+// …
 
-The toolbar sits above the textarea inside the body field's `<label>`:
-
-```tsx
 <label className={styles.field} htmlFor={ids.body}>
   <span className={styles.label}>Body</span>
-  <MarkdownToolbar onCommand={runCommand} />
+  <MarkdownToolbar htmlFor={ids.body} boldRef={boldRef} italicRef={italicRef} />
   <Textarea
     ref={bodyRef}
     id={ids.body}
@@ -230,84 +223,68 @@ The toolbar sits above the textarea inside the body field's `<label>`:
 </label>
 ```
 
+Why click the `<md-*>` element instead of dispatching directly: the library reads the textarea state on every click event it receives. Triggering a click is the public API; reaching past it isn't.
+
+`bodyRef` is included for completeness (a focused textarea is what the library targets, located via the `for=` attribute on `<markdown-toolbar>`). It also lets future features hook in without re-plumbing.
+
+### `Textarea` ref forwarding
+
+`src/lib/ui/Textarea.tsx` is a plain function component today and doesn't forward `ref`. Wrap it in `forwardRef<HTMLTextAreaElement, TextareaProps>` so `bodyRef` reaches the underlying `<textarea>`. No call site is affected — none currently pass a ref.
+
 ### Icons
 
-Four new SVGs under `src/lib/ui/icons/` — `bold.tsx`, `italic.tsx`, `bullet-list.tsx`, `numbered-list.tsx` — matching the existing icon pattern (24×24 stroke icons). Sourced from the same set as the other editor icons; final visual choice tuned during implementation.
-
-### Styling
-
-`MarkdownToolbar.module.css` is short:
-
-```css
-.toolbar {
-  display: flex;
-  gap: var(--space-1);
-  margin-top: var(--space-1);
-}
-```
-
-No new tokens required. Buttons inherit `IconButton`'s focus ring, hover state, and disabled state.
+Four new SVGs under `src/lib/ui/icons/` matching the existing 24×24 stroke style: `bold.tsx`, `italic.tsx`, `bullet-list.tsx`, `numbered-list.tsx`. Visual choice tuned during implementation against representative cards.
 
 ## Testing
 
 ### Vitest (jsdom)
 
-- **`commands.test.ts`** — the bulk of the coverage. Table-driven tests for every branch of `toggleWrap` and `togglePrefix`:
-  - `toggleWrap`:
-    - Empty value, empty selection → `****`, caret between.
-    - Selection plain text → wrap.
-    - Selection includes markers (`**foo**`) → strip.
-    - Selection between markers (`foo` with `**` immediately around) → strip.
-    - Multi-line selection wraps the whole range as one (single pair of markers).
-    - Selection at start / end of value (no out-of-bounds when probing for outer markers).
-    - `_` italic marker behaves identically to `**`.
-  - `togglePrefix`:
-    - Single-line caret, no prefix → adds prefix.
-    - Single-line caret, has prefix → strips.
-    - Multi-line selection, none prefixed → adds to all.
-    - Multi-line selection, all prefixed → strips from all.
-    - Multi-line selection, mixed → adds to all.
-    - Numbered renumbers from `1.` regardless of any source numbering.
-    - Selection ending exactly on a newline doesn't pull in the next line.
-    - Empty value (caret at 0) — adds prefix on the current empty line, no crash.
-- **`MarkdownToolbar.test.tsx`** — renders, `getByRole("button", { name: "Bold" })` etc. exist, `userEvent.click(boldButton)` calls `onCommand` with `"bold"`. `onMouseDown.preventDefault` is exercised implicitly by `userEvent`.
-- **`CardEditor.test.tsx`** — extend. `Cmd+B` keystroke on the body textarea triggers the bold command path; assert via the `onChange` it receives. Does **not** assert on the result of DOM mutation (that's Playwright's job — execCommand isn't real here).
+Web components register via the `customElements` registry, which jsdom supports.
+
+- **`MarkdownToolbar.test.tsx`** —
+  - Renders four buttons; each has the expected `aria-label` (`getByRole("button", { name: /bold/i })`, etc.).
+  - The `<markdown-toolbar>` element has the right `for` attribute pointing at the linked textarea id.
+  - Clicking a button does not throw (the library's `execCommand` path will exercise jsdom's behavior; jsdom does not implement `execCommand`, so the library's fallback runs — that's fine, we're only asserting the React/DOM glue here, not formatting behavior).
+
+- **`CardEditor.test.tsx`** — extend.
+  - `Cmd+B` keystroke on the body textarea calls `boldRef.current.click()`. Spy on the click via `userEvent` + `addEventListener`, assert dispatched.
+  - `Cmd+I` similarly.
+  - `Cmd+Shift+B` does not trigger bold (modifier guard).
+
+The pure-helper tests from the previous design are gone — the helpers no longer exist.
 
 ### Playwright (`e2e/editor-markdown.spec.ts`)
 
-Real Chromium; this is where the DOM-mutating behavior is verified end-to-end.
+Real Chromium; the only place we verify formatting actually happens.
 
-- Load the editor for a card.
 - **Toolbar bold:** type "hello world", select "hello", click Bold. Textarea reads `**hello** world`. Click Bold again — back to `hello world`.
-- **Keyboard bold:** type "abc", select "abc", press Cmd+B. Reads `**abc**`.
+- **Keyboard bold:** type "abc", select "abc", press Cmd/Meta+B. Reads `**abc**`.
 - **Italic:** same pair of cases for `Cmd+I` / italic button.
 - **Bullet multi-line:** type three lines, select all, click Bullet. All three lines get `- ` prefix. Click again — prefixes gone.
-- **Numbered multi-line:** same setup, click Numbered. Lines read `1. one\n2. two\n3. three`.
-- **Undo preservation:** type "hello world", select "world", click Bold (now `hello **world**`). Press Cmd+Z (or `keyboard.press("Meta+z")` / `Control+z` per platform). Textarea reverts to `hello world`. Press Cmd+Z again — typed text begins to undo character by character.
+- **Numbered multi-line:** same setup, click Numbered. Lines read `1. one\n2. two\n3. three` (or whatever the library produces — assert on the actual library behavior, not a guess).
+- **Undo preservation:** type "hello world", select "world", click Bold (now `hello **world**`). Press Cmd/Meta+Z. Textarea reverts to `hello world`. Press Cmd/Meta+Z again — typed text begins to undo character by character.
 - **Focus retention:** click a toolbar button; `document.activeElement` is still the textarea.
 
 ## Edge cases
 
-- **execCommand returns false / unsupported.** Fallback path (`onChange` with computed value); Cmd+Z then collapses the toolbar click into one undo entry. Documented behavior.
-- **Selection at value boundary** when checking for outer markers (case 2 of `toggleWrap`). Helper guards `s - m.length >= 0` and `e + m.length <= value.length` before slicing.
-- **Multi-byte characters in selection.** JS string indices are UTF-16 code units, which is what `selectionStart`/`selectionEnd` already use. No special handling needed.
-- **Numbered list >9 items.** `1. … 10. … 11.` — works fine; helper just counts.
-- **Caret at end of an empty line** when toggling a list. Treated as a line of zero characters; gets `- ` (or `1. `) prepended; caret remains after the prefix. (The `replacement` ends with the prefix, and post-edit selection is at `replaceStart + replacement.length`.)
-- **A line that is whitespace-only** (e.g., spaces). Gets prefixed in add mode; the prefix-detection regex on strip mode requires the prefix at the start of the line content (not before the leading whitespace), so a line like `   - foo` strips to `   foo`. We anchor the strip regex to `^[ \t]*(- |\d+\.\s+)?` and re-emit the leading whitespace.
-- **Selection of just the marker characters** (e.g., user selects `**` and presses Cmd+B). `e - s === 2` fails the case-1 length guard, so the helper falls through to case 4 (wrap), producing `****`. Acceptable and matches what GitHub does.
+- **`execCommand` unsupported.** The library falls back to direct `value` assignment with `ms-beginUndoUnit`/`ms-endUndoUnit` wrapping (its existing fallback). Cmd+Z then collapses the toolbar action into one undo entry. Documented degradation; no work for us.
+- **`<markdown-toolbar>` rendered without a matching textarea id.** The library's click handlers no-op; nothing else breaks. Not a real failure mode in our app — `htmlFor` always matches a real id from `useId`.
+- **Form submission.** `<md-bold>` etc. set `role="button"` but are not `<button type=…>` elements; they will not submit a parent form. The card editor's `<form>` already has `onSubmit={(e) => e.preventDefault()}`, so this is a non-issue.
+- **Keyboard layout.** `e.key` reads the produced character, which on most layouts gives `b`/`i` as expected. On non-Latin layouts where Cmd+B types something else, the shortcut won't fire — same behavior as Google Docs and similar editors. Not worth complicating with `e.code`.
 
 ## Risks
 
-- **`execCommand` removal in some future browser.** Mitigated by feature detection + fallback. The fallback is functionally correct; only the granularity of native undo degrades.
-- **`Textarea` `forwardRef` change.** Shared primitive change, but unobservable to existing call sites — they pass no `ref`, and `forwardRef` is type-compatible with the current `(props) => JSX` shape.
-- **Keyboard shortcut conflict with browser bookmarks bar (`Cmd+B`).** `preventDefault` on the textarea-scoped handler is sufficient; Chrome/Firefox/Safari all let the page swallow `Cmd+B` when fired on a focused editable element.
-- **Toolbar icons not yet picked.** Visual choice is small but real; expect a brief tuning step during implementation. Spec doesn't gate on it.
+- **Library maintenance / removal.** GitHub uses the library on github.com daily; archival risk is low. If it ever happens, the library is small enough to vendor.
+- **Web-component lifecycle in tests.** jsdom supports custom elements but quirks exist. Mitigated by keeping Vitest assertions DOM-shaped (aria-labels, attributes) rather than formatting-shaped, and pushing real-behavior assertions into Playwright.
+- **TypeScript intrinsic drift.** If the project's tsconfig flips to `react-jsx`, the JSX namespace declaration moves from `JSX.IntrinsicElements` to `React.JSX.IntrinsicElements`. One-line fix when it happens.
+- **Visual drift from `IconButton`.** The toolbar buttons replicate IconButton's appearance via a separate CSS module rather than reusing the React primitive (we can't nest a real `<button>` inside `role="button"`). If IconButton's styling evolves, MarkdownToolbar's CSS may lag. Mitigated by referencing the same screen tokens; flagged here so a future design-system pass knows to check both.
 
 ## Out of scope
 
 - Cmd+Shift+8 / Cmd+Shift+7 list shortcuts.
-- Enter-continues-list / Enter-on-empty-list-line-exits.
+- Enter-continues-list / Enter-on-empty-list-line-exits — not provided by the library.
+- Active-state highlighting on toolbar buttons.
 - Live preview, WYSIWYG, or any rich-text model.
-- Link, table, code-block, heading, checklist, blockquote affordances.
+- Link, table, code-block, heading, checklist, blockquote, mention, or ref affordances.
 - A `MarkdownEditor` primitive in `src/lib/ui/`. Re-evaluate if a second consumer ever appears.
 - A migration that auto-formats existing cards.

--- a/e2e/editor-markdown.spec.ts
+++ b/e2e/editor-markdown.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "@playwright/test";
+import { seedDeck, TEST_DECK_ID } from "./fixtures";
+
+const cardId = "00000000-0000-4000-8000-200000000001";
+
+test.beforeEach(async ({ page }) => {
+  await seedDeck(page, [
+    {
+      id: cardId,
+      name: "Markdown Test Item",
+      body: "",
+      headerTags: ["Wondrous item"],
+      footerTags: [],
+    },
+  ]);
+  await page.goto(`/deck/${TEST_DECK_ID}/edit/${cardId}`);
+});
+
+test("toolbar Bold wraps and unwraps the selection", async ({ page }) => {
+  const body = page.getByLabel(/body/i);
+  await body.fill("hello world");
+
+  // Select "hello".
+  await body.evaluate((el: HTMLTextAreaElement) => {
+    el.setSelectionRange(0, "hello".length);
+  });
+
+  await page.getByRole("button", { name: /bold/i }).click();
+  await expect(body).toHaveValue("**hello** world");
+
+  // Re-select "hello" (now inside the **…** wrapper, offsets shifted by 2).
+  await body.evaluate((el: HTMLTextAreaElement) => {
+    el.setSelectionRange(2, 2 + "hello".length);
+  });
+  await page.getByRole("button", { name: /bold/i }).click();
+  await expect(body).toHaveValue("hello world");
+});
+
+test("Cmd/Meta+B wraps the selection in bold", async ({ page }) => {
+  const body = page.getByLabel(/body/i);
+  await body.fill("abc");
+  await body.evaluate((el: HTMLTextAreaElement) => el.setSelectionRange(0, 3));
+
+  await body.focus();
+  await page.keyboard.press("Meta+b");
+
+  await expect(body).toHaveValue("**abc**");
+});
+
+test("Cmd/Meta+I wraps the selection in italics", async ({ page }) => {
+  const body = page.getByLabel(/body/i);
+  await body.fill("abc");
+  await body.evaluate((el: HTMLTextAreaElement) => el.setSelectionRange(0, 3));
+
+  await body.focus();
+  await page.keyboard.press("Meta+i");
+
+  // The library uses `_` for italics by default.
+  await expect(body).toHaveValue("_abc_");
+});
+
+test("Bullet list toggles a `- ` prefix on each selected line", async ({ page }) => {
+  const body = page.getByLabel(/body/i);
+  await body.fill("one\ntwo\nthree");
+  await body.evaluate((el: HTMLTextAreaElement) => el.setSelectionRange(0, el.value.length));
+
+  await page.getByRole("button", { name: /bullet list/i }).click();
+  await expect(body).toHaveValue("- one\n- two\n- three");
+
+  // Re-select the whole value (its length grew by 6) and toggle off.
+  await body.evaluate((el: HTMLTextAreaElement) => el.setSelectionRange(0, el.value.length));
+  await page.getByRole("button", { name: /bullet list/i }).click();
+  await expect(body).toHaveValue("one\ntwo\nthree");
+});
+
+test("Numbered list toggles `1. `/`2. `/`3. ` prefixes on selected lines", async ({ page }) => {
+  const body = page.getByLabel(/body/i);
+  await body.fill("one\ntwo\nthree");
+  await body.evaluate((el: HTMLTextAreaElement) => el.setSelectionRange(0, el.value.length));
+
+  await page.getByRole("button", { name: /numbered list/i }).click();
+  await expect(body).toHaveValue("1. one\n2. two\n3. three");
+});
+
+test("undo collapses a toolbar action into a single Cmd+Z", async ({ page }) => {
+  const body = page.getByLabel(/body/i);
+  await body.fill("hello world");
+  await body.evaluate((el: HTMLTextAreaElement) =>
+    el.setSelectionRange("hello ".length, "hello ".length + "world".length),
+  );
+
+  await page.getByRole("button", { name: /bold/i }).click();
+  await expect(body).toHaveValue("hello **world**");
+
+  await body.focus();
+  await page.keyboard.press("Meta+z");
+  await expect(body).toHaveValue("hello world");
+
+  // One more undo begins peeling the typed text.
+  await page.keyboard.press("Meta+z");
+  await expect(body).not.toHaveValue("hello world");
+});
+
+test("clicking a toolbar button keeps focus on the textarea", async ({ page }) => {
+  const body = page.getByLabel(/body/i);
+  await body.fill("abc");
+  await body.focus();
+
+  await page.getByRole("button", { name: /bold/i }).click();
+
+  await expect(body).toBeFocused();
+});

--- a/e2e/editor-markdown.spec.ts
+++ b/e2e/editor-markdown.spec.ts
@@ -93,11 +93,11 @@ test("undo collapses a toolbar action into a single Cmd+Z", async ({ page }) => 
   await expect(body).toHaveValue("hello **world**");
 
   await body.focus();
-  await page.keyboard.press("Meta+z");
+  await page.keyboard.press("ControlOrMeta+z");
   await expect(body).toHaveValue("hello world");
 
   // One more undo begins peeling the typed text.
-  await page.keyboard.press("Meta+z");
+  await page.keyboard.press("ControlOrMeta+z");
   await expect(body).not.toHaveValue("hello world");
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource/cinzel": "^5.2.8",
+        "@github/markdown-toolbar-element": "^2.2.3",
         "@iconify-icons/game-icons": "^1.2.1",
         "@iconify-icons/logos": "^1.2.36",
         "@iconify-icons/lucide": "^1.2.135",
@@ -546,6 +547,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
       }
+    },
+    "node_modules/@github/markdown-toolbar-element": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@github/markdown-toolbar-element/-/markdown-toolbar-element-2.2.3.tgz",
+      "integrity": "sha512-AlquKGee+IWiAMYVB0xyHFZRMnu4n3X4HTvJHu79GiVJ1ojTukCWyxMlF5NMsecoLcBKsuBhx3QPv2vkE/zQ0A==",
+      "license": "MIT"
     },
     "node_modules/@iconify-icons/game-icons": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource/cinzel": "^5.2.8",
+    "@github/markdown-toolbar-element": "^2.2.3",
     "@iconify-icons/game-icons": "^1.2.1",
     "@iconify-icons/logos": "^1.2.36",
     "@iconify-icons/lucide": "^1.2.135",

--- a/src/cards/CardEditor.test.tsx
+++ b/src/cards/CardEditor.test.tsx
@@ -186,6 +186,92 @@ describe("<CardEditor>", () => {
     expect(nameField?.parentElement?.tagName).toBe("DIV");
     expect(nameField?.parentElement?.contains(typeRadio)).toBe(true);
   });
+
+  test("renders the markdown toolbar associated with the body field", () => {
+    const card = itemCardFactory.build();
+    render(<Harness initial={card} />);
+
+    const toolbar = screen.getByRole("toolbar", { name: /formatting/i });
+    const body = screen.getByLabelText(/body/i);
+
+    // Toolbar's for= attribute targets the body textarea.
+    expect(toolbar.getAttribute("for")).toBe(body.getAttribute("id"));
+  });
+
+  test("Cmd+B on the body textarea clicks the Bold toolbar button", async () => {
+    const card = itemCardFactory.build();
+    render(<Harness initial={card} />);
+
+    const body = screen.getByLabelText(/body/i);
+    const bold = screen.getByRole("button", { name: /bold/i });
+    const clickSpy = vi.spyOn(bold, "click");
+
+    body.focus();
+    await userEvent.keyboard("{Meta>}b{/Meta}");
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("Ctrl+B on the body textarea clicks the Bold toolbar button (non-mac)", async () => {
+    const card = itemCardFactory.build();
+    render(<Harness initial={card} />);
+
+    const body = screen.getByLabelText(/body/i);
+    const bold = screen.getByRole("button", { name: /bold/i });
+    const clickSpy = vi.spyOn(bold, "click");
+
+    body.focus();
+    await userEvent.keyboard("{Control>}b{/Control}");
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("Cmd+I on the body textarea clicks the Italic toolbar button", async () => {
+    const card = itemCardFactory.build();
+    render(<Harness initial={card} />);
+
+    const body = screen.getByLabelText(/body/i);
+    const italic = screen.getByRole("button", { name: /italic/i });
+    const clickSpy = vi.spyOn(italic, "click");
+
+    body.focus();
+    await userEvent.keyboard("{Meta>}i{/Meta}");
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("Cmd+Shift+B does not trigger Bold (modifier guard)", async () => {
+    const card = itemCardFactory.build();
+    render(<Harness initial={card} />);
+
+    const body = screen.getByLabelText(/body/i);
+    const bold = screen.getByRole("button", { name: /bold/i });
+    const clickSpy = vi.spyOn(bold, "click");
+
+    body.focus();
+    await userEvent.keyboard("{Meta>}{Shift>}b{/Shift}{/Meta}");
+
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
+  test("Cmd+B on the body textarea calls preventDefault", () => {
+    const card = itemCardFactory.build();
+    render(<Harness initial={card} />);
+
+    const body = screen.getByLabelText(/body/i);
+    body.focus();
+
+    // Use a raw KeyboardEvent so we can inspect defaultPrevented after dispatch.
+    const event = new KeyboardEvent("keydown", {
+      key: "b",
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    body.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
 });
 
 describe("<CardEditor> with a spell card", () => {

--- a/src/cards/CardEditor.tsx
+++ b/src/cards/CardEditor.tsx
@@ -64,7 +64,6 @@ export function CardEditor({ card, onChange }: Props) {
     typeLabel: `${idBase}-typeLabel`,
   };
 
-  // Wired but unread — exposes the textarea node for future toolbar features without re-plumbing.
   const bodyRef = useRef<HTMLTextAreaElement>(null);
   const boldRef = useRef<HTMLElement>(null);
   const italicRef = useRef<HTMLElement>(null);

--- a/src/cards/CardEditor.tsx
+++ b/src/cards/CardEditor.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, useId } from "react";
+import { type ChangeEvent, type KeyboardEvent, useId, useRef } from "react";
 import { nowIso } from "../lib/time";
 import { IconPickerDialog } from "../lib/ui/IconPickerDialog";
 import { IconPreview } from "../lib/ui/IconPreview";
@@ -10,6 +10,7 @@ import { ToggleButton } from "../lib/ui/ToggleButton";
 import { ToggleButtonGroup } from "../lib/ui/ToggleButtonGroup";
 import styles from "./CardEditor.module.css";
 import { FALLBACK_ICON_KEY, pickIconKey } from "./iconRules";
+import { MarkdownToolbar } from "./MarkdownToolbar";
 import type { RenderableCard } from "./types";
 
 type Props = {
@@ -61,6 +62,23 @@ export function CardEditor({ card, onChange }: Props) {
     footerTagsLabel: `${idBase}-footerTagsLabel`,
     footerTagsHelp: `${idBase}-footerTagsHelp`,
     typeLabel: `${idBase}-typeLabel`,
+  };
+
+  // Wired but unread — exposes the textarea node for future toolbar features without re-plumbing.
+  const bodyRef = useRef<HTMLTextAreaElement>(null);
+  const boldRef = useRef<HTMLElement>(null);
+  const italicRef = useRef<HTMLElement>(null);
+
+  const onBodyKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (!(e.metaKey || e.ctrlKey) || e.shiftKey || e.altKey) return;
+    const k = e.key.toLowerCase();
+    if (k === "b") {
+      e.preventDefault();
+      boldRef.current?.click();
+    } else if (k === "i") {
+      e.preventDefault();
+      italicRef.current?.click();
+    }
   };
 
   return (
@@ -124,11 +142,14 @@ export function CardEditor({ card, onChange }: Props) {
       </div>
       <label className={styles.field} htmlFor={ids.body}>
         <span className={styles.label}>Body</span>
+        <MarkdownToolbar htmlFor={ids.body} boldRef={boldRef} italicRef={italicRef} />
         <Textarea
+          ref={bodyRef}
           id={ids.body}
           aria-describedby={ids.bodyHelp}
           value={card.body}
           onChange={handle("body")}
+          onKeyDown={onBodyKeyDown}
           rows={8}
         />
         <span id={ids.bodyHelp} className={styles.help}>

--- a/src/cards/MarkdownToolbar.module.css
+++ b/src/cards/MarkdownToolbar.module.css
@@ -1,0 +1,39 @@
+.toolbar {
+  display: flex;
+  gap: var(--space-1);
+  margin-top: var(--space-1);
+}
+
+.button {
+  font: inherit;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  user-select: none;
+  transition:
+    background 0.12s,
+    color 0.12s;
+}
+
+/* :hover (not [data-hovered]) — md-* elements are web components, not react-aria primitives. */
+.button:hover {
+  background: var(--color-surface-2);
+  color: var(--color-text);
+}
+
+.button:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.button > svg {
+  width: 1rem;
+  height: 1rem;
+}

--- a/src/cards/MarkdownToolbar.test.tsx
+++ b/src/cards/MarkdownToolbar.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { useId } from "react";
+import { describe, expect, test } from "vitest";
+import { MarkdownToolbar } from "./MarkdownToolbar";
+
+function Harness() {
+  const id = useId();
+  return (
+    <>
+      <MarkdownToolbar htmlFor={id} />
+      <textarea id={id} aria-label="body" defaultValue="" />
+    </>
+  );
+}
+
+describe("<MarkdownToolbar>", () => {
+  test("renders four buttons with accessible labels", () => {
+    render(<Harness />);
+    expect(screen.getByRole("button", { name: /bold/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /italic/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /bullet list/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /numbered list/i })).toBeInTheDocument();
+  });
+
+  test("bold and italic buttons advertise their keyboard shortcut", () => {
+    render(<Harness />);
+    expect(screen.getByRole("button", { name: /bold/i })).toHaveAccessibleName(/⌘B/);
+    expect(screen.getByRole("button", { name: /italic/i })).toHaveAccessibleName(/⌘I/);
+  });
+
+  test("toolbar is labelled and has role=toolbar", () => {
+    render(<Harness />);
+    const toolbar = screen.getByRole("toolbar", { name: /formatting/i });
+    expect(toolbar.tagName.toLowerCase()).toBe("markdown-toolbar");
+  });
+
+  test("toolbar's for= matches a real textarea id (the library targets that field)", () => {
+    render(<Harness />);
+    const toolbar = screen.getByRole("toolbar", { name: /formatting/i });
+    const targetId = toolbar.getAttribute("for");
+    expect(targetId).toBeTruthy();
+    expect(document.getElementById(targetId as string)?.tagName.toLowerCase()).toBe("textarea");
+  });
+
+  test("first button has tabindex=0, others tabindex=-1 (roving-tabindex init)", () => {
+    render(<Harness />);
+    const bold = screen.getByRole("button", { name: /bold/i });
+    const italic = screen.getByRole("button", { name: /italic/i });
+    const bullet = screen.getByRole("button", { name: /bullet list/i });
+    const numbered = screen.getByRole("button", { name: /numbered list/i });
+    expect(bold).toHaveAttribute("tabindex", "0");
+    expect(italic).toHaveAttribute("tabindex", "-1");
+    expect(bullet).toHaveAttribute("tabindex", "-1");
+    expect(numbered).toHaveAttribute("tabindex", "-1");
+  });
+});

--- a/src/cards/MarkdownToolbar.tsx
+++ b/src/cards/MarkdownToolbar.tsx
@@ -1,0 +1,59 @@
+import "@github/markdown-toolbar-element";
+import type { RefObject } from "react";
+import { BoldIcon } from "../lib/ui/icons/BoldIcon";
+import { BulletListIcon } from "../lib/ui/icons/BulletListIcon";
+import { ItalicIcon } from "../lib/ui/icons/ItalicIcon";
+import { NumberedListIcon } from "../lib/ui/icons/NumberedListIcon";
+import styles from "./MarkdownToolbar.module.css";
+
+type Props = {
+  htmlFor: string;
+  boldRef?: RefObject<HTMLElement | null>;
+  italicRef?: RefObject<HTMLElement | null>;
+};
+
+export function MarkdownToolbar({ htmlFor, boldRef, italicRef }: Props) {
+  return (
+    <markdown-toolbar
+      for={htmlFor}
+      role="toolbar"
+      aria-label="Formatting"
+      className={styles.toolbar}
+    >
+      <md-bold
+        ref={boldRef}
+        role="button"
+        tabIndex={0}
+        className={styles.button}
+        aria-label="Bold (⌘B)"
+      >
+        <BoldIcon />
+      </md-bold>
+      <md-italic
+        ref={italicRef}
+        role="button"
+        tabIndex={-1}
+        className={styles.button}
+        aria-label="Italic (⌘I)"
+      >
+        <ItalicIcon />
+      </md-italic>
+      <md-unordered-list
+        role="button"
+        tabIndex={-1}
+        className={styles.button}
+        aria-label="Bullet list"
+      >
+        <BulletListIcon />
+      </md-unordered-list>
+      <md-ordered-list
+        role="button"
+        tabIndex={-1}
+        className={styles.button}
+        aria-label="Numbered list"
+      >
+        <NumberedListIcon />
+      </md-ordered-list>
+    </markdown-toolbar>
+  );
+}

--- a/src/lib/ui/Textarea.tsx
+++ b/src/lib/ui/Textarea.tsx
@@ -1,10 +1,17 @@
-import type { TextareaHTMLAttributes } from "react";
+import { forwardRef, type TextareaHTMLAttributes } from "react";
 import styles from "./Textarea.module.css";
 
 export type TextareaProps = Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "className"> & {
   className?: string;
 };
 
-export function Textarea({ className, ...rest }: TextareaProps) {
-  return <textarea {...rest} className={[styles.textarea, className].filter(Boolean).join(" ")} />;
-}
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...rest }, ref) => (
+    <textarea
+      ref={ref}
+      {...rest}
+      className={[styles.textarea, className].filter(Boolean).join(" ")}
+    />
+  ),
+);
+Textarea.displayName = "Textarea";

--- a/src/lib/ui/icons/BoldIcon.tsx
+++ b/src/lib/ui/icons/BoldIcon.tsx
@@ -1,0 +1,6 @@
+import { Icon } from "@iconify/react";
+import boldIcon from "@iconify-icons/lucide/bold";
+
+export function BoldIcon({ size = 16 }: { size?: number }) {
+  return <Icon icon={boldIcon} width={size} height={size} aria-hidden="true" />;
+}

--- a/src/lib/ui/icons/BulletListIcon.tsx
+++ b/src/lib/ui/icons/BulletListIcon.tsx
@@ -1,0 +1,6 @@
+import { Icon } from "@iconify/react";
+import listIcon from "@iconify-icons/lucide/list";
+
+export function BulletListIcon({ size = 16 }: { size?: number }) {
+  return <Icon icon={listIcon} width={size} height={size} aria-hidden="true" />;
+}

--- a/src/lib/ui/icons/ItalicIcon.tsx
+++ b/src/lib/ui/icons/ItalicIcon.tsx
@@ -1,0 +1,6 @@
+import { Icon } from "@iconify/react";
+import italicIcon from "@iconify-icons/lucide/italic";
+
+export function ItalicIcon({ size = 16 }: { size?: number }) {
+  return <Icon icon={italicIcon} width={size} height={size} aria-hidden="true" />;
+}

--- a/src/lib/ui/icons/NumberedListIcon.tsx
+++ b/src/lib/ui/icons/NumberedListIcon.tsx
@@ -1,0 +1,6 @@
+import { Icon } from "@iconify/react";
+import listOrderedIcon from "@iconify-icons/lucide/list-ordered";
+
+export function NumberedListIcon({ size = 16 }: { size?: number }) {
+  return <Icon icon={listOrderedIcon} width={size} height={size} aria-hidden="true" />;
+}

--- a/src/types/jsx-markdown-toolbar.d.ts
+++ b/src/types/jsx-markdown-toolbar.d.ts
@@ -1,0 +1,19 @@
+import type { DetailedHTMLProps, HTMLAttributes } from "react";
+
+type MarkdownToolbarAttrs = DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> & {
+  for?: string;
+};
+
+type MdButtonAttrs = DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>;
+
+declare module "react" {
+  namespace JSX {
+    interface IntrinsicElements {
+      "markdown-toolbar": MarkdownToolbarAttrs;
+      "md-bold": MdButtonAttrs;
+      "md-italic": MdButtonAttrs;
+      "md-unordered-list": MdButtonAttrs;
+      "md-ordered-list": MdButtonAttrs;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a four-button toolbar (Bold / Italic / Bullet list / Numbered list) above the body textarea in `CardEditor`, plus `Cmd/Ctrl+B` and `Cmd/Ctrl+I` shortcuts when the textarea has focus.
- Built on [`@github/markdown-toolbar-element`](https://github.com/github/markdown-toolbar-element) (~5KB web component used by github.com). The library handles selection wrap/unwrap, multi-line list toggling, and undo preservation via `document.execCommand("insertText")`.
- Custom styling (matches `IconButton` appearance via existing screen tokens) and Lucide icons (matches existing `@iconify-icons/lucide` icon convention) — no GitHub CSS or icons in the bundle.

## Out of scope (per the [spec](docs/superpowers/specs/2026-05-08-markdown-editor-toolbar-design.md))

- Active-state highlighting on toolbar buttons
- `Cmd+Shift+8/7` list shortcuts
- Link / image / code / header / quote / task-list buttons
- Live preview / WYSIWYG / general `MarkdownEditor` primitive

## Test plan

- [x] Unit tests pass (`npm test`) — 23 tests in `CardEditor.test.tsx`, 5 in `MarkdownToolbar.test.tsx`
- [x] Playwright tests pass (`npm run test:e2e`) — 7 new tests in `e2e/editor-markdown.spec.ts` covering toolbar bold (wrap/unwrap), keyboard shortcuts, multi-line lists, undo preservation, and focus retention
- [x] Typecheck and lint clean (`npm run typecheck`, `npm run lint`)
- [x] Visual smoke test in dev server — toolbar renders above body field, hover/focus states work, keyboard shortcuts wrap selection, native `Cmd+Z` undo collapses one toolbar action per keystroke

🤖 Generated with [Claude Code](https://claude.com/claude-code)