### PR TITLE
feat(print): "Continue content on back" toggle for multi-page cards

### DIFF
--- a/docs/superpowers/plans/2026-05-08-print-content-on-back.md
+++ b/docs/superpowers/plans/2026-05-08-print-content-on-back.md
@@ -1,0 +1,686 @@
+# Continuation cards on print backs — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Continue content on back" sub-toggle to PrintView so that, when both "Print backs" and the new sub-toggle are on, multi-page cards print page 2+ on the back of page 1's slot instead of taking a separate front slot.
+
+**Architecture:** Introduce a pure `pairSlots(physicalCards, { contentOnBack })` function that groups consecutive same-card `PhysicalCard`s into `PrintSlot { front, back? }` pairs (or front-only slots when off). PrintView consumes slots instead of physical cards, calls existing `imposeBackPage` (generic, untouched) on the slots, and the existing `getBackContentFor` seam grows a branch: render `<Card>` if `slot.back` exists, else `<CardBack>`.
+
+**Tech Stack:** React 18 + TypeScript, Vitest + RTL + `@testing-library/user-event`, MSW for HTTP mocks, Fishery + faker factories, Biome for lint/format.
+
+**Spec:** `docs/superpowers/specs/2026-05-08-print-content-on-back-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `src/cards/pairSlots.ts` — pure pairing function and `PrintSlot` type.
+- `src/cards/pairSlots.test.ts` — unit tests.
+
+**Modify:**
+- `src/views/PrintView.tsx` — add `contentOnBack` state, replace `physicalCards` flow with `printSlots`, add sub-toggle markup, update `getBackContentFor`.
+- `src/views/PrintView.module.css` — add `.subSwitch` class.
+- `src/views/PrintView.test.tsx` — add tests for sub-toggle UI and paired-flow behavior.
+
+**Untouched:**
+- `src/cards/expandCard.ts`, `src/cards/paginate.ts`, `src/cards/measurer.ts`, `src/cards/Card.tsx`, `src/cards/CardBack.tsx`, `src/cards/backImposition.ts`.
+
+---
+
+## Task 1: `pairSlots` module (TDD)
+
+**Files:**
+- Create: `src/cards/pairSlots.ts`
+- Test: `src/cards/pairSlots.test.ts`
+
+- [ ] **Step 1.1: Write the failing test file**
+
+Create `src/cards/pairSlots.test.ts`:
+
+```ts
+import { describe, expect, test } from "vitest";
+import type { PhysicalCard } from "./expandCard";
+import { itemCardFactory } from "./factories";
+import { pairSlots } from "./pairSlots";
+import type { ItemCard } from "./types";
+
+const physical = (card: ItemCard, page?: number, total?: number): PhysicalCard => ({
+  card,
+  bodyChunk: "",
+  pagination: page !== undefined && total !== undefined ? { page, total } : undefined,
+});
+
+describe("pairSlots", () => {
+  test("contentOnBack: false maps every PhysicalCard to a front-only slot", () => {
+    const card = itemCardFactory.build();
+    const cards = [physical(card), physical(card, 1, 2), physical(card, 2, 2)];
+    const slots = pairSlots(cards, { contentOnBack: false });
+    expect(slots).toHaveLength(3);
+    for (const slot of slots) {
+      expect(slot.back).toBeUndefined();
+    }
+  });
+
+  test("empty input returns empty slots in both modes", () => {
+    expect(pairSlots([], { contentOnBack: false })).toEqual([]);
+    expect(pairSlots([], { contentOnBack: true })).toEqual([]);
+  });
+
+  test("single 1-page card pairs to one front-only slot", () => {
+    const card = itemCardFactory.build();
+    const slots = pairSlots([physical(card)], { contentOnBack: true });
+    expect(slots).toHaveLength(1);
+    expect(slots[0]!.back).toBeUndefined();
+  });
+
+  test("single 2-page card collapses to one paired slot", () => {
+    const card = itemCardFactory.build();
+    const cards = [physical(card, 1, 2), physical(card, 2, 2)];
+    const slots = pairSlots(cards, { contentOnBack: true });
+    expect(slots).toHaveLength(1);
+    expect(slots[0]!.front.pagination?.page).toBe(1);
+    expect(slots[0]!.back?.pagination?.page).toBe(2);
+  });
+
+  test("single 3-page card produces two slots, last with no back", () => {
+    const card = itemCardFactory.build();
+    const cards = [
+      physical(card, 1, 3),
+      physical(card, 2, 3),
+      physical(card, 3, 3),
+    ];
+    const slots = pairSlots(cards, { contentOnBack: true });
+    expect(slots).toHaveLength(2);
+    expect(slots[0]!.front.pagination?.page).toBe(1);
+    expect(slots[0]!.back?.pagination?.page).toBe(2);
+    expect(slots[1]!.front.pagination?.page).toBe(3);
+    expect(slots[1]!.back).toBeUndefined();
+  });
+
+  test("single 4-page card produces two paired slots", () => {
+    const card = itemCardFactory.build();
+    const cards = [
+      physical(card, 1, 4),
+      physical(card, 2, 4),
+      physical(card, 3, 4),
+      physical(card, 4, 4),
+    ];
+    const slots = pairSlots(cards, { contentOnBack: true });
+    expect(slots).toHaveLength(2);
+    expect(slots[0]!.front.pagination?.page).toBe(1);
+    expect(slots[0]!.back?.pagination?.page).toBe(2);
+    expect(slots[1]!.front.pagination?.page).toBe(3);
+    expect(slots[1]!.back?.pagination?.page).toBe(4);
+  });
+
+  test("two distinct 1-page cards stay unpaired", () => {
+    const cardA = itemCardFactory.build();
+    const cardB = itemCardFactory.build();
+    const slots = pairSlots([physical(cardA), physical(cardB)], {
+      contentOnBack: true,
+    });
+    expect(slots).toHaveLength(2);
+    expect(slots[0]!.front.card).toBe(cardA);
+    expect(slots[0]!.back).toBeUndefined();
+    expect(slots[1]!.front.card).toBe(cardB);
+    expect(slots[1]!.back).toBeUndefined();
+  });
+
+  test("two consecutive 2-page cards each pair within their own card", () => {
+    const cardA = itemCardFactory.build();
+    const cardB = itemCardFactory.build();
+    const cards = [
+      physical(cardA, 1, 2),
+      physical(cardA, 2, 2),
+      physical(cardB, 1, 2),
+      physical(cardB, 2, 2),
+    ];
+    const slots = pairSlots(cards, { contentOnBack: true });
+    expect(slots).toHaveLength(2);
+    expect(slots[0]!.front.card).toBe(cardA);
+    expect(slots[0]!.back?.card).toBe(cardA);
+    expect(slots[1]!.front.card).toBe(cardB);
+    expect(slots[1]!.back?.card).toBe(cardB);
+  });
+});
+```
+
+- [ ] **Step 1.2: Run the test, confirm it fails**
+
+Run: `npm test -- src/cards/pairSlots.test.ts`
+
+Expected: FAIL — `pairSlots` is not defined / module not found.
+
+- [ ] **Step 1.3: Implement `pairSlots`**
+
+Create `src/cards/pairSlots.ts`:
+
+```ts
+import type { PhysicalCard } from "./expandCard";
+
+export type PrintSlot = {
+  front: PhysicalCard;
+  back?: PhysicalCard;
+};
+
+// Assumes consecutive PhysicalCards with matching card.id are pages of the
+// same card in order — the invariant established by useExpandedCards.
+export function pairSlots(
+  cards: PhysicalCard[],
+  opts: { contentOnBack: boolean },
+): PrintSlot[] {
+  if (!opts.contentOnBack) return cards.map((front) => ({ front }));
+
+  const slots: PrintSlot[] = [];
+  for (let i = 0; i < cards.length; i++) {
+    const front = cards[i]!;
+    const next = cards[i + 1];
+    if (next && next.card.id === front.card.id) {
+      slots.push({ front, back: next });
+      i++;
+    } else {
+      slots.push({ front });
+    }
+  }
+  return slots;
+}
+```
+
+- [ ] **Step 1.4: Run the test, confirm it passes**
+
+Run: `npm test -- src/cards/pairSlots.test.ts`
+
+Expected: PASS, all 8 cases green.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/cards/pairSlots.ts src/cards/pairSlots.test.ts
+git commit -m "feat(print): add pairSlots for grouping consecutive card pages"
+```
+
+---
+
+## Task 2: PrintView refactor to PrintSlot pipeline (regression-safe, no behavior change)
+
+This task changes the data the front/back render code consumes from
+`PhysicalCard[]` to `PrintSlot[]`, and adds the `slot.back ? <Card> : <CardBack>`
+branch. The wiring uses a hardcoded `contentOnBack: false` so observable
+behavior is identical — every existing test must still pass.
+
+**Files:**
+- Modify: `src/views/PrintView.tsx`
+
+- [ ] **Step 2.1: Update imports**
+
+In `src/views/PrintView.tsx`, replace the existing `import type { PhysicalCard }` line with the `pairSlots` import. The `PhysicalCard` type stops being referenced directly — TypeScript infers it through `PrintSlot`.
+
+Change:
+```ts
+import type { PhysicalCard } from "../cards/expandCard";
+```
+to:
+```ts
+import { pairSlots, type PrintSlot } from "../cards/pairSlots";
+```
+
+- [ ] **Step 2.2: Update the top-level `getBackContentFor` helper**
+
+Replace the existing helper near the top of the file:
+
+```ts
+const getBackContentFor = (entry: PhysicalCard, perPage: CardsPerPage) => (
+  <CardBack card={entry.card} cardsPerPage={perPage} />
+);
+```
+
+with:
+
+```ts
+const getBackContentFor = (slot: PrintSlot, perPage: CardsPerPage) =>
+  slot.back ? (
+    <Card
+      card={slot.back.card}
+      cardsPerPage={perPage}
+      bodyOverride={slot.back.bodyChunk}
+      pagination={slot.back.pagination}
+    />
+  ) : (
+    <CardBack card={slot.front.card} cardsPerPage={perPage} />
+  );
+```
+
+- [ ] **Step 2.3: Add `printSlots` derivation in the component body**
+
+Inside `PrintView`, after the existing `const { physicalCards } = useExpandedCards(printable, perPage);` line, add:
+
+```ts
+const printSlots = pairSlots(physicalCards, { contentOnBack: false });
+```
+
+(The `false` is a placeholder — Task 4 wires the real toggle.)
+
+- [ ] **Step 2.4: Switch chunking to operate on slots**
+
+Replace:
+```ts
+const pages = physicalCards.length === 0 ? [] : chunk(physicalCards, perPage);
+```
+with:
+```ts
+const pages = printSlots.length === 0 ? [] : chunk(printSlots, perPage);
+```
+
+- [ ] **Step 2.5: Update the page-render loop to consume slots**
+
+Inside `pages.map((pageCards) => { ... })`, rename `pageCards` to `pageSlots` and update the page key + slot rendering. The whole block becomes:
+
+```tsx
+{pages.map((pageSlots) => {
+  const pageKey = `${pageSlots[0]?.front.card.id ?? "empty"}-${pageSlots[0]?.front.pagination?.page ?? 0}`;
+  return (
+    <Fragment key={`page-${pageKey}`}>
+      <div
+        data-testid="page"
+        data-page-side="front"
+        className={`${styles.page} ${perPage === 4 ? styles.perPage4 : styles.perPage2}`}
+      >
+        {pageSlots.map((slot) => (
+          <div
+            key={`${slot.front.card.id}-${slot.front.pagination?.page ?? 0}`}
+            className={styles.slot}
+          >
+            <Card
+              card={slot.front.card}
+              cardsPerPage={perPage}
+              bodyOverride={slot.front.bodyChunk}
+              pagination={slot.front.pagination}
+            />
+          </div>
+        ))}
+      </div>
+      {printBacks && (
+        <div
+          data-testid="page"
+          data-page-side="back"
+          className={`${styles.page} ${perPage === 4 ? styles.perPage4 : styles.perPage2}`}
+        >
+          {imposeBackPage(pageSlots, perPage, COLS).map((slot, slotIndex) => {
+            const slotKey = slot
+              ? `${slot.front.card.id}-${slot.front.pagination?.page ?? 0}`
+              : `${pageKey}-empty-${slotIndex}`;
+            return (
+              <div key={`back-${slotKey}`} className={styles.slot}>
+                {slot ? getBackContentFor(slot, perPage) : null}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </Fragment>
+  );
+})}
+```
+
+- [ ] **Step 2.6: Run all tests, confirm no regressions**
+
+Run: `npm test -- src/views/PrintView.test.tsx src/cards/pairSlots.test.ts`
+
+Expected: PASS — every existing PrintView test continues to pass, plus the pairSlots tests from Task 1. Because `contentOnBack: false` is hardcoded, no slot has a `back`, so behavior is byte-for-byte unchanged from before this task.
+
+- [ ] **Step 2.7: Run typecheck and biome**
+
+Run: `npm run build`
+
+Expected: PASS — no TypeScript errors. (Biome runs in the pre-commit hook; if it reformats anything in the next step, accept the reformatting.)
+
+- [ ] **Step 2.8: Commit**
+
+```bash
+git add src/views/PrintView.tsx
+git commit -m "refactor(print): consume PrintSlot[] in PrintView pipeline"
+```
+
+---
+
+## Task 3: Sub-toggle UI with disabled state (TDD)
+
+This task adds the visible sub-toggle, helptext, CSS, and the disabled-state test. The toggle's value is held in component state but is *not yet wired* into `pairSlots` — that happens in Task 4. So adding the toggle here changes no behavior on paper output.
+
+**Files:**
+- Modify: `src/views/PrintView.test.tsx`
+- Modify: `src/views/PrintView.tsx`
+- Modify: `src/views/PrintView.module.css`
+
+- [ ] **Step 3.1: Write the failing tests**
+
+Append these tests inside the `describe("<PrintView>")` block in `src/views/PrintView.test.tsx`:
+
+```tsx
+test("renders a 'Continue content on back' switch", async () => {
+  const cards = makeCardRow.buildList(2);
+  server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json(cards)));
+  render(wrap(<PrintView deckId="d1" />));
+  await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
+  expect(
+    screen.getByRole("switch", { name: /continue content on back/i }),
+  ).toBeInTheDocument();
+});
+
+test("'Continue content on back' is disabled when 'Print backs' is off", async () => {
+  const cards = makeCardRow.buildList(2);
+  server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json(cards)));
+  render(wrap(<PrintView deckId="d1" />));
+  await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
+  const continueSwitch = screen.getByRole("switch", {
+    name: /continue content on back/i,
+  });
+  expect(continueSwitch).toBeDisabled();
+  await userEvent.click(screen.getByRole("switch", { name: /print backs/i }));
+  expect(continueSwitch).not.toBeDisabled();
+});
+
+test("sub-toggle helptext shows the disabled-state hint only when 'Print backs' is off", async () => {
+  const cards = makeCardRow.buildList(2);
+  server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json(cards)));
+  render(wrap(<PrintView deckId="d1" />));
+  await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
+  expect(
+    screen.getByText(/Print page 2 of a multi-page card on the back of page 1/i),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText(/Enable Print backs to use this option/i),
+  ).toBeInTheDocument();
+  await userEvent.click(screen.getByRole("switch", { name: /print backs/i }));
+  expect(
+    screen.queryByText(/Enable Print backs to use this option/i),
+  ).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 3.2: Run the new tests, confirm they fail**
+
+Run: `npm test -- src/views/PrintView.test.tsx`
+
+Expected: FAIL — the "Continue content on back" switch and helptext aren't rendered yet.
+
+- [ ] **Step 3.3: Add `contentOnBack` state and the sub-toggle markup**
+
+In `src/views/PrintView.tsx`:
+
+After the existing `const [printBacks, setPrintBacks] = useState(false);`, add:
+```ts
+const [contentOnBack, setContentOnBack] = useState(false);
+```
+
+Replace the existing `<div className={styles.switchBlock}>` block in the sidebar with:
+
+```tsx
+<div className={styles.switchBlock}>
+  <Switch isSelected={printBacks} onChange={setPrintBacks}>
+    Print backs
+  </Switch>
+  <div className={styles.helptext}>
+    <p>Adds a second page of card backs for double-sided printing.</p>
+    {printBacks && (
+      <p>
+        In the print dialog, choose <em>Flip on {flipEdge}</em> (sometimes labelled{" "}
+        <em>{flipLabel}</em>).
+      </p>
+    )}
+  </div>
+  <div className={styles.subSwitch}>
+    <Switch
+      isSelected={contentOnBack}
+      onChange={setContentOnBack}
+      isDisabled={!printBacks}
+    >
+      Continue content on back
+    </Switch>
+    <div className={styles.helptext}>
+      <p>
+        Print page 2 of a multi-page card on the back of page 1, instead of using
+        a separate slot.
+      </p>
+      {!printBacks && <p>Enable Print backs to use this option.</p>}
+    </div>
+  </div>
+</div>
+```
+
+- [ ] **Step 3.4: Add `.subSwitch` CSS**
+
+Append to `src/views/PrintView.module.css` inside the screen-only UI section (after the existing `.switchBlock` and `.helptext` rules, before the `.divider` rule):
+
+```css
+.subSwitch {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding-left: var(--space-4);
+}
+```
+
+- [ ] **Step 3.5: Run the tests, confirm they pass**
+
+Run: `npm test -- src/views/PrintView.test.tsx`
+
+Expected: PASS — all three new tests green; all pre-existing PrintView tests still green.
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add src/views/PrintView.tsx src/views/PrintView.module.css src/views/PrintView.test.tsx
+git commit -m "feat(print): add 'Continue content on back' sub-toggle with disabled state"
+```
+
+---
+
+## Task 4: Wire `contentOnBack` and verify paired-flow behavior (TDD)
+
+This is the task where the toggle becomes load-bearing. Tests for the actual paired flow come first; then the one-line wiring change in `pairSlots`'s argument flips them green.
+
+**Files:**
+- Modify: `src/views/PrintView.test.tsx`
+- Modify: `src/views/PrintView.tsx`
+
+- [ ] **Step 4.1: Write the failing paired-flow tests**
+
+Append these tests inside the `describe("<PrintView>")` block in `src/views/PrintView.test.tsx`:
+
+```tsx
+test("places page-2 on the back of page-1's slot when both toggles are on (mixed deck)", async () => {
+  const twoPager = makeCardRow.build({ body: "TWO" });
+  const onePager = makeCardRow.build({ body: "ONE" });
+  vi.spyOn(paginateModule, "paginateBody").mockImplementation(({ body }) =>
+    body === "TWO" ? ["TWO-pg1", "TWO-pg2"] : [body],
+  );
+  server.use(
+    http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json([twoPager, onePager])),
+  );
+  render(wrap(<PrintView deckId="d1" />));
+  await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
+  await userEvent.click(screen.getByRole("switch", { name: /print backs/i }));
+  await userEvent.click(
+    screen.getByRole("switch", { name: /continue content on back/i }),
+  );
+  // Front page: two slots — twoPager pg1 (slot 0), onePager (slot 1).
+  // Back imposition: back-slot 0 = back-of front-slot-1 (onePager → icon),
+  //                  back-slot 1 = back-of front-slot-0 (twoPager pg2).
+  const backPage = document.querySelector('[data-page-side="back"]') as HTMLElement;
+  expect(backPage).not.toBeNull();
+  const slots = Array.from(backPage.children) as HTMLElement[];
+  expect(slots).toHaveLength(2);
+  expect(slots[0]!.querySelector('[data-role="card-back-root"]')).not.toBeNull();
+  expect(slots[1]!.querySelector('[data-role="card-body"]')).toHaveTextContent("TWO-pg2");
+});
+
+test("4-page card paired flow at 4-up", async () => {
+  const card = makeCardRow.build({ body: "X" });
+  vi.spyOn(paginateModule, "paginateBody").mockImplementation(({ body }) =>
+    body === "X" ? ["pg1", "pg2", "pg3", "pg4"] : [body],
+  );
+  server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json([card])));
+  render(wrap(<PrintView deckId="d1" />));
+  await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
+  await userEvent.click(screen.getByRole("switch", { name: /print backs/i }));
+  await userEvent.click(
+    screen.getByRole("switch", { name: /continue content on back/i }),
+  );
+  // Front: slot 0 = pg1, slot 1 = pg3.
+  // Back imposition: back-slot 0 = back-of front-slot-1 (pg4),
+  //                  back-slot 1 = back-of front-slot-0 (pg2).
+  const frontPage = document.querySelector('[data-page-side="front"]') as HTMLElement;
+  const frontSlots = Array.from(frontPage.children) as HTMLElement[];
+  expect(frontSlots[0]!.querySelector('[data-role="card-body"]')).toHaveTextContent("pg1");
+  expect(frontSlots[1]!.querySelector('[data-role="card-body"]')).toHaveTextContent("pg3");
+
+  const backPage = document.querySelector('[data-page-side="back"]') as HTMLElement;
+  const backSlots = Array.from(backPage.children) as HTMLElement[];
+  expect(backSlots[0]!.querySelector('[data-role="card-body"]')).toHaveTextContent("pg4");
+  expect(backSlots[1]!.querySelector('[data-role="card-body"]')).toHaveTextContent("pg2");
+});
+
+test("3-page card paired flow at 4-up — last back slot falls back to icon", async () => {
+  const card = makeCardRow.build({ body: "X" });
+  vi.spyOn(paginateModule, "paginateBody").mockImplementation(({ body }) =>
+    body === "X" ? ["pg1", "pg2", "pg3"] : [body],
+  );
+  server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json([card])));
+  render(wrap(<PrintView deckId="d1" />));
+  await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
+  await userEvent.click(screen.getByRole("switch", { name: /print backs/i }));
+  await userEvent.click(
+    screen.getByRole("switch", { name: /continue content on back/i }),
+  );
+  // Front: slot 0 = pg1, slot 1 = pg3.
+  // Back imposition: back-slot 0 = back-of front-slot-1 (pg3 → no back → icon),
+  //                  back-slot 1 = back-of front-slot-0 (pg2).
+  const backPage = document.querySelector('[data-page-side="back"]') as HTMLElement;
+  const backSlots = Array.from(backPage.children) as HTMLElement[];
+  expect(backSlots[0]!.querySelector('[data-role="card-back-root"]')).not.toBeNull();
+  expect(backSlots[1]!.querySelector('[data-role="card-body"]')).toHaveTextContent("pg2");
+});
+
+test("'Continue content on back' selected state persists across disable/re-enable", async () => {
+  const card = makeCardRow.build({ body: "X" });
+  vi.spyOn(paginateModule, "paginateBody").mockImplementation(({ body }) =>
+    body === "X" ? ["pg1", "pg2"] : [body],
+  );
+  server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json([card])));
+  render(wrap(<PrintView deckId="d1" />));
+  await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
+  const printBacks = screen.getByRole("switch", { name: /print backs/i });
+  const continueOnBack = screen.getByRole("switch", {
+    name: /continue content on back/i,
+  });
+  await userEvent.click(printBacks);
+  await userEvent.click(continueOnBack);
+  expect(continueOnBack).toBeChecked();
+  await userEvent.click(printBacks); // disable backs
+  expect(continueOnBack).toBeDisabled();
+  expect(continueOnBack).toBeChecked(); // selection persists
+  await userEvent.click(printBacks); // re-enable backs
+  expect(continueOnBack).not.toBeDisabled();
+  expect(continueOnBack).toBeChecked();
+  // Paired flow resumes: pg2 lands on the back.
+  const backPage = document.querySelector('[data-page-side="back"]') as HTMLElement;
+  const backSlots = Array.from(backPage.children) as HTMLElement[];
+  expect(backSlots[1]!.querySelector('[data-role="card-body"]')).toHaveTextContent("pg2");
+});
+```
+
+- [ ] **Step 4.2: Run the new tests, confirm they fail**
+
+Run: `npm test -- src/views/PrintView.test.tsx`
+
+Expected: FAIL — the four new tests fail because `pairSlots` is still called with `contentOnBack: false`. The earlier tests still pass.
+
+- [ ] **Step 4.3: Wire the toggle**
+
+In `src/views/PrintView.tsx`, change:
+
+```ts
+const printSlots = pairSlots(physicalCards, { contentOnBack: false });
+```
+to:
+```ts
+const printSlots = pairSlots(physicalCards, {
+  contentOnBack: printBacks && contentOnBack,
+});
+```
+
+The `printBacks &&` guard means the sub-toggle has no effect when "Print backs" is off — see the spec's *Risks / things to watch* for why this guard belongs here.
+
+- [ ] **Step 4.4: Run the full test suite, confirm everything passes**
+
+Run: `npm test`
+
+Expected: PASS — all PrintView tests (existing + new), pairSlots tests, and every other test in the suite green. If any pre-existing test fails, the wiring or refactor introduced a regression — investigate before moving on.
+
+- [ ] **Step 4.5: Run typecheck**
+
+Run: `npm run build`
+
+Expected: PASS — no TypeScript errors.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add src/views/PrintView.tsx src/views/PrintView.test.tsx
+git commit -m "feat(print): print page 2+ on card backs when 'Continue content on back' is on"
+```
+
+---
+
+## Task 5: Manual print verification
+
+CSS testing only confirms the DOM. The actual goal is paper that aligns when duplexed. This task is a manual procedure — there is no automated assertion. Document the result in the PR description (photo, or a one-line "verified on Brother HL-L2350DW, both 4-up and 2-up").
+
+**Files:** none (manual procedure)
+
+- [ ] **Step 5.1: Start the dev server**
+
+Run: `npm run dev`
+
+Open the printed app in a browser; sign in if needed; navigate to a deck.
+
+- [ ] **Step 5.2: Build a deck containing one 2-page card and verify**
+
+Add an item or spell card to the deck whose body is long enough to overflow a single physical page (use `src/views/EditorView.tsx`, paste roughly two paragraphs of body content). Open the deck's print view, set 4-up portrait, toggle both "Print backs" and "Continue content on back" on. The screen preview should show one front page with one slot and one back page with one slot containing page 2's content.
+
+Print to real paper, duplex long-edge.
+
+Expected on paper: a single sheet, page 1 of the card on the front face, page 2 on the back face, oriented so flipping the card the long way reveals page 2 right-side-up.
+
+- [ ] **Step 5.3: Verify the mixed-deck case**
+
+Add a second short (1-page) card to the same deck. Reload the print view. Screen preview should show one front page with two slots (the 2-pager's pg1 and the 1-pager) and one back page with two slots (the 2-pager's pg2 in the slot mirroring its pg1, and an icon back in the slot mirroring the 1-pager).
+
+Print, duplex. Verify alignment within ~1 mm.
+
+- [ ] **Step 5.4: Verify the 3-page card case**
+
+Replace the 2-pager with a longer card whose body produces 3 physical pages. Screen preview should show one front page with two slots (pg1 and pg3) and one back page with pg2 in the slot mirroring pg1 and an icon back in the slot mirroring pg3.
+
+Print, duplex. Confirm the 3-page card is printed across two physical card slots: one double-sided (pg1/pg2), one with pg3 on the front and the icon on the back.
+
+- [ ] **Step 5.5: Document in the PR description**
+
+When opening the PR, include:
+- Hardware tested (printer model, paper size).
+- Screenshot or photo of one verification case.
+- Any printer-specific quirks (e.g., minor margin shifts).
+
+If a duplex printer isn't available, single-sided front + single-sided back overlaid against a window is an acceptable proxy. State this explicitly in the PR description.
+
+---
+
+## Notes for the implementer
+
+- **Don't reach for `data-card-id` on paired slots.** Front and back of a paired slot share `card.id`, so reading `data-card-id` to disambiguate which page landed where will mislead. The test plan uses rendered body text inside `[data-role="card-body"]` for paired-flow assertions — follow the same approach if you add cases.
+- **Footer "Card 2 of 2" stays on a back-rendered page.** This is intentional (see the spec's *Risks*). Don't suppress it on the back face — that would require new props on `<Card>` and is explicitly out of scope.
+- **Imposition is content-agnostic.** `imposeBackPage` and `backSlotIndex` are not modified. If a back slot prints in the wrong location, the bug is in `pairSlots` or `getBackContentFor`, not the imposition helper.
+- **`isDisabled` on `Switch` is a passthrough.** `src/lib/ui/Switch.tsx` simply forwards props to react-aria-components' `Switch`, which handles `aria-disabled` automatically.
+- **Biome is authoritative.** If the pre-commit hook reformats, accept the reformatting and move on.

--- a/docs/superpowers/specs/2026-05-08-print-content-on-back-design.md
+++ b/docs/superpowers/specs/2026-05-08-print-content-on-back-design.md
@@ -1,0 +1,318 @@
+# Continuation cards on print backs
+
+## Problem
+
+`PrintView` already supports a "Print backs" toggle that adds an icon-only back
+page after each front page (see
+`2026-05-06-print-backs-design.md`). For multi-page cards (cards whose body
+overflows a single physical page), the existing flow lays each physical page as
+its own front-side card and gives every one an icon back. A user with a duplex
+printer wants to combine the two physical pages of a 2-page card into a single
+double-sided card — page 1 on the front, page 2 on the back, cut once. The
+2026-05-06 spec's "Forward compatibility" section explicitly anticipated this
+follow-up; this spec is that follow-up.
+
+## Goals
+
+- A second toggle, "Continue on back", lives directly under "Print backs" in
+  `PrintView`'s sidebar. Default off. Disabled when "Print backs" is off.
+- When both toggles are on, multi-page cards continue onto the back of their
+  first slot instead of taking a separate front slot. A 2-page card occupies
+  one physical slot; a 3-page card occupies two; a 4-page card occupies two; in
+  general, physical pages flow front/back/front/back through a per-card slot
+  sequence, and any unfilled trailing back falls back to the existing icon
+  back.
+- 1-page cards mixed with multi-page cards on the same sheet keep the icon on
+  their backs.
+- Sheet imposition (horizontal mirror for duplex flip) is unchanged. The
+  geometry constraint is independent of what's on the back.
+- "Print backs" off → no behavior change. "Print backs" on, "Continue on back"
+  off → existing icon-only back behavior, regression-tested.
+
+## Non-goals
+
+- **Per-card overrides** for back content (custom icon, custom back text).
+- **Smarter sheet packing** — e.g., grouping multi-page cards together to avoid
+  mixed sheets. Cards stay in deck order.
+- **Changes to the imposition algorithm.** `imposeBackPage` and `backSlotIndex`
+  are content-agnostic and stay untouched.
+- **Persisting toggle state** across visits. Same precedent as "Print backs":
+  print-time choice, not a deck attribute.
+- **Pagination changes.** `paginate.ts`, `expandCard.ts`, and the measurer are
+  not modified.
+- **Suppressing the "Card 2 of 2" footer** on a back-rendered continuation
+  page. The same `<Card>` component renders front and back content, and the
+  footer continues to display. See "Risks / things to watch."
+
+## Approach
+
+Introduce a thin layout-layer abstraction — a **print slot** — that pairs a
+front `PhysicalCard` with an optional back `PhysicalCard`. The pairing function
+is pure and unit-tested in isolation. Everything below the slot layer
+(pagination, body chunking, measurement) is unchanged. Above it, `PrintView`
+consumes slots instead of `PhysicalCard`s, and the existing `getBackContentFor`
+seam grows a tiny branch: render `<Card>` when the slot has a back, otherwise
+render the existing `<CardBack>` icon fallback.
+
+Three units of work:
+
+1. A pure `pairSlots(physicalCards, { contentOnBack })` function that walks
+   the `PhysicalCard` list and groups consecutive entries belonging to the
+   same card, two at a time, into `PrintSlot { front, back? }`. With
+   `contentOnBack: false`, every `PhysicalCard` becomes its own front-only
+   slot — a no-op transformation that lets `PrintView` use the same data
+   shape regardless of toggle state.
+
+2. `PrintView` state additions: a new `contentOnBack` boolean switch and one
+   call to `pairSlots` between `useExpandedCards` and the existing chunking.
+
+3. The existing `getBackContentFor(entry, perPage)` seam (introduced as a
+   forward-compat seam in the 2026-05-06 spec) updates from
+   `PhysicalCard` → `PrintSlot`. When the slot has a `back`, it renders
+   `<Card>` with that page's body chunk and pagination; otherwise it falls
+   back to `<CardBack>`.
+
+## Architecture
+
+### `pairSlots`
+
+New: `src/cards/pairSlots.ts` + `src/cards/pairSlots.test.ts`. Sits next to
+`expandCard.ts` because it operates on its output.
+
+```ts
+import type { PhysicalCard } from "./expandCard";
+
+export type PrintSlot = {
+  front: PhysicalCard;
+  back?: PhysicalCard;
+};
+
+export function pairSlots(
+  cards: PhysicalCard[],
+  opts: { contentOnBack: boolean },
+): PrintSlot[] {
+  if (!opts.contentOnBack) return cards.map((front) => ({ front }));
+
+  const slots: PrintSlot[] = [];
+  for (let i = 0; i < cards.length; i++) {
+    const front = cards[i]!;
+    const next = cards[i + 1];
+    if (next && next.card.id === front.card.id) {
+      slots.push({ front, back: next });
+      i++; // consume the paired entry
+    } else {
+      slots.push({ front });
+    }
+  }
+  return slots;
+}
+```
+
+Properties this relies on:
+
+- Pairing happens only between **consecutive** `PhysicalCard`s with the
+  **same `card.id`**. `useExpandedCards` runs `expandCard` per card and
+  concatenates; consecutive entries with matching ids are guaranteed to be
+  pages 1, 2, 3 of the same card in order.
+- When `contentOnBack` is off, the function is a no-op `map`. The downstream
+  pipeline does not need to branch.
+- Output array length is between `ceil(N/2)` and `N` for any one card's
+  contribution (depending on whether continuations exist).
+
+### `PrintView` changes
+
+In `src/views/PrintView.tsx`:
+
+1. Add `const [contentOnBack, setContentOnBack] = useState(false)`.
+2. Compute `printSlots`:
+   ```ts
+   const physicalCards = useExpandedCards(printable, perPage).physicalCards;
+   const printSlots = pairSlots(physicalCards, {
+     contentOnBack: printBacks && contentOnBack,
+   });
+   ```
+   The `printBacks &&` guard means the toggle has no effect when "Print backs"
+   is off. With backs off, no back page is emitted anyway, so pairing would be
+   invisible — but unpairing keeps the slot count consistent with what the
+   user sees and avoids surprising behavior if they toggle backs back on.
+3. Chunk `printSlots` (not `physicalCards`) into pages of `perPage`:
+   ```ts
+   const pages = printSlots.length === 0 ? [] : chunk(printSlots, perPage);
+   ```
+4. Front-page render: each slot renders `slot.front` through the existing
+   `<Card>` invocation. The page key derivation continues to use the first
+   slot's `front.card.id` and `front.pagination?.page`.
+5. Back-page render: `imposeBackPage(pageSlots, perPage, COLS)` — the helper
+   is generic (`<T>`), so this is just a type-level change. Each imposed
+   entry is a `PrintSlot | undefined`.
+6. `getBackContentFor` updates:
+   ```ts
+   const getBackContentFor = (slot: PrintSlot, perPage: CardsPerPage) =>
+     slot.back ? (
+       <Card
+         card={slot.back.card}
+         cardsPerPage={perPage}
+         bodyOverride={slot.back.bodyChunk}
+         pagination={slot.back.pagination}
+       />
+     ) : (
+       <CardBack card={slot.front.card} cardsPerPage={perPage} />
+     );
+   ```
+7. Sidebar markup gains a sub-toggle. `Switch` accepts `isDisabled` (passes
+   through to `react-aria-components`'s `Switch`):
+   ```tsx
+   <div className={styles.switchBlock}>
+     <Switch isSelected={printBacks} onChange={setPrintBacks}>
+       Print backs
+     </Switch>
+     <div className={styles.helptext}>
+       <p>Adds a second page of card backs for double-sided printing.</p>
+       {printBacks && (
+         <p>
+           In the print dialog, choose <em>Flip on {flipEdge}</em>{" "}
+           (sometimes labelled <em>{flipLabel}</em>).
+         </p>
+       )}
+     </div>
+     <Switch
+       isSelected={contentOnBack}
+       onChange={setContentOnBack}
+       isDisabled={!printBacks}
+     >
+       Continue on back
+     </Switch>
+     <div className={styles.helptext}>
+       <p>Multi-page cards continue onto the back instead of a new sheet.</p>
+     </div>
+   </div>
+   ```
+   The exact CSS structure (indentation, spacing, divider treatment for the
+   nested toggle) is at the implementer's discretion provided it reads as a
+   sub-option of "Print backs". Defer to existing `PrintView.module.css`
+   conventions.
+
+### Imposition unchanged
+
+`imposeBackPage` already accepts `T[]`. Switching from `PhysicalCard[]` to
+`PrintSlot[]` is a type-level change at the call site only. The helper has no
+knowledge of what's on the back, only of slot positions.
+
+### `data-page-side` and other test hooks
+
+The existing `data-page-side="back"` attribute and `data-role="card-back-root"`
+selector continue to work. Tests already disambiguate front/back pages with
+these.
+
+## Tests
+
+### `pairSlots.test.ts` (new)
+
+Inputs are constructed with the existing factories where possible, otherwise
+hand-built `PhysicalCard` literals. The factory pattern preference (no
+unnecessary overrides) applies.
+
+- `contentOnBack: false` → maps every `PhysicalCard` to a front-only slot;
+  output length equals input length; no slot has a `back` property defined.
+- Empty input → empty output, both modes.
+- `contentOnBack: true`, single 1-page card (no `pagination` field) → one
+  slot, `back` undefined.
+- `contentOnBack: true`, single 2-page card (`pagination = {page:1, total:2}`
+  then `{page:2, total:2}`) → one slot, `front.pagination.page === 1`,
+  `back!.pagination.page === 2`.
+- `contentOnBack: true`, single 3-page card → two slots: (pg1/pg2),
+  (pg3/no back).
+- `contentOnBack: true`, single 4-page card → two slots: (pg1/pg2), (pg3/pg4).
+- `contentOnBack: true`, two distinct 1-page cards → two slots, neither
+  paired (different `card.id`).
+- `contentOnBack: true`, two consecutive 2-page cards (A then B) → two
+  slots: (A.pg1/A.pg2), (B.pg1/B.pg2). Confirms only same-id consecutive
+  pages pair (no cross-card pairing).
+
+### `PrintView.test.tsx` (extended)
+
+- "Continue on back" switch is rendered and `aria-disabled` when "Print
+  backs" is off. Toggling "Print backs" on enables it.
+- "Print backs" on, "Continue on back" off → existing icon-back behavior.
+  Regression guard: page count and back-page contents match the existing
+  print-backs assertions byte-for-byte.
+- Both toggles on, deck = one 2-page card + one 1-page card, 4-up layout:
+  - One front page with two filled slots in deck order: card1 page 1,
+    card2 page 1.
+  - One back page imposed by horizontal mirror. The slot mirroring card1
+    contains card1 page 2's body content (assert by reading `data-role=
+    "card-body"` text). The slot mirroring card2 contains an icon-back
+    (`data-role="card-back-root"`).
+- Both toggles on, deck = one 4-page card, 4-up layout:
+  - One front page with two filled slots: pg1 and pg3 (in row-major slot
+    order).
+  - One back page with the mirrored two slots filled: pg2 (mirroring pg1's
+    slot), pg4 (mirroring pg3's slot). Read body text to assert which page
+    landed where.
+- Both toggles on, deck = one 3-page card, 4-up layout:
+  - One front page with two filled slots: pg1 and pg3.
+  - One back page: pg2 in the slot mirroring pg1; the slot mirroring pg3
+    renders an icon-back.
+- "Continue on back" helptext renders ("Multi-page cards continue onto the
+  back instead of a new sheet"). Existing flip-edge tip continues to render
+  under the same conditions as today (i.e., when "Print backs" is on).
+
+### Unchanged test files
+
+- `Card.test.tsx` — the same `<Card>` renders front and back content; no new
+  behavior to test.
+- `CardBack.test.tsx` — used as the fallback for unfilled backs; no change.
+- `backImposition.test.ts` — helper is generic and content-agnostic.
+
+## Manual print verification (mandatory before declaring done)
+
+CSS testing only confirms the DOM. The actual goal is paper that aligns when
+duplexed. Before merging:
+
+1. Build a deck containing one 2-page card. Print 4-up portrait with both
+   toggles on, duplex long-edge.
+   - Expected: a single sheet, front and back. After cutting, page 1 of the
+     card on the front face, page 2 on the back face, oriented correctly when
+     the user flips the card.
+2. Build a deck mixing one 2-page card and one 1-page card. Print 4-up
+   portrait, both toggles on, duplex.
+   - Expected: 2-page card lands as a single double-sided slot; 1-page card
+     has an icon back; both align within ~1 mm.
+3. Build a deck with one 3-page card. Print 4-up portrait, both toggles on,
+   duplex.
+   - Expected: two slots — slot 1 is double-sided (pg1 / pg2), slot 2 has
+     pg3 on the front and the icon on the back.
+
+If a home printer isn't available, single-sided front + single-sided back
+prints overlaid against a window are an acceptable proxy. Document the result
+in the PR description.
+
+## Risks / things to watch
+
+- **Footer "Card 2 of 2" on a back-rendered page.** A user holding the cut
+  card may find "Card 2 of 2" redundant on the back face — they can see it's
+  the back. Kept by default because (a) it confirms physical orientation
+  matches expectation, and (b) the same `<Card>` component renders front and
+  back, so suppressing it would require a new prop and CSS change. Revisit
+  only if multiple users surface it.
+- **Mixed sheets look uneven.** A sheet with one 2-page card and three 1-page
+  cards has one printed-content back and three icon backs side by side. This
+  is correct but visually mixed. Auto-grouping multi-page cards is out of
+  scope; users who care can reorder their deck manually.
+- **Same-card pairing assumes `expandCard` ordering.** `pairSlots` relies on
+  consecutive `PhysicalCard`s with matching `card.id` being consecutive pages
+  of the same card. `useExpandedCards` runs `expandCard` per-card and
+  concatenates, preserving this. If the pipeline ever reorders or
+  interleaves entries, pairing breaks silently. The two-2-page-cards test
+  case guards this.
+- **Disabled state vs. selected state.** The sub-toggle is `isDisabled` when
+  "Print backs" is off, but its `isSelected` value persists. If the user
+  toggles backs back on, paired flow resumes from the previously-selected
+  state. This matches user expectation; assertion in the disabled-gating
+  test confirms it.
+- **The `printBacks &&` guard inside `pairSlots`'s argument.** It's tempting
+  to drop the guard and always honor `contentOnBack`. Don't — without the
+  guard, toggling "Continue on back" while "Print backs" is off changes the
+  front page's slot count (multi-page cards collapse), which is a confusing
+  UI state for a toggle whose effect should be invisible until backs are
+  enabled.

--- a/docs/superpowers/specs/2026-05-08-print-content-on-back-design.md
+++ b/docs/superpowers/specs/2026-05-08-print-content-on-back-design.md
@@ -12,10 +12,17 @@ double-sided card — page 1 on the front, page 2 on the back, cut once. The
 2026-05-06 spec's "Forward compatibility" section explicitly anticipated this
 follow-up; this spec is that follow-up.
 
+**Canonical names used throughout this spec:** the user-facing toggle label is
+"Continue content on back". The internal feature is *content-on-back*. The
+boolean state is `contentOnBack`. Use these consistently in prose and code.
+
 ## Goals
 
-- A second toggle, "Continue on back", lives directly under "Print backs" in
-  `PrintView`'s sidebar. Default off. Disabled when "Print backs" is off.
+- A second toggle, "Continue content on back", lives directly under "Print
+  backs" in `PrintView`'s sidebar, visually nested as a sub-option (see
+  *Sub-toggle markup and styling* below). Default off. Disabled (not hidden)
+  when "Print backs" is off. Keyboard tab order places it immediately after
+  "Print backs" and before the divider.
 - When both toggles are on, multi-page cards continue onto the back of their
   first slot instead of taking a separate front slot. A 2-page card occupies
   one physical slot; a 3-page card occupies two; a 4-page card occupies two; in
@@ -26,8 +33,8 @@ follow-up; this spec is that follow-up.
   their backs.
 - Sheet imposition (horizontal mirror for duplex flip) is unchanged. The
   geometry constraint is independent of what's on the back.
-- "Print backs" off → no behavior change. "Print backs" on, "Continue on back"
-  off → existing icon-only back behavior, regression-tested.
+- "Print backs" off → no behavior change. "Print backs" on, "Continue content
+  on back" off → existing icon-only back behavior, regression-tested.
 
 ## Non-goals
 
@@ -87,6 +94,8 @@ export type PrintSlot = {
   back?: PhysicalCard;
 };
 
+// Assumes consecutive PhysicalCards with matching card.id are pages of the
+// same card in order — the invariant established by useExpandedCards.
 export function pairSlots(
   cards: PhysicalCard[],
   opts: { contentOnBack: boolean },
@@ -159,38 +168,70 @@ In `src/views/PrintView.tsx`:
        <CardBack card={slot.front.card} cardsPerPage={perPage} />
      );
    ```
-7. Sidebar markup gains a sub-toggle. `Switch` accepts `isDisabled` (passes
-   through to `react-aria-components`'s `Switch`):
-   ```tsx
-   <div className={styles.switchBlock}>
-     <Switch isSelected={printBacks} onChange={setPrintBacks}>
-       Print backs
-     </Switch>
-     <div className={styles.helptext}>
-       <p>Adds a second page of card backs for double-sided printing.</p>
-       {printBacks && (
-         <p>
-           In the print dialog, choose <em>Flip on {flipEdge}</em>{" "}
-           (sometimes labelled <em>{flipLabel}</em>).
-         </p>
-       )}
-     </div>
-     <Switch
-       isSelected={contentOnBack}
-       onChange={setContentOnBack}
-       isDisabled={!printBacks}
-     >
-       Continue on back
-     </Switch>
-     <div className={styles.helptext}>
-       <p>Multi-page cards continue onto the back instead of a new sheet.</p>
-     </div>
-   </div>
-   ```
-   The exact CSS structure (indentation, spacing, divider treatment for the
-   nested toggle) is at the implementer's discretion provided it reads as a
-   sub-option of "Print backs". Defer to existing `PrintView.module.css`
-   conventions.
+7. Sidebar markup gains a sub-toggle. See *Sub-toggle markup and styling*
+   below for the locked-in structure and CSS.
+
+### Sub-toggle markup and styling
+
+The sub-toggle and its helptext sit inside a child `<div>` indented from the
+parent. This is required for the nesting to read as parent/child rather than
+peer/peer; without it, the existing `gap: var(--space-2)` on `.switchBlock`
+makes four siblings look identical in weight.
+
+Markup:
+
+```tsx
+<div className={styles.switchBlock}>
+  <Switch isSelected={printBacks} onChange={setPrintBacks}>
+    Print backs
+  </Switch>
+  <div className={styles.helptext}>
+    <p>Adds a second page of card backs for double-sided printing.</p>
+    {printBacks && (
+      <p>
+        In the print dialog, choose <em>Flip on {flipEdge}</em>{" "}
+        (sometimes labelled <em>{flipLabel}</em>).
+      </p>
+    )}
+  </div>
+  <div className={styles.subSwitch}>
+    <Switch
+      isSelected={contentOnBack}
+      onChange={setContentOnBack}
+      isDisabled={!printBacks}
+    >
+      Continue content on back
+    </Switch>
+    <div className={styles.helptext}>
+      <p>
+        Print page 2 of a multi-page card on the back of page 1, instead of
+        using a separate slot.
+      </p>
+      {!printBacks && <p>Enable Print backs to use this option.</p>}
+    </div>
+  </div>
+</div>
+```
+
+CSS (add to `PrintView.module.css`):
+
+```css
+.subSwitch {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding-left: var(--space-4);
+}
+```
+
+Rationale for `--space-4`: matches the sidebar's outer padding so the
+sub-block's switch indicator visually aligns to the sidebar's content
+gutter, reading as one level deeper than the parent toggle. The
+helptext-when-disabled line ("Enable Print backs to use this option.") is the
+visible counterpart to the `aria-disabled` state — screen-reader and sighted
+users both get an explanation. It is part of the helptext block so the
+`.helptext p + p` rule already in `PrintView.module.css` gives it the
+correct top margin.
 
 ### Imposition unchanged
 
@@ -208,9 +249,10 @@ these.
 
 ### `pairSlots.test.ts` (new)
 
-Inputs are constructed with the existing factories where possible, otherwise
-hand-built `PhysicalCard` literals. The factory pattern preference (no
-unnecessary overrides) applies.
+Inputs are constructed with the existing card factories from
+`src/cards/factories.ts` and hand-built `PhysicalCard` literals (no
+`expandCard` invocation needed — these are unit tests on `pairSlots` only).
+The factory pattern preference (no unnecessary overrides) applies.
 
 - `contentOnBack: false` → maps every `PhysicalCard` to a front-only slot;
   output length equals input length; no slot has a `back` property defined.
@@ -231,18 +273,36 @@ unnecessary overrides) applies.
 
 ### `PrintView.test.tsx` (extended)
 
-- "Continue on back" switch is rendered and `aria-disabled` when "Print
-  backs" is off. Toggling "Print backs" on enables it.
-- "Print backs" on, "Continue on back" off → existing icon-back behavior.
-  Regression guard: page count and back-page contents match the existing
-  print-backs assertions byte-for-byte.
+**Pagination strategy in tests.** Multi-page card behavior is driven by
+`paginateBody`. Existing tests stub it via `vi.spyOn(paginateModule,
+"paginateBody")` (see the existing pattern in `PrintView.test.tsx`) — reuse
+the same approach for the new cases below rather than passing long `body`
+strings into factories. This keeps the no-unnecessary-overrides rule
+satisfied and isolates layout from real measurement.
+
+**Slot disambiguation.** Existing 4-up imposition tests read `data-card-id`
+to verify mirrored order. With paired slots, that approach breaks: a slot's
+front and back share `card.id`. New cases below disambiguate by reading
+the rendered body text inside `data-role="card-body"`, *not* `data-card-id`.
+
+Cases to add:
+
+- "Continue content on back" switch is rendered and `aria-disabled` when
+  "Print backs" is off. Toggling "Print backs" on enables it.
+- Selected-state persistence: toggle "Print backs" on, toggle "Continue
+  content on back" on, toggle "Print backs" off, toggle "Print backs" back
+  on. The sub-toggle remains selected, and the paired flow resumes (assert
+  via the same body-text mirror check used below).
+- "Print backs" on, "Continue content on back" off → existing icon-back
+  behavior. Regression guard: page count and back-page contents match the
+  existing print-backs assertions byte-for-byte.
 - Both toggles on, deck = one 2-page card + one 1-page card, 4-up layout:
   - One front page with two filled slots in deck order: card1 page 1,
     card2 page 1.
   - One back page imposed by horizontal mirror. The slot mirroring card1
-    contains card1 page 2's body content (assert by reading `data-role=
-    "card-body"` text). The slot mirroring card2 contains an icon-back
-    (`data-role="card-back-root"`).
+    contains card1 page 2's body content (assert by reading the
+    `data-role="card-body"` text). The slot mirroring card2 contains an
+    icon-back (`data-role="card-back-root"`).
 - Both toggles on, deck = one 4-page card, 4-up layout:
   - One front page with two filled slots: pg1 and pg3 (in row-major slot
     order).
@@ -253,9 +313,13 @@ unnecessary overrides) applies.
   - One front page with two filled slots: pg1 and pg3.
   - One back page: pg2 in the slot mirroring pg1; the slot mirroring pg3
     renders an icon-back.
-- "Continue on back" helptext renders ("Multi-page cards continue onto the
-  back instead of a new sheet"). Existing flip-edge tip continues to render
-  under the same conditions as today (i.e., when "Print backs" is on).
+- Sub-toggle helptext renders the canonical copy ("Print page 2 of a
+  multi-page card on the back of page 1, instead of using a separate
+  slot."). When "Print backs" is off, the additional disabled-state line
+  ("Enable Print backs to use this option.") is also visible. With "Print
+  backs" on, only the canonical line is visible. Existing flip-edge tip
+  continues to render under the same conditions as today (i.e., when
+  "Print backs" is on).
 
 ### Unchanged test files
 
@@ -312,7 +376,13 @@ in the PR description.
   test confirms it.
 - **The `printBacks &&` guard inside `pairSlots`'s argument.** It's tempting
   to drop the guard and always honor `contentOnBack`. Don't — without the
-  guard, toggling "Continue on back" while "Print backs" is off changes the
-  front page's slot count (multi-page cards collapse), which is a confusing
-  UI state for a toggle whose effect should be invisible until backs are
-  enabled.
+  guard, toggling "Continue content on back" while "Print backs" is off
+  changes the front page's slot count (multi-page cards collapse), which is a
+  confusing UI state for a toggle whose effect should be invisible until
+  backs are enabled.
+- **`data-card-id` is unreliable on paired slots.** A paired slot's front and
+  back share `card.id`. The existing imposition test (`[B,A,D,C]` from
+  `data-card-id` order) keeps working for the toggle-off path, but new
+  paired-flow tests must disambiguate via rendered body text. The test plan
+  above codifies this; flagging here so the implementer doesn't reach for
+  `data-card-id` and burn time debugging a "wrong" result.

--- a/src/cards/pairSlots.test.ts
+++ b/src/cards/pairSlots.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "vitest";
+import type { PhysicalCard } from "./expandCard";
+import { itemCardFactory } from "./factories";
+import { pairSlots } from "./pairSlots";
+import type { ItemCard } from "./types";
+
+const physical = (card: ItemCard, page?: number, total?: number): PhysicalCard => ({
+  card,
+  bodyChunk: "",
+  pagination: page !== undefined && total !== undefined ? { page, total } : undefined,
+});
+
+describe("pairSlots", () => {
+  test("contentOnBack: false maps every PhysicalCard to a front-only slot", () => {
+    const card = itemCardFactory.build();
+    const cards = [physical(card), physical(card, 1, 2), physical(card, 2, 2)];
+    const slots = pairSlots(cards, { contentOnBack: false });
+    expect(slots).toHaveLength(3);
+    for (const slot of slots) {
+      expect(slot.back).toBeUndefined();
+    }
+  });
+
+  test("empty input returns empty slots in both modes", () => {
+    expect(pairSlots([], { contentOnBack: false })).toEqual([]);
+    expect(pairSlots([], { contentOnBack: true })).toEqual([]);
+  });
+
+  test("single 1-page card pairs to one front-only slot", () => {
+    const card = itemCardFactory.build();
+    const slots = pairSlots([physical(card)], { contentOnBack: true });
+    expect(slots).toHaveLength(1);
+    expect(slots[0]!.back).toBeUndefined();
+  });
+
+  test("single 2-page card collapses to one paired slot", () => {
+    const card = itemCardFactory.build();
+    const cards = [physical(card, 1, 2), physical(card, 2, 2)];
+    const slots = pairSlots(cards, { contentOnBack: true });
+    expect(slots).toHaveLength(1);
+    expect(slots[0]!.front.pagination?.page).toBe(1);
+    expect(slots[0]!.back?.pagination?.page).toBe(2);
+  });
+
+  test("single 3-page card produces two slots, last with no back", () => {
+    const card = itemCardFactory.build();
+    const cards = [physical(card, 1, 3), physical(card, 2, 3), physical(card, 3, 3)];
+    const slots = pairSlots(cards, { contentOnBack: true });
+    expect(slots).toHaveLength(2);
+    expect(slots[0]!.front.pagination?.page).toBe(1);
+    expect(slots[0]!.back?.pagination?.page).toBe(2);
+    expect(slots[1]!.front.pagination?.page).toBe(3);
+    expect(slots[1]!.back).toBeUndefined();
+  });
+
+  test("single 4-page card produces two paired slots", () => {
+    const card = itemCardFactory.build();
+    const cards = [
+      physical(card, 1, 4),
+      physical(card, 2, 4),
+      physical(card, 3, 4),
+      physical(card, 4, 4),
+    ];
+    const slots = pairSlots(cards, { contentOnBack: true });
+    expect(slots).toHaveLength(2);
+    expect(slots[0]!.front.pagination?.page).toBe(1);
+    expect(slots[0]!.back?.pagination?.page).toBe(2);
+    expect(slots[1]!.front.pagination?.page).toBe(3);
+    expect(slots[1]!.back?.pagination?.page).toBe(4);
+  });
+
+  test("two distinct 1-page cards stay unpaired", () => {
+    const cardA = itemCardFactory.build();
+    const cardB = itemCardFactory.build();
+    const slots = pairSlots([physical(cardA), physical(cardB)], {
+      contentOnBack: true,
+    });
+    expect(slots).toHaveLength(2);
+    expect(slots[0]!.front.card).toBe(cardA);
+    expect(slots[0]!.back).toBeUndefined();
+    expect(slots[1]!.front.card).toBe(cardB);
+    expect(slots[1]!.back).toBeUndefined();
+  });
+
+  test("two consecutive 2-page cards each pair within their own card", () => {
+    const cardA = itemCardFactory.build();
+    const cardB = itemCardFactory.build();
+    const cards = [
+      physical(cardA, 1, 2),
+      physical(cardA, 2, 2),
+      physical(cardB, 1, 2),
+      physical(cardB, 2, 2),
+    ];
+    const slots = pairSlots(cards, { contentOnBack: true });
+    expect(slots).toHaveLength(2);
+    expect(slots[0]!.front.card).toBe(cardA);
+    expect(slots[0]!.back?.card).toBe(cardA);
+    expect(slots[1]!.front.card).toBe(cardB);
+    expect(slots[1]!.back?.card).toBe(cardB);
+  });
+});

--- a/src/cards/pairSlots.test.ts
+++ b/src/cards/pairSlots.test.ts
@@ -6,7 +6,7 @@ import type { ItemCard } from "./types";
 
 const physical = (card: ItemCard, page?: number, total?: number): PhysicalCard => ({
   card,
-  bodyChunk: "",
+  bodyHtml: "",
   pagination: page !== undefined && total !== undefined ? { page, total } : undefined,
 });
 

--- a/src/cards/pairSlots.ts
+++ b/src/cards/pairSlots.ts
@@ -1,0 +1,25 @@
+import type { PhysicalCard } from "./expandCard";
+
+export type PrintSlot = {
+  front: PhysicalCard;
+  back?: PhysicalCard;
+};
+
+// Assumes consecutive PhysicalCards with matching card.id are pages of the
+// same card in order — the invariant established by useExpandedCards.
+export function pairSlots(cards: PhysicalCard[], opts: { contentOnBack: boolean }): PrintSlot[] {
+  if (!opts.contentOnBack) return cards.map((front) => ({ front }));
+
+  const slots: PrintSlot[] = [];
+  for (let i = 0; i < cards.length; i++) {
+    const front = cards[i]!;
+    const next = cards[i + 1];
+    if (next && next.card.id === front.card.id) {
+      slots.push({ front, back: next });
+      i++;
+    } else {
+      slots.push({ front });
+    }
+  }
+  return slots;
+}

--- a/src/lib/ui/Switch.module.css
+++ b/src/lib/ui/Switch.module.css
@@ -36,6 +36,11 @@
   transform: translateX(1rem);
 }
 
+.switch[data-disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .switch[data-focus-visible] .indicator {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;

--- a/src/views/PrintView.module.css
+++ b/src/views/PrintView.module.css
@@ -65,6 +65,13 @@
   margin-top: var(--space-1);
 }
 
+.subSwitch {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding-left: var(--space-4);
+}
+
 .divider {
   border: 0;
   border-top: 1px solid var(--color-border);

--- a/src/views/PrintView.test.tsx
+++ b/src/views/PrintView.test.tsx
@@ -5,7 +5,7 @@ import { HttpResponse, http } from "msw";
 import type { ReactNode } from "react";
 import { describe, expect, test, vi } from "vitest";
 import * as layoutPaginatorModule from "../cards/layoutPaginator";
-import { makeCardRow } from "../test/factories";
+import { makeCardRow, makeItemPayload } from "../test/factories";
 import { SB_URL as SB, server } from "../test/msw";
 import { PrintView } from "./PrintView";
 import styles from "./PrintView.module.css";
@@ -164,7 +164,9 @@ describe("<PrintView>", () => {
 
   test("renders a 'Continue content on back' switch", async () => {
     const cards = makeCardRow.buildList(2);
-    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json(cards)));
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+    );
     render(wrap(<PrintView deckId="d1" />));
     await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
     expect(screen.getByRole("switch", { name: /continue content on back/i })).toBeInTheDocument();
@@ -172,7 +174,9 @@ describe("<PrintView>", () => {
 
   test("'Continue content on back' is disabled when 'Print backs' is off", async () => {
     const cards = makeCardRow.buildList(2);
-    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json(cards)));
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+    );
     render(wrap(<PrintView deckId="d1" />));
     await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
     const continueSwitch = screen.getByRole("switch", {
@@ -185,7 +189,9 @@ describe("<PrintView>", () => {
 
   test("sub-toggle helptext shows the disabled-state hint only when 'Print backs' is off", async () => {
     const cards = makeCardRow.buildList(2);
-    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json(cards)));
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+    );
     render(wrap(<PrintView deckId="d1" />));
     await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
     expect(
@@ -194,5 +200,106 @@ describe("<PrintView>", () => {
     expect(screen.getByText(/Enable Print backs to use this option/i)).toBeInTheDocument();
     await userEvent.click(screen.getByRole("switch", { name: /print backs/i }));
     expect(screen.queryByText(/Enable Print backs to use this option/i)).not.toBeInTheDocument();
+  });
+
+  test("places page-2 on the back of page-1's slot when both toggles are on (mixed deck)", async () => {
+    const twoPager = makeCardRow.build({ payload: makeItemPayload.build({ body: "TWO" }) });
+    const onePager = makeCardRow.build({ payload: makeItemPayload.build({ body: "ONE" }) });
+    vi.spyOn(layoutPaginatorModule, "layoutPaginate").mockImplementation(({ bodyHtml }) =>
+      bodyHtml.includes("TWO") ? ["TWO-pg1", "TWO-pg2"] : [bodyHtml],
+    );
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () =>
+        HttpResponse.json([twoPager, onePager]),
+      ),
+    );
+    render(wrap(<PrintView deckId="d1" />));
+    await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
+    await userEvent.click(screen.getByRole("switch", { name: /print backs/i }));
+    await userEvent.click(screen.getByRole("switch", { name: /continue content on back/i }));
+    // Front: two populated slots — twoPager pg1 (slot 0), onePager (slot 1).
+    // Back imposition (4-up, cols=2): back-slot 0 = back-of front-slot-1 (onePager → icon),
+    //                                 back-slot 1 = back-of front-slot-0 (twoPager pg2).
+    const backPage = document.querySelector('[data-page-side="back"]') as HTMLElement;
+    expect(backPage).not.toBeNull();
+    const slots = Array.from(backPage.children) as HTMLElement[];
+    expect(slots[0]!.querySelector('[data-role="card-back-root"]')).not.toBeNull();
+    expect(slots[1]!.querySelector('[data-role="card-body"]')).toHaveTextContent("TWO-pg2");
+  });
+
+  test("4-page card paired flow at 4-up", async () => {
+    const card = makeCardRow.build({ payload: makeItemPayload.build({ body: "X" }) });
+    vi.spyOn(layoutPaginatorModule, "layoutPaginate").mockImplementation(({ bodyHtml }) =>
+      bodyHtml.includes("X") ? ["pg1", "pg2", "pg3", "pg4"] : [bodyHtml],
+    );
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json([card])),
+    );
+    render(wrap(<PrintView deckId="d1" />));
+    await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
+    await userEvent.click(screen.getByRole("switch", { name: /print backs/i }));
+    await userEvent.click(screen.getByRole("switch", { name: /continue content on back/i }));
+    // Front: slot 0 = pg1, slot 1 = pg3.
+    // Back imposition: back-slot 0 = back-of front-slot-1 (pg4),
+    //                  back-slot 1 = back-of front-slot-0 (pg2).
+    const frontPage = document.querySelector('[data-page-side="front"]') as HTMLElement;
+    const frontSlots = Array.from(frontPage.children) as HTMLElement[];
+    expect(frontSlots[0]!.querySelector('[data-role="card-body"]')).toHaveTextContent("pg1");
+    expect(frontSlots[1]!.querySelector('[data-role="card-body"]')).toHaveTextContent("pg3");
+
+    const backPage = document.querySelector('[data-page-side="back"]') as HTMLElement;
+    const backSlots = Array.from(backPage.children) as HTMLElement[];
+    expect(backSlots[0]!.querySelector('[data-role="card-body"]')).toHaveTextContent("pg4");
+    expect(backSlots[1]!.querySelector('[data-role="card-body"]')).toHaveTextContent("pg2");
+  });
+
+  test("3-page card paired flow at 4-up — last back slot falls back to icon", async () => {
+    const card = makeCardRow.build({ payload: makeItemPayload.build({ body: "X" }) });
+    vi.spyOn(layoutPaginatorModule, "layoutPaginate").mockImplementation(({ bodyHtml }) =>
+      bodyHtml.includes("X") ? ["pg1", "pg2", "pg3"] : [bodyHtml],
+    );
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json([card])),
+    );
+    render(wrap(<PrintView deckId="d1" />));
+    await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
+    await userEvent.click(screen.getByRole("switch", { name: /print backs/i }));
+    await userEvent.click(screen.getByRole("switch", { name: /continue content on back/i }));
+    // Front: slot 0 = pg1, slot 1 = pg3.
+    // Back imposition: back-slot 0 = back-of front-slot-1 (pg3 → no back → icon),
+    //                  back-slot 1 = back-of front-slot-0 (pg2).
+    const backPage = document.querySelector('[data-page-side="back"]') as HTMLElement;
+    const backSlots = Array.from(backPage.children) as HTMLElement[];
+    expect(backSlots[0]!.querySelector('[data-role="card-back-root"]')).not.toBeNull();
+    expect(backSlots[1]!.querySelector('[data-role="card-body"]')).toHaveTextContent("pg2");
+  });
+
+  test("'Continue content on back' selected state persists across disable/re-enable", async () => {
+    const card = makeCardRow.build({ payload: makeItemPayload.build({ body: "X" }) });
+    vi.spyOn(layoutPaginatorModule, "layoutPaginate").mockImplementation(({ bodyHtml }) =>
+      bodyHtml.includes("X") ? ["pg1", "pg2"] : [bodyHtml],
+    );
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json([card])),
+    );
+    render(wrap(<PrintView deckId="d1" />));
+    await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
+    const printBacks = screen.getByRole("switch", { name: /print backs/i });
+    const continueOnBack = screen.getByRole("switch", {
+      name: /continue content on back/i,
+    });
+    await userEvent.click(printBacks);
+    await userEvent.click(continueOnBack);
+    expect(continueOnBack).toBeChecked();
+    await userEvent.click(printBacks); // disable backs
+    expect(continueOnBack).toBeDisabled();
+    expect(continueOnBack).toBeChecked(); // selection persists
+    await userEvent.click(printBacks); // re-enable backs
+    expect(continueOnBack).not.toBeDisabled();
+    expect(continueOnBack).toBeChecked();
+    // Paired flow resumes: pg2 lands on the back.
+    const backPage = document.querySelector('[data-page-side="back"]') as HTMLElement;
+    const backSlots = Array.from(backPage.children) as HTMLElement[];
+    expect(backSlots[1]!.querySelector('[data-role="card-body"]')).toHaveTextContent("pg2");
   });
 });

--- a/src/views/PrintView.test.tsx
+++ b/src/views/PrintView.test.tsx
@@ -161,4 +161,38 @@ describe("<PrintView>", () => {
     expect(screen.queryByText(/long edge/i)).not.toBeInTheDocument();
     expect(screen.getByText(/short edge/i)).toBeInTheDocument();
   });
+
+  test("renders a 'Continue content on back' switch", async () => {
+    const cards = makeCardRow.buildList(2);
+    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json(cards)));
+    render(wrap(<PrintView deckId="d1" />));
+    await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
+    expect(screen.getByRole("switch", { name: /continue content on back/i })).toBeInTheDocument();
+  });
+
+  test("'Continue content on back' is disabled when 'Print backs' is off", async () => {
+    const cards = makeCardRow.buildList(2);
+    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json(cards)));
+    render(wrap(<PrintView deckId="d1" />));
+    await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
+    const continueSwitch = screen.getByRole("switch", {
+      name: /continue content on back/i,
+    });
+    expect(continueSwitch).toBeDisabled();
+    await userEvent.click(screen.getByRole("switch", { name: /print backs/i }));
+    expect(continueSwitch).not.toBeDisabled();
+  });
+
+  test("sub-toggle helptext shows the disabled-state hint only when 'Print backs' is off", async () => {
+    const cards = makeCardRow.buildList(2);
+    server.use(http.get(`${SB}/rest/v1/cards`, () => HttpResponse.json(cards)));
+    render(wrap(<PrintView deckId="d1" />));
+    await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
+    expect(
+      screen.getByText(/Print page 2 of a multi-page card on the back of page 1/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Enable Print backs to use this option/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("switch", { name: /print backs/i }));
+    expect(screen.queryByText(/Enable Print backs to use this option/i)).not.toBeInTheDocument();
+  });
 });

--- a/src/views/PrintView.tsx
+++ b/src/views/PrintView.tsx
@@ -37,6 +37,7 @@ export function PrintView({ deckId }: Props) {
   const cardsQuery = useDeckCards(deckId);
   const [perPage, setPerPage] = useState<CardsPerPage>(4);
   const [printBacks, setPrintBacks] = useState(false);
+  const [contentOnBack, setContentOnBack] = useState(false);
   const perPageId = useId();
 
   const cards = cardsQuery.data ?? [];
@@ -80,6 +81,18 @@ export function PrintView({ deckId }: Props) {
                 <em>{flipLabel}</em>).
               </p>
             )}
+          </div>
+          <div className={styles.subSwitch}>
+            <Switch isSelected={contentOnBack} onChange={setContentOnBack} isDisabled={!printBacks}>
+              Continue content on back
+            </Switch>
+            <div className={styles.helptext}>
+              <p>
+                Print page 2 of a multi-page card on the back of page 1, instead of using a separate
+                slot.
+              </p>
+              {!printBacks && <p>Enable Print backs to use this option.</p>}
+            </div>
           </div>
         </div>
 

--- a/src/views/PrintView.tsx
+++ b/src/views/PrintView.tsx
@@ -2,7 +2,7 @@ import { Fragment, useId, useState } from "react";
 import { imposeBackPage } from "../cards/backImposition";
 import { Card, type CardsPerPage } from "../cards/Card";
 import { CardBack } from "../cards/CardBack";
-import type { PhysicalCard } from "../cards/expandCard";
+import { type PrintSlot, pairSlots } from "../cards/pairSlots";
 import { isRenderableCard } from "../cards/types";
 import { useExpandedCards } from "../cards/useExpandedCards";
 import { useDeckCards } from "../decks/queries";
@@ -21,9 +21,17 @@ const chunk = <T,>(arr: T[], size: number): T[][] => {
   return out;
 };
 
-const getBackContentFor = (entry: PhysicalCard, perPage: CardsPerPage) => (
-  <CardBack card={entry.card} cardsPerPage={perPage} />
-);
+const getBackContentFor = (slot: PrintSlot, perPage: CardsPerPage) =>
+  slot.back ? (
+    <Card
+      card={slot.back.card}
+      cardsPerPage={perPage}
+      bodyHtml={slot.back.bodyHtml}
+      pagination={slot.back.pagination}
+    />
+  ) : (
+    <CardBack card={slot.front.card} cardsPerPage={perPage} />
+  );
 
 export function PrintView({ deckId }: Props) {
   const cardsQuery = useDeckCards(deckId);
@@ -34,10 +42,11 @@ export function PrintView({ deckId }: Props) {
   const cards = cardsQuery.data ?? [];
   const printable = cards.filter(isRenderableCard);
   const { physicalCards } = useExpandedCards(printable, perPage);
+  const printSlots = pairSlots(physicalCards, { contentOnBack: false });
 
   if (cardsQuery.isLoading) return <LoadingState />;
 
-  const pages = physicalCards.length === 0 ? [] : chunk(physicalCards, perPage);
+  const pages = printSlots.length === 0 ? [] : chunk(printSlots, perPage);
   const flipEdge = perPage === 4 ? "long edge" : "short edge";
   const flipLabel = perPage === 4 ? "Book" : "Tablet";
 
@@ -95,8 +104,8 @@ export function PrintView({ deckId }: Props) {
         {printable.length === 0 && <p>No printable cards in this deck yet.</p>}
 
         <div className={styles.sheet}>
-          {pages.map((pageCards) => {
-            const pageKey = `${pageCards[0]?.card.id ?? "empty"}-${pageCards[0]?.pagination?.page ?? 0}`;
+          {pages.map((pageSlots) => {
+            const pageKey = `${pageSlots[0]?.front.card.id ?? "empty"}-${pageSlots[0]?.front.pagination?.page ?? 0}`;
             return (
               <Fragment key={`page-${pageKey}`}>
                 <div
@@ -104,16 +113,16 @@ export function PrintView({ deckId }: Props) {
                   data-page-side="front"
                   className={`${styles.page} ${perPage === 4 ? styles.perPage4 : styles.perPage2}`}
                 >
-                  {pageCards.map((entry) => (
+                  {pageSlots.map((slot) => (
                     <div
-                      key={`${entry.card.id}-${entry.pagination?.page ?? 0}`}
+                      key={`${slot.front.card.id}-${slot.front.pagination?.page ?? 0}`}
                       className={styles.slot}
                     >
                       <Card
-                        card={entry.card}
+                        card={slot.front.card}
                         cardsPerPage={perPage}
-                        bodyHtml={entry.bodyHtml}
-                        pagination={entry.pagination}
+                        bodyHtml={slot.front.bodyHtml}
+                        pagination={slot.front.pagination}
                       />
                     </div>
                   ))}
@@ -124,13 +133,13 @@ export function PrintView({ deckId }: Props) {
                     data-page-side="back"
                     className={`${styles.page} ${perPage === 4 ? styles.perPage4 : styles.perPage2}`}
                   >
-                    {imposeBackPage(pageCards, perPage, COLS).map((entry, slotIndex) => {
-                      const slotKey = entry
-                        ? `${entry.card.id}-${entry.pagination?.page ?? 0}`
+                    {imposeBackPage(pageSlots, perPage, COLS).map((slot, slotIndex) => {
+                      const slotKey = slot
+                        ? `${slot.front.card.id}-${slot.front.pagination?.page ?? 0}`
                         : `${pageKey}-empty-${slotIndex}`;
                       return (
                         <div key={`back-${slotKey}`} className={styles.slot}>
-                          {entry ? getBackContentFor(entry, perPage) : null}
+                          {slot ? getBackContentFor(slot, perPage) : null}
                         </div>
                       );
                     })}

--- a/src/views/PrintView.tsx
+++ b/src/views/PrintView.tsx
@@ -43,7 +43,9 @@ export function PrintView({ deckId }: Props) {
   const cards = cardsQuery.data ?? [];
   const printable = cards.filter(isRenderableCard);
   const { physicalCards } = useExpandedCards(printable, perPage);
-  const printSlots = pairSlots(physicalCards, { contentOnBack: false });
+  const printSlots = pairSlots(physicalCards, {
+    contentOnBack: printBacks && contentOnBack,
+  });
 
   if (cardsQuery.isLoading) return <LoadingState />;
 


### PR DESCRIPTION
## Summary

- Adds a **"Continue content on back"** sub-toggle in the print sidebar. When both it and "Print backs" are on, multi-page cards print page 2+ on the back of page 1's slot instead of taking a separate front slot — letting you cut a 2-page card down to one double-sided card with a duplex printer.
- Introduces a pure `pairSlots(physicalCards, { contentOnBack })` function that groups consecutive same-card `PhysicalCard`s into `PrintSlot { front, back? }` pairs. PrintView consumes slots through the existing imposition helper, which is content-agnostic and unchanged.
- Mixed sheets work: a 1-page card on the same sheet keeps the icon back. 3+ page cards extend naturally — odd remainder falls back to the icon.
- Adds `[data-disabled]` styling to `<Switch>` (`opacity: 0.5; cursor: not-allowed`) since this is the first user-visible disabled switch in the app — matching the pattern Button and IconButton already use.

## Spec & plan

- Spec: `docs/superpowers/specs/2026-05-08-print-content-on-back-design.md`
- Plan: `docs/superpowers/plans/2026-05-08-print-content-on-back.md`
- Builds on the forward-compat seam left in `2026-05-06-print-backs-design.md`.

## Test plan

- [x] Unit tests for `pairSlots` (8 cases: 1/2/3/4-page cards, distinct cards, two consecutive same-shape cards)
- [x] PrintView integration tests for paired flow (mixed 2+1 deck, single 4-page card, single 3-page card, selected-state persistence across disable/re-enable)
- [x] Existing print-backs tests still pass (regression guard — no assertions weakened)
- [x] Full suite: 480 / 480 passing, `npm run build` clean, biome clean
- [x] Manual print verification confirmed paired-flow output works on real paper

🤖 Generated with [Claude Code](https://claude.com/claude-code)