### PR TITLE
feat(browse): registry-driven sidebar with content-type tabs and source menu

### DIFF
--- a/docs/superpowers/plans/2026-05-09-srd-browse-rework.md
+++ b/docs/superpowers/plans/2026-05-09-srd-browse-rework.md
@@ -1,0 +1,1114 @@
+# SRD Browse Rework Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the four-toggle header in `BrowseApiModal` with a left sidebar of content types + a single source dropdown, backed by a content-type registry so adding monsters/effects/feats later is purely additive.
+
+**Architecture:** Introduce `src/api/content-types/` with a per-type module (`items.ts`, `spells.ts`) exporting a `ContentType` whose `useResults(source, query)` hook closes over the entry shape. The modal iterates `CONTENT_TYPES` to render `react-aria-components` `Tabs` (sidebar) + `MenuTrigger`/`Menu` (source dropdown). A wrapper inside the modal carries `container-type: inline-size`; below ~560px the sidebar collapses into a second `MenuTrigger` for type. No backend or schema changes — saved card payloads are byte-identical.
+
+**Tech Stack:** React 18, TypeScript, Vite, `react-aria-components`, TanStack Query (existing hooks), CSS Modules, Vitest + Testing Library + MSW.
+
+**Spec:** `docs/superpowers/specs/2026-05-09-srd-browse-rework-design.md`
+
+---
+
+## File Structure
+
+**New:**
+- `src/api/content-types/types.ts` — `ContentType`, `ContentRow`, `ContentTypeResults` interfaces
+- `src/api/content-types/items.ts` — items module (closes over `MagicItem`)
+- `src/api/content-types/spells.ts` — spells module (closes over `Spell`)
+- `src/api/content-types/index.ts` — exports `CONTENT_TYPES`
+- `src/views/BrowseApiModal.menu.module.css` — *not creating; reuse the existing module*
+
+**Modified:**
+- `src/views/BrowseApiModal.tsx` — full rewrite: registry-driven, `Tabs` + `MenuTrigger`
+- `src/views/BrowseApiModal.module.css` — add layout/sidebar/tabs/menu/container-query rules; relax footer copy
+- `src/views/BrowseApiModal.test.tsx` — switch ARIA selectors to `tab` and `menuitem`; add new assertions
+
+**Untouched (verify imports continue to compile):** `src/api/endpoints/*`, `src/api/mappers/*`, `src/api/hooks.ts`, `src/decks/mutations.ts`, `src/lib/ui/*`.
+
+---
+
+## Sequencing
+
+Phase 1 — Registry foundation (Tasks 1–4): pure additions, no behavior change.
+Phase 2 — Modal refactor (Tasks 5–6): tests then implementation; one commit each.
+Phase 3 — Polish (Task 7): footer copy, final verification.
+
+`npm test`, `npm run typecheck`, `npm run lint`, `npm run dev`, `npm run build` are pre-approved per project memory — run as needed without asking.
+
+---
+
+## Task 1: Create `content-types/types.ts`
+
+**Files:**
+- Create: `src/api/content-types/types.ts`
+
+This task only declares interfaces — TypeScript validates correctness. No runtime test.
+
+- [ ] **Step 1: Create the file.**
+
+```ts
+// src/api/content-types/types.ts
+import type { Card } from "../../cards/types";
+import type { Ruleset } from "../endpoints/magicItems";
+
+export type ContentRow = {
+  key: string;
+  name: string;
+  meta: string;
+  toCard: () => Card;
+};
+
+export type ContentTypeResults = {
+  isLoading: boolean;
+  isError: boolean;
+  refetch: () => void;
+  rows: ReadonlyArray<ContentRow>;
+};
+
+export type ContentType = {
+  id: string;
+  label: string;
+  searchPlaceholder: string;
+  supportedSources: readonly Ruleset[];
+  useResults: (source: Ruleset, query: string) => ContentTypeResults;
+};
+```
+
+- [ ] **Step 2: Verify typecheck passes.**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add src/api/content-types/types.ts
+git commit -m "refactor(browse): add ContentType registry interfaces"
+```
+
+---
+
+## Task 2: Create `content-types/items.ts`
+
+**Files:**
+- Create: `src/api/content-types/items.ts`
+
+Extracts the items branch of `BrowseApiModal` (the `useMagicItemIndex` call, the substring filter, the rarity-as-meta formatter, and the `magicItemDetailToCard({ ...entry, ruleset })` call) into a self-contained `ContentType`.
+
+- [ ] **Step 1: Create the file.**
+
+```ts
+// src/api/content-types/items.ts
+import { useMemo } from "react";
+import { useMagicItemIndex } from "../hooks";
+import { magicItemDetailToCard } from "../mappers/magicItems";
+import type { ContentType } from "./types";
+
+const capitalize = (s: string): string =>
+  s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+
+export const itemsContentType: ContentType = {
+  id: "items",
+  label: "Items",
+  searchPlaceholder: "Search items…",
+  supportedSources: ["2014", "2024"] as const,
+  useResults: (source, query) => {
+    const idx = useMagicItemIndex(source);
+    const rows = useMemo(() => {
+      const q = query.trim().toLowerCase();
+      return (idx.data?.results ?? [])
+        .filter((e) => q === "" || e.name.toLowerCase().includes(q))
+        .map((entry) => ({
+          key: entry.key,
+          name: entry.name,
+          meta: capitalize(entry.rarity.name),
+          toCard: () => magicItemDetailToCard({ ...entry, ruleset: source }),
+        }));
+    }, [idx.data, query, source]);
+    return {
+      isLoading: idx.isLoading,
+      isError: idx.isError,
+      refetch: idx.refetch,
+      rows,
+    };
+  },
+};
+```
+
+- [ ] **Step 2: Verify typecheck passes.**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add src/api/content-types/items.ts
+git commit -m "refactor(browse): extract items content-type module"
+```
+
+---
+
+## Task 3: Create `content-types/spells.ts`
+
+**Files:**
+- Create: `src/api/content-types/spells.ts`
+
+Mirror of Task 2 for spells. Extracts the spells branch — `useSpellIndex` + the level/school formatter + `spellDetailToCard`.
+
+- [ ] **Step 1: Create the file.**
+
+```ts
+// src/api/content-types/spells.ts
+import { useMemo } from "react";
+import { useSpellIndex } from "../hooks";
+import { spellDetailToCard } from "../mappers/spells";
+import type { ContentType } from "./types";
+
+const ordinal = (n: number): string => {
+  if (n === 1) return "1st";
+  if (n === 2) return "2nd";
+  if (n === 3) return "3rd";
+  return `${n}th`;
+};
+
+const capitalize = (s: string): string =>
+  s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+
+const spellMeta = (level: number, schoolName: string): string => {
+  const school = schoolName.toLowerCase();
+  if (level === 0) return `${capitalize(school)} cantrip`;
+  return `${ordinal(level)}-level ${school}`;
+};
+
+export const spellsContentType: ContentType = {
+  id: "spells",
+  label: "Spells",
+  searchPlaceholder: "Search spells…",
+  supportedSources: ["2014", "2024"] as const,
+  useResults: (source, query) => {
+    const idx = useSpellIndex(source);
+    const rows = useMemo(() => {
+      const q = query.trim().toLowerCase();
+      return (idx.data?.results ?? [])
+        .filter((e) => q === "" || e.name.toLowerCase().includes(q))
+        .map((entry) => ({
+          key: entry.key,
+          name: entry.name,
+          meta: spellMeta(entry.level, entry.school.name),
+          toCard: () => spellDetailToCard({ ...entry, ruleset: source }),
+        }));
+    }, [idx.data, query, source]);
+    return {
+      isLoading: idx.isLoading,
+      isError: idx.isError,
+      refetch: idx.refetch,
+      rows,
+    };
+  },
+};
+```
+
+- [ ] **Step 2: Verify typecheck passes.**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add src/api/content-types/spells.ts
+git commit -m "refactor(browse): extract spells content-type module"
+```
+
+---
+
+## Task 4: Create `content-types/index.ts`
+
+**Files:**
+- Create: `src/api/content-types/index.ts`
+
+Aggregator. Order in the array determines sidebar order; today's modal lists Items first, Spells second — preserve that.
+
+- [ ] **Step 1: Create the file.**
+
+```ts
+// src/api/content-types/index.ts
+import { itemsContentType } from "./items";
+import { spellsContentType } from "./spells";
+import type { ContentType } from "./types";
+
+export const CONTENT_TYPES: readonly ContentType[] = [itemsContentType, spellsContentType];
+
+export type { ContentType, ContentRow, ContentTypeResults } from "./types";
+```
+
+- [ ] **Step 2: Verify typecheck passes.**
+
+Run: `npm run typecheck`
+Expected: PASS. The new modules are now importable but nothing imports them yet, so no behavior change.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add src/api/content-types/index.ts
+git commit -m "refactor(browse): add CONTENT_TYPES registry"
+```
+
+---
+
+## Task 5: Rewrite the test file for the new ARIA shape
+
+**Files:**
+- Modify: `src/views/BrowseApiModal.test.tsx`
+
+Today's tests select the kind toggle via `getByRole("radio", { name: "Spells" })` (RAC `ToggleButton` exposes `role="radio"` inside a single-select `ToggleButtonGroup`). After the rework the type selector is a vertical `Tabs`, so type selection becomes `getByRole("tab", { name: "Spells" })`. The source toggle becomes a `MenuTrigger` — selecting a source means clicking the trigger button, then a `menuitem`.
+
+This task updates **all** existing assertions to the new selectors and adds the new ones the spec calls for. Tests will fail at the end of this task — Task 6 makes them pass.
+
+- [ ] **Step 1: Replace `BrowseApiModal.test.tsx` with the rewritten version.**
+
+```tsx
+// src/views/BrowseApiModal.test.tsx
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import type { ReactNode } from "react";
+import { describe, expect, test, vi } from "vitest";
+import type { MagicItemIndex, Ruleset } from "../api/endpoints/magicItems";
+import type { SpellIndex } from "../api/endpoints/spells";
+import { magicItemIndexEntryFactory, spellIndexEntryFactory } from "../api/factories";
+import { makeCardRow } from "../test/factories";
+import { SB_URL, server } from "../test/msw";
+import { render, screen, waitFor } from "../test/render";
+import { BrowseApiModal } from "./BrowseApiModal";
+
+const itemKey = (ruleset: Ruleset) => ["magic-items", ruleset, "index"];
+const spellKey = (ruleset: Ruleset) => ["spells", ruleset, "index"];
+
+type Seeds = {
+  items?: Partial<Record<Ruleset, MagicItemIndex>>;
+  spells?: Partial<Record<Ruleset, SpellIndex>>;
+};
+
+const makeClient = (seeds: Seeds = {}) => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  for (const [ruleset, body] of Object.entries(seeds.items ?? {}) as [Ruleset, MagicItemIndex][]) {
+    client.setQueryData(itemKey(ruleset), body);
+  }
+  for (const [ruleset, body] of Object.entries(seeds.spells ?? {}) as [Ruleset, SpellIndex][]) {
+    client.setQueryData(spellKey(ruleset), body);
+  }
+  return client;
+};
+
+const wrap = (ui: ReactNode, client: QueryClient) =>
+  render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+
+const openSourceMenu = async () => {
+  await userEvent.click(screen.getByRole("button", { name: /^Source:/ }));
+};
+
+describe("<BrowseApiModal>", () => {
+  test("renders the registered types as a vertical tablist in registry order", async () => {
+    const client = makeClient({ items: { "2024": { count: 0, results: [] } } });
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs.map((t) => t.textContent)).toEqual(["Items", "Spells"]);
+  });
+
+  test("shows index entries once the items list loads", async () => {
+    const entryA = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
+    const entryB = magicItemIndexEntryFactory.build({ name: "Cloak of Protection" });
+    const client = makeClient({ items: { "2024": { count: 2, results: [entryA, entryB] } } });
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    expect(await screen.findByRole("button", { name: /Bag of Holding/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Cloak of Protection/ })).toBeInTheDocument();
+  });
+
+  test("search filters the items list", async () => {
+    const entryA = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
+    const entryB = magicItemIndexEntryFactory.build({ name: "Cloak of Protection" });
+    const client = makeClient({ items: { "2024": { count: 2, results: [entryA, entryB] } } });
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    await screen.findByRole("button", { name: /Bag of Holding/ });
+    await userEvent.type(screen.getByRole("searchbox"), "bag");
+
+    expect(screen.getByRole("button", { name: /Bag of Holding/ })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Cloak of Protection/ })).not.toBeInTheDocument();
+  });
+
+  test("switching source loads a different items list", async () => {
+    const v2024 = magicItemIndexEntryFactory.build({ name: "Ring A" });
+    const v2014 = magicItemIndexEntryFactory.build({ name: "Ring Z" });
+    const client = makeClient({
+      items: {
+        "2024": { count: 1, results: [v2024] },
+        "2014": { count: 1, results: [v2014] },
+      },
+    });
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    await screen.findByRole("button", { name: /Ring A/ });
+    await openSourceMenu();
+    await userEvent.click(screen.getByRole("menuitem", { name: "2014" }));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /Ring Z/ })).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: /Ring A/ })).not.toBeInTheDocument();
+  });
+
+  test("switching to the Spells tab swaps the list source", async () => {
+    const item = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
+    const spell = spellIndexEntryFactory.build({ name: "Fireball" });
+    const client = makeClient({
+      items: { "2024": { count: 1, results: [item] } },
+      spells: { "2024": { count: 1, results: [spell] } },
+    });
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    await screen.findByRole("button", { name: /Bag of Holding/ });
+    await userEvent.click(screen.getByRole("tab", { name: "Spells" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Fireball/ })).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole("button", { name: /Bag of Holding/ })).not.toBeInTheDocument();
+  });
+
+  test("switching tabs clears the search query", async () => {
+    const item = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
+    const spell = spellIndexEntryFactory.build({ name: "Fireball" });
+    const client = makeClient({
+      items: { "2024": { count: 1, results: [item] } },
+      spells: { "2024": { count: 1, results: [spell] } },
+    });
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    await screen.findByRole("button", { name: /Bag of Holding/ });
+    await userEvent.type(screen.getByRole("searchbox"), "bag");
+
+    await userEvent.click(screen.getByRole("tab", { name: "Spells" }));
+
+    const spellsSearch = await screen.findByRole("searchbox");
+    expect(spellsSearch).toHaveValue("");
+    expect(spellsSearch).toHaveAttribute("placeholder", "Search spells…");
+  });
+
+  test("clicking an item POSTs a card with kind:item", async () => {
+    const entry = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
+    const client = makeClient({ items: { "2024": { count: 1, results: [entry] } } });
+    const onPost = vi.fn();
+    server.use(
+      http.post(`${SB_URL}/rest/v1/cards`, async ({ request }) => {
+        onPost(await request.json());
+        return HttpResponse.json([makeCardRow.build()], { status: 201 });
+      }),
+    );
+    const onSelected = vi.fn();
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={onSelected} />, client);
+
+    await userEvent.click(await screen.findByRole("button", { name: /Bag of Holding/ }));
+
+    await waitFor(() => expect(onPost).toHaveBeenCalled());
+    expect(onPost.mock.calls[0]?.[0]?.payload?.kind).toBe("item");
+    expect(onSelected).toHaveBeenCalledWith(expect.any(String));
+  });
+
+  test("clicking a spell POSTs a card with kind:spell", async () => {
+    const entry = spellIndexEntryFactory.build({ name: "Fireball" });
+    const client = makeClient({ spells: { "2024": { count: 1, results: [entry] } } });
+    const onPost = vi.fn();
+    server.use(
+      http.post(`${SB_URL}/rest/v1/cards`, async ({ request }) => {
+        onPost(await request.json());
+        return HttpResponse.json([makeCardRow.build()], { status: 201 });
+      }),
+    );
+    const onSelected = vi.fn();
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={onSelected} />, client);
+
+    await userEvent.click(screen.getByRole("tab", { name: "Spells" }));
+    await userEvent.click(await screen.findByRole("button", { name: /Fireball/ }));
+
+    await waitFor(() => expect(onPost).toHaveBeenCalled());
+    expect(onPost.mock.calls[0]?.[0]?.payload?.kind).toBe("spell");
+    expect(onSelected).toHaveBeenCalledWith(expect.any(String));
+  });
+
+  test("clicking the same row only POSTs once even under StrictMode double-render", async () => {
+    const entry = magicItemIndexEntryFactory.build({ name: "Flame Tongue" });
+    const client = makeClient({ items: { "2024": { count: 1, results: [entry] } } });
+    const onPost = vi.fn();
+    server.use(
+      http.post(`${SB_URL}/rest/v1/cards`, async ({ request }) => {
+        onPost(await request.json());
+        return HttpResponse.json([makeCardRow.build()], { status: 201 });
+      }),
+    );
+
+    render(
+      <QueryClientProvider client={client}>
+        <BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />
+      </QueryClientProvider>,
+    );
+
+    await userEvent.click(await screen.findByRole("button", { name: /Flame Tongue/ }));
+
+    await waitFor(() => expect(onPost).toHaveBeenCalledTimes(1));
+    await new Promise((r) => setTimeout(r, 50));
+    expect(onPost).toHaveBeenCalledTimes(1);
+  });
+
+  test("Escape calls onClose", async () => {
+    const onClose = vi.fn();
+    const client = makeClient({ items: { "2024": { count: 0, results: [] } } });
+
+    wrap(<BrowseApiModal deckId="d1" onClose={onClose} onSelected={() => {}} />, client);
+
+    await userEvent.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test("shows rarity in each item row", async () => {
+    const entry = magicItemIndexEntryFactory.build({
+      name: "Bag of Holding",
+      rarity: { name: "Uncommon" },
+    });
+    const client = makeClient({ items: { "2024": { count: 1, results: [entry] } } });
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    const row = await screen.findByRole("button", { name: /Bag of Holding/ });
+    expect(row).toHaveTextContent("Uncommon");
+  });
+
+  test("shows level and school in each spell row", async () => {
+    const cantrip = spellIndexEntryFactory.build({
+      name: "Light",
+      level: 0,
+      school: { name: "evocation" },
+    });
+    const leveled = spellIndexEntryFactory.build({
+      name: "Fireball",
+      level: 3,
+      school: { name: "evocation" },
+    });
+    const client = makeClient({
+      spells: { "2024": { count: 2, results: [cantrip, leveled] } },
+    });
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    await userEvent.click(screen.getByRole("tab", { name: "Spells" }));
+    const cantripRow = await screen.findByRole("button", { name: /Light/ });
+    expect(cantripRow).toHaveTextContent("Evocation cantrip");
+    const leveledRow = screen.getByRole("button", { name: /Fireball/ });
+    expect(leveledRow).toHaveTextContent("3rd-level evocation");
+  });
+
+  test("renders the SRD notice with a link", async () => {
+    const client = makeClient({ items: { "2024": { count: 0, results: [] } } });
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+    expect(await screen.findByRole("link", { name: "SRD" })).toHaveAttribute(
+      "href",
+      "https://www.dndbeyond.com/srd",
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail (we're red).**
+
+Run: `npm test -- BrowseApiModal`
+Expected: most tests fail (no `tab` role exists in the current modal, no `Source:` button). Some tests that don't depend on new ARIA may pass — that's fine.
+
+- [ ] **Step 3: Do NOT commit yet — stop here and proceed to Task 6.**
+
+The failing test file will be committed together with the implementation in Task 6 so we don't land a red commit on the branch.
+
+---
+
+## Task 6: Rewrite `BrowseApiModal.tsx` and CSS to use the registry
+
+**Files:**
+- Modify: `src/views/BrowseApiModal.tsx` (full rewrite)
+- Modify: `src/views/BrowseApiModal.module.css` (add layout/sidebar/tabs/menu/container-query rules; relax footer copy)
+
+This is the central change. The new `BrowseApiModal` owns `typeId`, `source`, `query`, `pickingKey`, `pickError`. A child `TypePanel` calls the active type's `useResults`. The source `MenuTrigger` lists exactly the active type's `supportedSources`. A wrapper `<div>` carries `container-type: inline-size` so the narrow-viewport CSS swap is local.
+
+- [ ] **Step 1: Replace `BrowseApiModal.tsx` with the rewritten version.**
+
+```tsx
+// src/views/BrowseApiModal.tsx
+import { useEffect, useMemo, useState } from "react";
+import {
+  Menu,
+  MenuItem,
+  MenuTrigger,
+  Popover,
+  Button as RACButton,
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
+  TextField,
+} from "react-aria-components";
+import type { Ruleset } from "../api/endpoints/magicItems";
+import { CONTENT_TYPES, type ContentType } from "../api/content-types";
+import type { Card } from "../cards/types";
+import { useSaveCard } from "../decks/mutations";
+import { Button } from "../lib/ui/Button";
+import { DialogHeader } from "../lib/ui/DialogHeader";
+import { DialogShell } from "../lib/ui/DialogShell";
+import { Input } from "../lib/ui/Input";
+import { Link } from "../lib/ui/Link";
+import { LoadingState } from "../lib/ui/LoadingState";
+import styles from "./BrowseApiModal.module.css";
+
+type Props = {
+  deckId: string;
+  onClose: () => void;
+  onSelected: (cardId: string) => void;
+};
+
+export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
+  const [typeId, setTypeId] = useState<string>(() => CONTENT_TYPES[0]?.id ?? "");
+  const activeType =
+    CONTENT_TYPES.find((t) => t.id === typeId) ?? CONTENT_TYPES[0];
+  if (!activeType) {
+    throw new Error("CONTENT_TYPES is empty");
+  }
+
+  const [source, setSource] = useState<Ruleset>(activeType.supportedSources[0] ?? "2024");
+  // Source × type invariant: source is always a member of the active type's supportedSources.
+  useEffect(() => {
+    if (!activeType.supportedSources.includes(source)) {
+      const fallback = activeType.supportedSources[0];
+      if (fallback) setSource(fallback);
+    }
+  }, [activeType, source]);
+
+  const [query, setQuery] = useState("");
+  const [pickingKey, setPickingKey] = useState<string | null>(null);
+  const [pickError, setPickError] = useState<string | null>(null);
+
+  const handleTabChange = (next: string) => {
+    if (next === typeId) return;
+    setTypeId(next);
+    setQuery("");
+    setPickError(null);
+  };
+
+  const saveCard = useSaveCard();
+  const handlePick = async (rowKey: string, card: Card) => {
+    if (pickingKey !== null) return;
+    setPickingKey(rowKey);
+    setPickError(null);
+    try {
+      await saveCard.mutateAsync({ card, deckId, isNew: true });
+      onSelected(card.id);
+    } catch (err) {
+      setPickError(
+        err instanceof Error ? err.message : "Couldn't add this card. Please try again.",
+      );
+    } finally {
+      setPickingKey(null);
+    }
+  };
+
+  return (
+    <DialogShell
+      isOpen
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+      aria-label="Browse SRD"
+      size="lg"
+      height={{ fixed: "min(70vh, 640px)" }}
+      bleed
+    >
+      {() => (
+        <>
+          <DialogHeader title="Browse SRD" onClose={onClose}>
+            <SourceMenu
+              source={source}
+              options={activeType.supportedSources}
+              onChange={setSource}
+            />
+          </DialogHeader>
+
+          <div className={styles.layout}>
+            <Tabs
+              orientation="vertical"
+              selectedKey={typeId}
+              onSelectionChange={(k) => handleTabChange(String(k))}
+              className={styles.tabs}
+            >
+              <TabList aria-label="Content type" className={styles.tabList}>
+                {CONTENT_TYPES.map((t) => (
+                  <Tab key={t.id} id={t.id} className={styles.tab}>
+                    {t.label}
+                  </Tab>
+                ))}
+              </TabList>
+              {/*
+                react-aria-components Tabs only mounts the active TabPanel by
+                default, so each TypePanel is created exactly once per active
+                type and unmounts on type switch — this keeps each TypePanel's
+                hook order stable for its single `type` prop.
+              */}
+              {CONTENT_TYPES.map((t) => (
+                <TabPanel key={t.id} id={t.id} className={styles.tabPanel}>
+                  <TypePanel
+                    type={t}
+                    source={source}
+                    query={query}
+                    onQueryChange={setQuery}
+                    pickingKey={pickingKey}
+                    pickError={pickError}
+                    onPick={handlePick}
+                  />
+                </TabPanel>
+              ))}
+            </Tabs>
+          </div>
+
+          <p className={styles.footer}>
+            All content shown is from the{" "}
+            <Link href="https://www.dndbeyond.com/srd" target="_blank" rel="noopener noreferrer">
+              SRD
+            </Link>{" "}
+            — content by Wizards of the Coast, licensed under{" "}
+            <Link
+              href="https://creativecommons.org/licenses/by/4.0/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              CC BY 4.0
+            </Link>
+            .
+          </p>
+        </>
+      )}
+    </DialogShell>
+  );
+}
+
+function SourceMenu({
+  source,
+  options,
+  onChange,
+}: {
+  source: Ruleset;
+  options: readonly Ruleset[];
+  onChange: (next: Ruleset) => void;
+}) {
+  return (
+    <MenuTrigger>
+      <RACButton
+        aria-label={`Source: SRD ${source}`}
+        className={styles.sourceTrigger}
+      >
+        Source: SRD {source} <span aria-hidden="true">▾</span>
+      </RACButton>
+      <Popover className={styles.sourcePopover} placement="bottom end">
+        <Menu
+          className={styles.sourceMenu}
+          onAction={(key) => onChange(String(key) as Ruleset)}
+        >
+          {options.map((opt) => (
+            <MenuItem key={opt} id={opt} className={styles.sourceItem}>
+              {opt}
+            </MenuItem>
+          ))}
+        </Menu>
+      </Popover>
+    </MenuTrigger>
+  );
+}
+
+type TypePanelProps = {
+  type: ContentType;
+  source: Ruleset;
+  query: string;
+  onQueryChange: (q: string) => void;
+  pickingKey: string | null;
+  pickError: string | null;
+  onPick: (rowKey: string, card: Card) => void;
+};
+
+function TypePanel({
+  type,
+  source,
+  query,
+  onQueryChange,
+  pickingKey,
+  pickError,
+  onPick,
+}: TypePanelProps) {
+  const results = type.useResults(source, query);
+  const emptyMessage = useMemo(
+    () => `No ${type.label.toLowerCase()} match your search.`,
+    [type.label],
+  );
+
+  return (
+    <>
+      <div className={styles.searchRow}>
+        <TextField aria-label={type.searchPlaceholder} className={styles.searchField}>
+          <Input
+            type="search"
+            placeholder={type.searchPlaceholder}
+            value={query}
+            onChange={(e) => onQueryChange(e.target.value)}
+            autoFocus
+          />
+        </TextField>
+      </div>
+
+      <div className={styles.results}>
+        {results.isLoading && <LoadingState />}
+        {results.isError && (
+          <div className={styles.state} role="alert">
+            Couldn't load the list.
+            <div className={styles.errorActions}>
+              <Button variant="secondary" size="sm" onPress={() => results.refetch()}>
+                Retry
+              </Button>
+            </div>
+          </div>
+        )}
+        {!results.isLoading && !results.isError && results.rows.length === 0 && (
+          <div className={styles.state}>{emptyMessage}</div>
+        )}
+        {pickError && (
+          <div className={styles.state} role="alert">
+            {pickError}
+          </div>
+        )}
+        {results.rows.map((row) => (
+          <button
+            key={row.key}
+            type="button"
+            className={styles.row}
+            onClick={() => onPick(row.key, row.toCard())}
+            disabled={pickingKey !== null}
+          >
+            <span className={styles.rowName}>{row.name}</span>
+            <span className={styles.rowMeta}>
+              {pickingKey === row.key ? "Loading…" : row.meta}
+            </span>
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}
+```
+
+- [ ] **Step 2: Replace `BrowseApiModal.module.css` with the updated rules.**
+
+```css
+/* src/views/BrowseApiModal.module.css */
+.layout {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+  container-type: inline-size;
+}
+
+.tabs {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+.tabList {
+  width: 10rem;
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-2) var(--space-2);
+  gap: var(--space-1);
+  border-right: 1px solid var(--color-border);
+  background: var(--color-surface-2);
+  outline: none;
+}
+
+.tab {
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  font: inherit;
+  font-family: var(--font-body);
+  color: var(--color-text);
+  cursor: pointer;
+  outline: none;
+}
+
+.tab[data-hovered]:not([data-selected]) {
+  background: var(--color-surface);
+}
+
+.tab[data-selected] {
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+  font-weight: 600;
+}
+
+.tab[data-focus-visible] {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.tabPanel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  outline: none;
+}
+
+.searchRow {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.searchField {
+  display: block;
+}
+
+.results {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--space-1) 0;
+}
+
+.row {
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-2) var(--space-4);
+  border: 0;
+  background: transparent;
+  text-align: left;
+  font: inherit;
+  font-family: var(--font-body);
+  cursor: pointer;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.row:last-child {
+  border-bottom: 0;
+}
+
+.row:hover:not(:disabled) {
+  background: var(--color-surface-2);
+}
+
+.row:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: -2px;
+}
+
+.row:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.rowName {
+  font-weight: 600;
+}
+
+.rowMeta {
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+}
+
+.state {
+  padding: var(--space-5);
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+.errorActions {
+  margin-top: var(--space-2);
+}
+
+.footer {
+  margin: 0;
+  padding: var(--space-3) var(--space-4);
+  border-top: 1px solid var(--color-border);
+  background: var(--color-surface-2);
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+  line-height: 1.4;
+}
+
+.sourceTrigger {
+  font: inherit;
+  font-family: var(--font-body);
+  font-size: var(--fs-sm);
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.sourceTrigger[data-focus-visible] {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.sourcePopover {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  outline: none;
+}
+
+.sourceMenu {
+  padding: var(--space-1);
+  outline: none;
+}
+
+.sourceItem {
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-sm);
+  cursor: pointer;
+  outline: none;
+}
+
+.sourceItem[data-hovered],
+.sourceItem[data-focused] {
+  background: var(--color-surface-2);
+}
+
+@container (max-width: 559px) {
+  .tabList {
+    display: none;
+  }
+}
+```
+
+> **Note on the narrow-viewport behavior:** the spec calls for the type sidebar to be replaced with a second `MenuTrigger` in the header at narrow widths. This plan implements only the sidebar-hide half; the spec defers visual verification of the narrow layout to manual QA. If a future task adds the type `MenuTrigger` to the header at narrow widths, it can be a small follow-up — leaving it out now avoids speculative UI for behavior that isn't unit-tested.
+>
+> The spec section 144 implies both halves; deviation noted here so the user can decide. If the user wants the full swap implemented now, add a second `MenuTrigger` next to `SourceMenu` in `BrowseApiModal` controlled by the same `typeId` state, with a CSS rule that hides it at `min-width: 560px` and shows it below.
+
+- [ ] **Step 3: Run typecheck.**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 4: Run the test suite.**
+
+Run: `npm test -- BrowseApiModal`
+Expected: all `BrowseApiModal` tests PASS. If any fail, read the output, fix the modal/CSS, re-run.
+
+- [ ] **Step 5: Run the full test suite to catch regressions.**
+
+Run: `npm test`
+Expected: all tests PASS. (Other suites should be untouched — `EditorView.test.tsx` and `DeckView.test.tsx` reference `BrowseApiModal` imports but its props haven't changed.)
+
+- [ ] **Step 6: Run lint.**
+
+Run: `npm run lint`
+Expected: PASS. If Biome reformats anything, accept it.
+
+- [ ] **Step 7: Smoke-test in the browser.**
+
+Run: `npm run dev`
+
+In the browser, open a deck and click "Browse SRD." Verify:
+1. The modal opens with the items sidebar tab selected and the items list visible.
+2. Clicking the "Spells" tab swaps the list and clears the search.
+3. Clicking the source button reveals 2014/2024; selecting one updates the list.
+4. Search filters the active list.
+5. Clicking an item adds it to the deck and closes the modal.
+6. Hitting Escape closes the modal.
+7. Resize the window narrow (≤ 540px wide-ish container) — the sidebar should disappear; the source dropdown still works.
+
+Stop the dev server.
+
+- [ ] **Step 8: Commit (test file + component + CSS together).**
+
+```bash
+git add src/views/BrowseApiModal.tsx src/views/BrowseApiModal.module.css src/views/BrowseApiModal.test.tsx
+git commit -m "refactor(browse): registry-driven layout with sidebar tabs and source menu"
+```
+
+---
+
+## Task 7: Final verification and PR-readiness check
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Confirm no stray imports of the old kind toggle still live in the modal.**
+
+Run: `grep -n "ToggleButton" src/views/BrowseApiModal.tsx`
+Expected: no matches.
+
+- [ ] **Step 2: Confirm the `Kind` union and `Pickable` types are gone.**
+
+Run: `grep -n "Pickable\|type Kind" src/views/BrowseApiModal.tsx`
+Expected: no matches.
+
+- [ ] **Step 3: Confirm content-type modules don't import each other.**
+
+Run: `grep -n "from \"\\./items\"" src/api/content-types/spells.ts && grep -n "from \"\\./spells\"" src/api/content-types/items.ts || echo "OK — modules are independent"`
+Expected: prints "OK — modules are independent".
+
+- [ ] **Step 4: Build.**
+
+Run: `npm run build`
+Expected: PASS. Catches any production-only TS issue (vite.config strict tsc).
+
+- [ ] **Step 5: Final test pass.**
+
+Run: `npm test && npm run lint && npm run typecheck`
+Expected: all PASS.
+
+- [ ] **Step 6: Review the diff.**
+
+Run: `git log --oneline origin/main..HEAD && git diff --stat origin/main..HEAD`
+Expected: 6 commits (Tasks 1–6), files limited to:
+- `src/api/content-types/{types,items,spells,index}.ts`
+- `src/views/BrowseApiModal.{tsx,module.css,test.tsx}`
+- `docs/superpowers/{specs,plans}/2026-05-09-srd-browse-rework-*.md`
+
+If unexpected files appear, reconcile before proceeding.
+
+- [ ] **Step 7: Stop.**
+
+Do **not** push, open a PR, or merge. Report completion to the user; they will decide whether to open a PR.
+
+---
+
+## Out-of-scope follow-ups (already in spec)
+
+- Sidebar counts (eager-load all type indices for `.length`)
+- Per-type attribute filters (rarity, level, school, CR)
+- Cross-type "All" view
+- Per-source attribution footer copy
+- Renaming dialog to "Browse Library" when fan/non-SRD content arrives
+- Narrow-viewport type `MenuTrigger` in the header (see note in Task 6)

--- a/docs/superpowers/specs/2026-05-09-srd-browse-rework-design.md
+++ b/docs/superpowers/specs/2026-05-09-srd-browse-rework-design.md
@@ -23,92 +23,176 @@ Reshape the dialog so adding a content type is a localized, additive change — 
 
 `DialogShell` size grows from `md` (640px) to `lg` (720px). At wide widths the dialog is split:
 
-- **Header** (existing `DialogHeader`): title "Browse SRD" on the left; a single `Select` "Source: SRD 2024 ▾" on the right; close button.
-- **Sidebar** (~160px, left): vertical list of registered content types, active type styled in `--color-primary`. Only types whose `supportedSources` include the current source are rendered; if the active type doesn't support the chosen source, see "Source × type interaction" below.
-- **Main pane** (right): existing search row + results list + attribution footer. No structural change beyond receiving the active type from the sidebar instead of from the kind toggle.
+- **Header** (existing `DialogHeader`): title "Browse SRD" on the left; a source dropdown on the right (visible label "SRD 2024 ▾"); close button.
+- **Sidebar** (10rem / 160px, left, literal in the new CSS module — no `--space-*` token at that magnitude): vertical list of registered content types, active type styled with `--color-primary`. Only types whose `supportedSources` include the current source render; selection rules in "Source × type interaction" below.
+- **Main pane** (right): existing search row + results list + attribution footer. No structural change beyond receiving the active type from the sidebar instead of the kind toggle.
 
-Sidebar uses **`Tabs` from `react-aria-components`** in vertical orientation. Sidebar items act like tabs (each one switches the active result panel), and the primitive gives keyboard nav (↑/↓/Home/End), focus management, and the right ARIA roles for free. Each `TabPanel` renders the search field + results for one type.
+Sidebar uses **`Tabs` from `react-aria-components`** in vertical orientation. Sidebar items act like tabs (each switches the active result panel); the primitive gives keyboard nav (↑/↓/Home/End), focus management, and ARIA roles for free. Each `TabPanel` renders the search field + results for one type.
+
+Source dropdown uses **`MenuTrigger` + `Popover` + `Menu` + `MenuItem` from `react-aria-components`** — the same pattern already used by `src/lib/ui/UserMenu.tsx`. There is no `Select` primitive in `lib/ui/` and we are not introducing one; the menu pattern is sufficient for a small read-only list of sources, requires zero new wrappers, and inherits the project's existing trigger styling. The trigger button shows the active source label; menu items are the available sources for the active type. Selection updates the source state.
 
 All styling uses existing screen tokens (`--color-*`, `--space-*`, `--radius-*`, `--fs-*`); no new tokens introduced.
 
 ### Type registry
 
-Replace the hardcoded `Kind` union and its switch sites with a single registry array. Each content type is a self-contained module:
+Replace the hardcoded `Kind` union and its switch sites with a registry array. The interface deliberately **closes over each type's entry shape inside the module** so the registry's element type is non-generic and the array is simply `ContentType[]`. (An earlier sketch typed the array as `ContentType<unknown>[]`; that does not typecheck because `rowMeta(entry)`/`toCard(entry, …)` are contravariant in `TEntry`.)
 
 ```ts
 // src/api/content-types/types.ts
-export type ContentType<TEntry> = {
-  id: string;                   // "items"
-  label: string;                // "Items"
-  searchPlaceholder: string;    // "Search items…"
-  emptyMessage: string;         // "No items match your search."
-  supportedSources: Ruleset[];  // ["2014", "2024"]
-  useIndex: (source: Ruleset) => UseQueryResult<{ results: TEntry[] }>;
-  rowMeta: (entry: TEntry) => string;          // right-side text on each row
-  toCard: (entry: TEntry, source: Ruleset) => Card;
+import type { Ruleset } from "../endpoints/magicItems";
+import type { Card } from "../../cards/types";
+
+export type ContentRow = {
+  key: string;
+  name: string;
+  meta: string;             // pre-rendered right-side text
+  toCard: () => Card;       // closes over the original entry + source
 };
 
-// src/api/content-types/index.ts
-export const CONTENT_TYPES: ContentType<unknown>[] = [items, spells];
+export type ContentTypeResults = {
+  isLoading: boolean;
+  isError: boolean;
+  refetch: () => void;
+  rows: ReadonlyArray<ContentRow>;
+};
+
+export type ContentType = {
+  id: string;                          // "items"
+  label: string;                       // "Items"
+  searchPlaceholder: string;           // derived once: `Search ${label.toLowerCase()}…`
+  supportedSources: readonly Ruleset[];
+  useResults: (source: Ruleset, query: string) => ContentTypeResults;
+};
 ```
 
-`BrowseApiModal` becomes type-agnostic: it iterates `CONTENT_TYPES` to render the sidebar/tab list, looks up the active type to drive the search field, calls its `useIndex` for results, and on click hands the entry to `toCard` then `useSaveCard`.
+Each module assembles its own `ContentType` and owns its entry shape end-to-end:
+
+```ts
+// src/api/content-types/items.ts (sketch — `capitalize` is a local helper today
+// in BrowseApiModal.tsx; it moves into the items module since only items use it)
+import { useMagicItemIndex } from "../hooks";
+import { magicItemDetailToCard } from "../mappers/magicItems";
+import type { ContentType } from "./types";
+
+const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+
+export const items: ContentType = {
+  id: "items",
+  label: "Items",
+  searchPlaceholder: "Search items…",
+  supportedSources: ["2014", "2024"] as const,
+  useResults: (source, query) => {
+    const idx = useMagicItemIndex(source);
+    const q = query.trim().toLowerCase();
+    const rows = (idx.data?.results ?? [])
+      .filter((e) => q === "" || e.name.toLowerCase().includes(q))
+      .map((entry) => ({
+        key: entry.key,
+        name: entry.name,
+        meta: capitalize(entry.rarity.name),
+        // ruleset injection lives inside the module, satisfying the existing mapper contract
+        toCard: () => magicItemDetailToCard({ ...entry, ruleset: source }),
+      }));
+    return {
+      isLoading: idx.isLoading,
+      isError: idx.isError,
+      refetch: idx.refetch,
+      rows,
+    };
+  },
+};
+```
+
+```ts
+// src/api/content-types/index.ts
+import { items } from "./items";
+import { spells } from "./spells";
+export const CONTENT_TYPES: readonly ContentType[] = [items, spells];
+```
+
+`BrowseApiModal` becomes type-agnostic: iterate `CONTENT_TYPES` to render the sidebar/tabs, look up the active type, call `useResults(source, query)`, render rows, on click call `row.toCard()` and pass the result to `useSaveCard`. The modal never sees `MagicItem` or `Spell` directly.
+
+**Payload preservation contract:** `toCard` injection of `ruleset` (today: `magicItemDetailToCard({ ...item.entry, ruleset })` at `BrowseApiModal.tsx:78–79`) moves *inside* each module's `toCard` closure. The `Card` payload produced is byte-identical to today's; `useSaveCard` keeps receiving the same shape.
 
 Re-homing existing pieces (no behavior change):
 
-- `magicItemDetailToCard` / `spellDetailToCard` → `toCard` on the items/spells type modules.
-- `useMagicItemIndex` / `useSpellIndex` → `useIndex` on each type module.
-- The current per-kind helpers (`itemMeta`, `spellMeta`, `placeholder`, `emptyMessage`) → fields on the type module.
+- `magicItemDetailToCard` / `spellDetailToCard` are still imported and called — by the type modules, not the modal.
+- `useMagicItemIndex` / `useSpellIndex` are called by the modules' `useResults`.
+- Per-kind helpers (`itemMeta`, `spellMeta`, `placeholder`, `emptyMessage`) become inline within their module.
 
-Adding monsters later is: create `src/api/content-types/monsters.ts`, append to the `CONTENT_TYPES` array. No edits to `BrowseApiModal`.
+Adding monsters later: create `src/api/content-types/monsters.ts`, append to `CONTENT_TYPES`. No edits to `BrowseApiModal`.
+
+**Why introduce the registry now (with only 2 types)?** CLAUDE.md cautions against "abstractions beyond what the task requires." The registry is justified here because the shape change is the actual scope of this rework — adding the third type without it would require touching `BrowseApiModal` again on the same lines. We're paying the abstraction cost once, alongside the layout change that benefits from it.
 
 ### Source × type interaction
 
-The header `Select` lists exactly the **active type's** `supportedSources` — nothing else appears. Switching the active type re-derives the dropdown options. If the previously selected source isn't supported by the new type, source falls back to the new type's first supported source (deterministic, no empty-pane dead end). Today every type supports both 2014 and 2024 so this is a no-op; the registry handles it correctly when a future type ships partial source coverage (e.g., monsters with only 2014 data).
+**One unified rule:** the source state is always a member of the active type's `supportedSources`. After every state change — initial mount, type switch, and any future registry change — the modal asserts this invariant; if the current source is not in the active type's list, it falls back to the active type's first supported source. The dropdown's options are exactly the active type's `supportedSources`, recomputed as the active type changes. Initial mount picks the first registered type and that type's first supported source.
+
+Today every type supports both 2014 and 2024 so the fallback path is a no-op; the rule pays for itself when a future type ships partial source coverage (e.g., monsters with only 2014 data).
 
 ### Search
 
-- Search stays scoped to the active type. Placeholder reads "Search {type}…" from the type module.
-- Query **clears on type switch.** A "fire" query for spells doesn't carry meaningful intent into items.
+- Search stays scoped to the active type. Placeholder reads from `type.searchPlaceholder`.
+- Query **clears on type switch.** A "fire" query for spells doesn't carry into items.
+- `pickError` also clears on type switch (consistent with query — both belong to the previous panel).
 - The current substring-on-name match logic stays as-is; no fuzzy match, no attribute filters.
+
+**Autofocus.** Today the search `<Input autoFocus>` focuses on dialog open (`BrowseApiModal.tsx:147`). With `react-aria-components` `Tabs`, only the active `TabPanel` is mounted, and its subtree unmounts/remounts on tab switch — so `autoFocus` on the panel-local search input fires both on open *and* on every tab switch, which is the desired behavior. No effect or `key`-driven remount is needed.
+
+### Pick lifecycle and tab switching
+
+`pickingKey` (the in-flight save state) currently disables all rows globally (`BrowseApiModal.tsx:181`). Behavior preserved: rows are disabled for the active panel during a save. The sidebar tabs are **not** disabled during a save — switching types mid-save is allowed (no extra coupling to add). The in-flight save still resolves; on success `onSelected` fires and the modal closes regardless of which tab is currently active. On error, `pickError` would render in the panel that owned the save; since panel state belongs to its tab, switching away effectively dismisses the error message — acceptable. (Documented here so the implementer doesn't have to rediscover it; matches today's behavior modulo the scope of `pickError` rendering.)
 
 ### Narrow viewports
 
-Modal width is `min(720px, 92vw)`. On a 375px viewport the dialog is ~345px wide and a 160px sidebar would crush the main pane. Use a **container query** (`@container` on the dialog) at ~560px:
+Modal width is `min(720px, 92vw)`. On a 375px viewport the dialog is ~345px wide and a 160px sidebar would crush the main pane. Use a container query at ~560px:
 
-- ≥ 560px: sidebar layout described above.
-- < 560px: hide sidebar; render type as a second `Select` ("Type: Items ▾") in the header next to the source select. Main pane gets full width. Same primitives, no markup duplication beyond the two header controls.
+- A `container-type: inline-size` declaration goes on a **wrapper element inside `BrowseApiModal`** (a top-level `<div className={styles.layout}>` that contains both the sidebar and main pane). It does **not** go on `DialogShell` — adding it there would change layout containment for every consumer (`IconPickerDialog`, `FirstDeckDialog`, the various confirm dialogs).
+- `@container (min-width: 560px)`: sidebar layout described above.
+- Below: hide sidebar; render type as a second dropdown (same `MenuTrigger` + `Menu` pattern as the source dropdown — one trigger labelled by the active type, menu items are the registered types) in the header next to the source dropdown. Main pane gets full width. No new primitives beyond the two header controls.
 
 ### Attribution footer
 
-Today's footer copy ("Only SRD spells and items are available…") is type-specific and breaks the moment we add monsters. Generalize to "Only SRD content is available…" and keep the SRD + CC BY 4.0 links unchanged. Footer remains rendered always; per-source variant copy is a future change.
+Today's footer copy ("Only SRD spells and items are available…") is type-specific and breaks the moment we add monsters. Generalize to "All content shown is from the SRD…" — keeps the SRD + CC BY 4.0 links exactly as they are, and reads naturally regardless of which types are registered. Footer remains rendered always; per-source variant copy is a future change when a non-SRD source ships.
 
 ## Component sketch
 
 - `BrowseApiModal.tsx`
-  - Owns: selected `typeId`, selected `source`, search query, picking state.
-  - Renders: `DialogShell` → `DialogHeader` (title + source `Select` + close) → vertical `Tabs` (sidebar = `TabList`, content = the active `TabPanel`).
-  - Each `TabPanel` renders `<TypePanel type={type} source={source} query={query} onQueryChange={...} onPick={...} />`.
+  - Owns: selected `typeId`, selected `source`, search query, picking state, pick error.
+  - Maintains the source-invariant rule (Source × type interaction) on every relevant state change.
+  - Renders: `DialogShell` → `DialogHeader` (title + source `MenuTrigger`/`Menu` + close) → wrapper `<div>` with `container-type: inline-size` → vertical `Tabs` (sidebar = `TabList`, content = the active `TabPanel`).
+  - At narrow widths, the sidebar is hidden by container query and a type `MenuTrigger` is shown in the header next to source.
+  - Each `TabPanel` renders `<TypePanel type={type} source={source} query={query} onQueryChange={...} onPick={...} pickingKey={pickingKey} pickError={pickError} />`.
 - `TypePanel` (new, internal to the file or co-located)
-  - Calls `type.useIndex(source)`, filters by query, renders the rows.
-  - Keeps the loading / error / empty / pick-error states from today (visuals unchanged).
+  - Calls `type.useResults(source, query)`, renders rows / loading / error / empty / pick-error states. Visuals unchanged from today.
+  - Hosts the `<Input autoFocus>` search field — a fresh mount on every tab switch reapplies focus.
 - `src/api/content-types/items.ts`, `src/api/content-types/spells.ts`
-  - Each exports a `ContentType` object built from the existing endpoint hook + mapper.
+  - Each exports a `ContentType` object that closes over its entry shape (`MagicItem` / `Spell`).
+- `src/api/content-types/types.ts`
+  - Exports `ContentType`, `ContentRow`, `ContentTypeResults`.
 - `src/api/content-types/index.ts`
   - Exports `CONTENT_TYPES`.
 
-The existing `BrowseApiModal.module.css` keeps its row / state / footer rules; new rules cover the sidebar/tabs and the container-query variant.
+The existing `BrowseApiModal.module.css` keeps its row / state / footer rules; new rules cover the layout wrapper, sidebar/tabs, and the container-query variant.
 
 ## Testing
 
-`BrowseApiModal.test.tsx` already exercises the modal end-to-end with MSW. Update it to:
+`BrowseApiModal.test.tsx` already exercises the modal end-to-end with MSW. Updates:
 
-- Assert the sidebar is rendered as a tablist with two tabs ("Items," "Spells") in the registered order.
-- Assert clicking a sidebar tab switches the placeholder, the visible rows, and clears the search query.
-- Assert the source `Select` lists the union of supported sources and switches results when changed.
-- Keep the existing "pick row → save card → onSelected fires" assertion.
+**Keep, unchanged in intent:**
+- Pick row → `useSaveCard` POSTs once → `onSelected` fires (still true via `row.toCard()`).
+- Escape closes the modal (`onClose` called).
+- Under StrictMode (the project's default), a single click results in a single POST — guards against the regression that surfaced in the StrictMode rollout.
+- Loading, empty, and error states render in the active panel; Retry triggers refetch.
 
-A small new test on the registry verifies that `CONTENT_TYPES` is non-empty and each entry exposes the required fields (acts as a guardrail when adding types).
+**New / revised:**
+- Assert the sidebar renders as a tablist with the registered types as tabs (today: "Items," "Spells") in registry order.
+- Clicking a sidebar tab switches placeholder text, rows, clears the search query, and clears any prior pick error.
+- Source dropdown options are exactly the active type's `supportedSources`. Switching the active type re-derives the options. (Today's two types both support 2014 and 2024, so this is a structural assertion via DOM, not a state transition.)
+- Switching source updates rows.
+- Below ~560px (set via container query — test by directly applying the narrow-state CSS class or by simulating container size if practical), the sidebar is hidden and a type dropdown appears in the header. If simulating container queries is impractical in JSDOM, fall back to a focused unit test against the layout component using a width prop or `data-` attribute as the toggle.
+
+**Dropped:** the previously proposed "registry shape guardrail" runtime test — TypeScript already enforces the shape; a runtime assert adds nothing.
 
 No new test infrastructure; existing MSW handlers continue to serve the bundled JSON.
 
@@ -118,11 +202,13 @@ None. Frontend refactor only — no database, RLS, or schema change. Saved cards
 
 ## Risks and edge cases
 
-- **Container query support**: relied on; current browser targets all support it.
-- **Vertical Tabs styling**: react-aria's `Tabs` defaults to horizontal; the orientation prop and CSS handle vertical layout. Verified pattern in their docs.
-- **Type with zero supported sources**: registry guards against this — such a type wouldn't appear at all.
+- **Container query support**: relied on; current browser targets all support it. The `container-type` declaration is scoped to the new layout wrapper inside `BrowseApiModal`, not `DialogShell`, so other dialog consumers are unaffected.
+- **Vertical Tabs styling**: `react-aria-components` `Tabs` defaults to horizontal; the `orientation="vertical"` prop plus CSS produces the sidebar.
+- **Type with zero supported sources**: registry filters such a type out of the sidebar.
+- **Active type's `useResults` errors**: the tab stays selected and the error renders inside the panel with a Retry button that calls `refetch()`. Today's behavior preserved (same control, scoped to the active panel).
+- **Switching tabs mid-save**: allowed. The save resolves regardless of active tab; on success `onSelected` fires and the modal closes. On error, `pickError` is rendered inside the panel that owned the save — switching away dismisses the error visually. Tab switch also clears `pickError` for the new panel.
 - **Dialog height**: keep `height={{ fixed: "min(70vh, 640px)" }}` from today; the sidebar inherits the dialog height.
-- **Focus on open**: search field still autofocuses on the active tab — preserves today's behavior.
+- **Focus on open and on tab switch**: `<Input autoFocus>` lives in the panel; RAC `Tabs` mounts only the active panel, so focus is applied on dialog open *and* on every tab switch. No effect needed.
 
 ## Out-of-scope follow-ups
 

--- a/docs/superpowers/specs/2026-05-09-srd-browse-rework-design.md
+++ b/docs/superpowers/specs/2026-05-09-srd-browse-rework-design.md
@@ -1,0 +1,133 @@
+# SRD browse modal — rework for content-type growth
+
+## Problem
+
+`BrowseApiModal` exposes two filter axes — content type (Items / Spells) and source (2014 / 2024 SRD) — as four sibling toggle buttons in the dialog header. Today that's manageable; we want to add monsters, effects, feats, and a few more types in the next year. With ~5–10 types the toggle row stops fitting and stops scaling. The modal also hardcodes the `Kind = "items" | "spells"` union and switches on it (mappers, hooks, placeholders, empty messages), so adding a new type means editing the modal in several places.
+
+## Goal
+
+Reshape the dialog so adding a content type is a localized, additive change — register one module, append it to a list, done. Visually, replace the four-toggle header with a left sidebar of types (the growing axis) and a single source dropdown in the header (the slow axis). Keep the modal a modal.
+
+## Non-goals
+
+- Counts in the sidebar. The bundled JSON would have to be dynamically imported for every registered type just to read `.length`. Not a clear win; trivial to add later.
+- Attribute filtering (rarity, spell level, school, CR, etc.). Out of scope for this rework.
+- Cross-type / "All" view with mixed listing. Users entering this dialog know whether they want a spell or an item; mixed listing changes how search behaves and is straightforward to add later if browsing patterns argue for it.
+- "Coming soon" placeholder rows for unimplemented types.
+- Renaming the dialog to "Browse Library." Stays "Browse SRD" until a non-SRD source actually ships.
+- Database changes. This is a frontend refactor; the saved card payload still flows through `useSaveCard` into the existing `cards` table.
+
+## Approach
+
+### Layout
+
+`DialogShell` size grows from `md` (640px) to `lg` (720px). At wide widths the dialog is split:
+
+- **Header** (existing `DialogHeader`): title "Browse SRD" on the left; a single `Select` "Source: SRD 2024 ▾" on the right; close button.
+- **Sidebar** (~160px, left): vertical list of registered content types, active type styled in `--color-primary`. Only types whose `supportedSources` include the current source are rendered; if the active type doesn't support the chosen source, see "Source × type interaction" below.
+- **Main pane** (right): existing search row + results list + attribution footer. No structural change beyond receiving the active type from the sidebar instead of from the kind toggle.
+
+Sidebar uses **`Tabs` from `react-aria-components`** in vertical orientation. Sidebar items act like tabs (each one switches the active result panel), and the primitive gives keyboard nav (↑/↓/Home/End), focus management, and the right ARIA roles for free. Each `TabPanel` renders the search field + results for one type.
+
+All styling uses existing screen tokens (`--color-*`, `--space-*`, `--radius-*`, `--fs-*`); no new tokens introduced.
+
+### Type registry
+
+Replace the hardcoded `Kind` union and its switch sites with a single registry array. Each content type is a self-contained module:
+
+```ts
+// src/api/content-types/types.ts
+export type ContentType<TEntry> = {
+  id: string;                   // "items"
+  label: string;                // "Items"
+  searchPlaceholder: string;    // "Search items…"
+  emptyMessage: string;         // "No items match your search."
+  supportedSources: Ruleset[];  // ["2014", "2024"]
+  useIndex: (source: Ruleset) => UseQueryResult<{ results: TEntry[] }>;
+  rowMeta: (entry: TEntry) => string;          // right-side text on each row
+  toCard: (entry: TEntry, source: Ruleset) => Card;
+};
+
+// src/api/content-types/index.ts
+export const CONTENT_TYPES: ContentType<unknown>[] = [items, spells];
+```
+
+`BrowseApiModal` becomes type-agnostic: it iterates `CONTENT_TYPES` to render the sidebar/tab list, looks up the active type to drive the search field, calls its `useIndex` for results, and on click hands the entry to `toCard` then `useSaveCard`.
+
+Re-homing existing pieces (no behavior change):
+
+- `magicItemDetailToCard` / `spellDetailToCard` → `toCard` on the items/spells type modules.
+- `useMagicItemIndex` / `useSpellIndex` → `useIndex` on each type module.
+- The current per-kind helpers (`itemMeta`, `spellMeta`, `placeholder`, `emptyMessage`) → fields on the type module.
+
+Adding monsters later is: create `src/api/content-types/monsters.ts`, append to the `CONTENT_TYPES` array. No edits to `BrowseApiModal`.
+
+### Source × type interaction
+
+The header `Select` lists exactly the **active type's** `supportedSources` — nothing else appears. Switching the active type re-derives the dropdown options. If the previously selected source isn't supported by the new type, source falls back to the new type's first supported source (deterministic, no empty-pane dead end). Today every type supports both 2014 and 2024 so this is a no-op; the registry handles it correctly when a future type ships partial source coverage (e.g., monsters with only 2014 data).
+
+### Search
+
+- Search stays scoped to the active type. Placeholder reads "Search {type}…" from the type module.
+- Query **clears on type switch.** A "fire" query for spells doesn't carry meaningful intent into items.
+- The current substring-on-name match logic stays as-is; no fuzzy match, no attribute filters.
+
+### Narrow viewports
+
+Modal width is `min(720px, 92vw)`. On a 375px viewport the dialog is ~345px wide and a 160px sidebar would crush the main pane. Use a **container query** (`@container` on the dialog) at ~560px:
+
+- ≥ 560px: sidebar layout described above.
+- < 560px: hide sidebar; render type as a second `Select` ("Type: Items ▾") in the header next to the source select. Main pane gets full width. Same primitives, no markup duplication beyond the two header controls.
+
+### Attribution footer
+
+Today's footer copy ("Only SRD spells and items are available…") is type-specific and breaks the moment we add monsters. Generalize to "Only SRD content is available…" and keep the SRD + CC BY 4.0 links unchanged. Footer remains rendered always; per-source variant copy is a future change.
+
+## Component sketch
+
+- `BrowseApiModal.tsx`
+  - Owns: selected `typeId`, selected `source`, search query, picking state.
+  - Renders: `DialogShell` → `DialogHeader` (title + source `Select` + close) → vertical `Tabs` (sidebar = `TabList`, content = the active `TabPanel`).
+  - Each `TabPanel` renders `<TypePanel type={type} source={source} query={query} onQueryChange={...} onPick={...} />`.
+- `TypePanel` (new, internal to the file or co-located)
+  - Calls `type.useIndex(source)`, filters by query, renders the rows.
+  - Keeps the loading / error / empty / pick-error states from today (visuals unchanged).
+- `src/api/content-types/items.ts`, `src/api/content-types/spells.ts`
+  - Each exports a `ContentType` object built from the existing endpoint hook + mapper.
+- `src/api/content-types/index.ts`
+  - Exports `CONTENT_TYPES`.
+
+The existing `BrowseApiModal.module.css` keeps its row / state / footer rules; new rules cover the sidebar/tabs and the container-query variant.
+
+## Testing
+
+`BrowseApiModal.test.tsx` already exercises the modal end-to-end with MSW. Update it to:
+
+- Assert the sidebar is rendered as a tablist with two tabs ("Items," "Spells") in the registered order.
+- Assert clicking a sidebar tab switches the placeholder, the visible rows, and clears the search query.
+- Assert the source `Select` lists the union of supported sources and switches results when changed.
+- Keep the existing "pick row → save card → onSelected fires" assertion.
+
+A small new test on the registry verifies that `CONTENT_TYPES` is non-empty and each entry exposes the required fields (acts as a guardrail when adding types).
+
+No new test infrastructure; existing MSW handlers continue to serve the bundled JSON.
+
+## Migration
+
+None. Frontend refactor only — no database, RLS, or schema change. Saved cards keep the same shape (`toCard` produces the same `Card` payload).
+
+## Risks and edge cases
+
+- **Container query support**: relied on; current browser targets all support it.
+- **Vertical Tabs styling**: react-aria's `Tabs` defaults to horizontal; the orientation prop and CSS handle vertical layout. Verified pattern in their docs.
+- **Type with zero supported sources**: registry guards against this — such a type wouldn't appear at all.
+- **Dialog height**: keep `height={{ fixed: "min(70vh, 640px)" }}` from today; the sidebar inherits the dialog height.
+- **Focus on open**: search field still autofocuses on the active tab — preserves today's behavior.
+
+## Out-of-scope follow-ups
+
+- Sidebar counts (eager-load all type indices, display `.length`).
+- Attribute filters per type (rarity, level, school, CR).
+- "All" cross-type view with row tags + unified search.
+- Per-source attribution footer copy when non-SRD sources land.
+- Renaming dialog to "Browse Library" when fan/non-SRD content arrives.

--- a/docs/superpowers/specs/2026-05-09-srd-browse-rework-design.md
+++ b/docs/superpowers/specs/2026-05-09-srd-browse-rework-design.md
@@ -83,16 +83,20 @@ export const items: ContentType = {
   supportedSources: ["2014", "2024"] as const,
   useResults: (source, query) => {
     const idx = useMagicItemIndex(source);
-    const q = query.trim().toLowerCase();
-    const rows = (idx.data?.results ?? [])
-      .filter((e) => q === "" || e.name.toLowerCase().includes(q))
-      .map((entry) => ({
-        key: entry.key,
-        name: entry.name,
-        meta: capitalize(entry.rarity.name),
-        // ruleset injection lives inside the module, satisfying the existing mapper contract
-        toCard: () => magicItemDetailToCard({ ...entry, ruleset: source }),
-      }));
+    // Memoize on the same triple BrowseApiModal currently uses
+    // (`useMemo([kind, itemIndex.data, query])` at BrowseApiModal.tsx:58–69).
+    const rows = useMemo(() => {
+      const q = query.trim().toLowerCase();
+      return (idx.data?.results ?? [])
+        .filter((e) => q === "" || e.name.toLowerCase().includes(q))
+        .map((entry) => ({
+          key: entry.key,
+          name: entry.name,
+          meta: capitalize(entry.rarity.name),
+          // ruleset injection lives inside the module, satisfying the existing mapper contract
+          toCard: () => magicItemDetailToCard({ ...entry, ruleset: source }),
+        }));
+    }, [idx.data, query, source]);
     return {
       isLoading: idx.isLoading,
       isError: idx.isError,
@@ -110,7 +114,9 @@ import { spells } from "./spells";
 export const CONTENT_TYPES: readonly ContentType[] = [items, spells];
 ```
 
-`BrowseApiModal` becomes type-agnostic: iterate `CONTENT_TYPES` to render the sidebar/tabs, look up the active type, call `useResults(source, query)`, render rows, on click call `row.toCard()` and pass the result to `useSaveCard`. The modal never sees `MagicItem` or `Spell` directly.
+`BrowseApiModal` becomes type-agnostic: it iterates `CONTENT_TYPES` to render `<Tab>` items in the `TabList` and a `<TabPanel key={type.id}>` per type. **The modal does not call `type.useResults` itself** — that would be a Rules-of-Hooks violation, since the resolved hook body would change as the active type changes. Instead, each `<TabPanel>` renders a `<TypePanel type={type} … />`, and `TypePanel` calls `type.useResults(source, query)` exactly once per render. Because `react-aria-components` `Tabs` only mounts the active `TabPanel` (default behavior — `shouldForceMount` is off), only one `TypePanel` is mounted at a time; switching the active type unmounts the prior `TypePanel` and mounts a fresh one keyed by `type.id`, so each `TypePanel` instance sees a single, stable `type` prop for its entire lifetime. This keeps the hook call order stable inside each `TypePanel`.
+
+On row click, `TypePanel` calls `row.toCard()` and hands the resulting `Card` up to the modal via the `onPick` prop, which in turn calls `useSaveCard.mutateAsync`. The modal never sees `MagicItem` or `Spell` directly.
 
 **Payload preservation contract:** `toCard` injection of `ruleset` (today: `magicItemDetailToCard({ ...item.entry, ruleset })` at `BrowseApiModal.tsx:78–79`) moves *inside* each module's `toCard` closure. The `Card` payload produced is byte-identical to today's; `useSaveCard` keeps receiving the same shape.
 
@@ -141,7 +147,11 @@ Today every type supports both 2014 and 2024 so the fallback path is a no-op; th
 
 ### Pick lifecycle and tab switching
 
-`pickingKey` (the in-flight save state) currently disables all rows globally (`BrowseApiModal.tsx:181`). Behavior preserved: rows are disabled for the active panel during a save. The sidebar tabs are **not** disabled during a save — switching types mid-save is allowed (no extra coupling to add). The in-flight save still resolves; on success `onSelected` fires and the modal closes regardless of which tab is currently active. On error, `pickError` would render in the panel that owned the save; since panel state belongs to its tab, switching away effectively dismisses the error message — acceptable. (Documented here so the implementer doesn't have to rediscover it; matches today's behavior modulo the scope of `pickError` rendering.)
+`pickingKey` and `pickError` are **single global pieces of state owned by `BrowseApiModal`** (not per-panel) — same as today. They flow into the active `TypePanel` as props.
+
+- `pickingKey` (the in-flight save key) disables rows in the active panel during a save (today: `BrowseApiModal.tsx:181`). Sidebar tabs are **not** disabled during a save; switching types mid-save is allowed.
+- The in-flight save still resolves regardless of which tab is currently active. On success `onSelected` fires and the modal closes.
+- `pickError` clears whenever the active type changes (the modal resets it on type switch, just like `query`). On error mid-save, `pickError` renders in whichever panel is active when the render happens — typically the panel that initiated the save, but if the user has switched away the prior panel is no longer mounted and the error is dismissed visually. This matches today's user-perceived behavior since the modal closes on success and the error is short-lived in failure.
 
 ### Narrow viewports
 
@@ -190,9 +200,10 @@ The existing `BrowseApiModal.module.css` keeps its row / state / footer rules; n
 - Clicking a sidebar tab switches placeholder text, rows, clears the search query, and clears any prior pick error.
 - Source dropdown options are exactly the active type's `supportedSources`. Switching the active type re-derives the options. (Today's two types both support 2014 and 2024, so this is a structural assertion via DOM, not a state transition.)
 - Switching source updates rows.
-- Below ~560px (set via container query — test by directly applying the narrow-state CSS class or by simulating container size if practical), the sidebar is hidden and a type dropdown appears in the header. If simulating container queries is impractical in JSDOM, fall back to a focused unit test against the layout component using a width prop or `data-` attribute as the toggle.
 
 **Dropped:** the previously proposed "registry shape guardrail" runtime test — TypeScript already enforces the shape; a runtime assert adds nothing.
+
+**Out of scope for unit tests:** the narrow-viewport layout swap is CSS-only (a `@container` rule that hides one element and shows another). The state machine — active type, source, query, picking — is identical at both widths, so the assertions above cover behavior at any width. We do **not** add a JSDOM-only `data-narrow` runtime toggle to make container queries testable; that would diverge production from the test path. Visual verification of the narrow layout is left to manual QA / future E2E.
 
 No new test infrastructure; existing MSW handlers continue to serve the bundled JSON.
 

--- a/src/api/content-types/index.ts
+++ b/src/api/content-types/index.ts
@@ -1,0 +1,7 @@
+import { itemsContentType } from "./items";
+import { spellsContentType } from "./spells";
+import type { ContentType } from "./types";
+
+export const CONTENT_TYPES: readonly ContentType[] = [itemsContentType, spellsContentType];
+
+export type { ContentRow, ContentType, ContentTypeResults } from "./types";

--- a/src/api/content-types/index.ts
+++ b/src/api/content-types/index.ts
@@ -2,6 +2,9 @@ import { itemsContentType } from "./items";
 import { spellsContentType } from "./spells";
 import type { ContentType } from "./types";
 
-export const CONTENT_TYPES: readonly ContentType[] = [itemsContentType, spellsContentType];
+export const CONTENT_TYPES: readonly [ContentType, ...ContentType[]] = [
+  itemsContentType,
+  spellsContentType,
+];
 
 export type { ContentRow, ContentType, ContentTypeResults } from "./types";

--- a/src/api/content-types/items.ts
+++ b/src/api/content-types/items.ts
@@ -5,8 +5,8 @@ import type { ContentType } from "./types";
 
 export const itemsContentType: ContentType = {
   id: "items",
-  label: "Items",
-  searchPlaceholder: "Search items…",
+  label: "Magic Items",
+  searchPlaceholder: "Search magic items…",
   supportedSources: ["2024", "2014"],
   useResults: (source, query) => {
     const idx = useMagicItemIndex(source);

--- a/src/api/content-types/items.ts
+++ b/src/api/content-types/items.ts
@@ -1,0 +1,33 @@
+import { useMemo } from "react";
+import { useMagicItemIndex } from "../hooks";
+import { magicItemDetailToCard } from "../mappers/magicItems";
+import type { ContentType } from "./types";
+
+const capitalize = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+
+export const itemsContentType: ContentType = {
+  id: "items",
+  label: "Items",
+  searchPlaceholder: "Search items…",
+  supportedSources: ["2014", "2024"] as const,
+  useResults: (source, query) => {
+    const idx = useMagicItemIndex(source);
+    const rows = useMemo(() => {
+      const q = query.trim().toLowerCase();
+      return (idx.data?.results ?? [])
+        .filter((e) => q === "" || e.name.toLowerCase().includes(q))
+        .map((entry) => ({
+          key: entry.key,
+          name: entry.name,
+          meta: capitalize(entry.rarity.name),
+          toCard: () => magicItemDetailToCard({ ...entry, ruleset: source }),
+        }));
+    }, [idx.data, query, source]);
+    return {
+      isLoading: idx.isLoading,
+      isError: idx.isError,
+      refetch: idx.refetch,
+      rows,
+    };
+  },
+};

--- a/src/api/content-types/items.ts
+++ b/src/api/content-types/items.ts
@@ -3,13 +3,11 @@ import { useMagicItemIndex } from "../hooks";
 import { magicItemDetailToCard } from "../mappers/magicItems";
 import type { ContentType } from "./types";
 
-const capitalize = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
-
 export const itemsContentType: ContentType = {
   id: "items",
   label: "Items",
   searchPlaceholder: "Search items…",
-  supportedSources: ["2024", "2014"] as const,
+  supportedSources: ["2024", "2014"],
   useResults: (source, query) => {
     const idx = useMagicItemIndex(source);
     const rows = useMemo(() => {
@@ -19,7 +17,7 @@ export const itemsContentType: ContentType = {
         .map((entry) => ({
           key: entry.key,
           name: entry.name,
-          meta: capitalize(entry.rarity.name),
+          meta: entry.rarity.name,
           toCard: () => magicItemDetailToCard({ ...entry, ruleset: source }),
         }));
     }, [idx.data, query, source]);

--- a/src/api/content-types/items.ts
+++ b/src/api/content-types/items.ts
@@ -9,7 +9,7 @@ export const itemsContentType: ContentType = {
   id: "items",
   label: "Items",
   searchPlaceholder: "Search items…",
-  supportedSources: ["2014", "2024"] as const,
+  supportedSources: ["2024", "2014"] as const,
   useResults: (source, query) => {
     const idx = useMagicItemIndex(source);
     const rows = useMemo(() => {

--- a/src/api/content-types/spells.ts
+++ b/src/api/content-types/spells.ts
@@ -1,28 +1,13 @@
 import { useMemo } from "react";
 import { useSpellIndex } from "../hooks";
-import { spellDetailToCard } from "../mappers/spells";
+import { levelTag, spellDetailToCard } from "../mappers/spells";
 import type { ContentType } from "./types";
-
-const ordinal = (n: number): string => {
-  if (n === 1) return "1st";
-  if (n === 2) return "2nd";
-  if (n === 3) return "3rd";
-  return `${n}th`;
-};
-
-const capitalize = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
-
-const spellMeta = (level: number, schoolName: string): string => {
-  const school = schoolName.toLowerCase();
-  if (level === 0) return `${capitalize(school)} cantrip`;
-  return `${ordinal(level)}-level ${school}`;
-};
 
 export const spellsContentType: ContentType = {
   id: "spells",
   label: "Spells",
   searchPlaceholder: "Search spells…",
-  supportedSources: ["2024", "2014"] as const,
+  supportedSources: ["2024", "2014"],
   useResults: (source, query) => {
     const idx = useSpellIndex(source);
     const rows = useMemo(() => {
@@ -32,7 +17,7 @@ export const spellsContentType: ContentType = {
         .map((entry) => ({
           key: entry.key,
           name: entry.name,
-          meta: spellMeta(entry.level, entry.school.name),
+          meta: levelTag(entry.level, entry.school.name),
           toCard: () => spellDetailToCard({ ...entry, ruleset: source }),
         }));
     }, [idx.data, query, source]);

--- a/src/api/content-types/spells.ts
+++ b/src/api/content-types/spells.ts
@@ -1,0 +1,46 @@
+import { useMemo } from "react";
+import { useSpellIndex } from "../hooks";
+import { spellDetailToCard } from "../mappers/spells";
+import type { ContentType } from "./types";
+
+const ordinal = (n: number): string => {
+  if (n === 1) return "1st";
+  if (n === 2) return "2nd";
+  if (n === 3) return "3rd";
+  return `${n}th`;
+};
+
+const capitalize = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+
+const spellMeta = (level: number, schoolName: string): string => {
+  const school = schoolName.toLowerCase();
+  if (level === 0) return `${capitalize(school)} cantrip`;
+  return `${ordinal(level)}-level ${school}`;
+};
+
+export const spellsContentType: ContentType = {
+  id: "spells",
+  label: "Spells",
+  searchPlaceholder: "Search spells…",
+  supportedSources: ["2014", "2024"] as const,
+  useResults: (source, query) => {
+    const idx = useSpellIndex(source);
+    const rows = useMemo(() => {
+      const q = query.trim().toLowerCase();
+      return (idx.data?.results ?? [])
+        .filter((e) => q === "" || e.name.toLowerCase().includes(q))
+        .map((entry) => ({
+          key: entry.key,
+          name: entry.name,
+          meta: spellMeta(entry.level, entry.school.name),
+          toCard: () => spellDetailToCard({ ...entry, ruleset: source }),
+        }));
+    }, [idx.data, query, source]);
+    return {
+      isLoading: idx.isLoading,
+      isError: idx.isError,
+      refetch: idx.refetch,
+      rows,
+    };
+  },
+};

--- a/src/api/content-types/spells.ts
+++ b/src/api/content-types/spells.ts
@@ -22,7 +22,7 @@ export const spellsContentType: ContentType = {
   id: "spells",
   label: "Spells",
   searchPlaceholder: "Search spells…",
-  supportedSources: ["2014", "2024"] as const,
+  supportedSources: ["2024", "2014"] as const,
   useResults: (source, query) => {
     const idx = useSpellIndex(source);
     const rows = useMemo(() => {

--- a/src/api/content-types/types.ts
+++ b/src/api/content-types/types.ts
@@ -1,0 +1,24 @@
+import type { Card } from "../../cards/types";
+import type { Ruleset } from "../endpoints/magicItems";
+
+export type ContentRow = {
+  key: string;
+  name: string;
+  meta: string;
+  toCard: () => Card;
+};
+
+export type ContentTypeResults = {
+  isLoading: boolean;
+  isError: boolean;
+  refetch: () => void;
+  rows: ReadonlyArray<ContentRow>;
+};
+
+export type ContentType = {
+  id: string;
+  label: string;
+  searchPlaceholder: string;
+  supportedSources: readonly Ruleset[];
+  useResults: (source: Ruleset, query: string) => ContentTypeResults;
+};

--- a/src/api/content-types/types.ts
+++ b/src/api/content-types/types.ts
@@ -19,6 +19,6 @@ export type ContentType = {
   id: string;
   label: string;
   searchPlaceholder: string;
-  supportedSources: readonly Ruleset[];
+  supportedSources: readonly [Ruleset, ...Ruleset[]];
   useResults: (source: Ruleset, query: string) => ContentTypeResults;
 };

--- a/src/api/mappers/spells.ts
+++ b/src/api/mappers/spells.ts
@@ -10,7 +10,7 @@ const ordinal = (n: number): string => {
   return `${n}th`;
 };
 
-const levelTag = (level: number, schoolName: string): string => {
+export const levelTag = (level: number, schoolName: string): string => {
   if (level === 0) {
     const cap = schoolName.charAt(0).toUpperCase() + schoolName.slice(1).toLowerCase();
     return `${cap} cantrip`;

--- a/src/views/BrowseApiModal.module.css
+++ b/src/views/BrowseApiModal.module.css
@@ -1,8 +1,15 @@
+.modalContainer {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  container-type: inline-size;
+}
+
 .layout {
   flex: 1;
   display: flex;
   min-height: 0;
-  container-type: inline-size;
 }
 
 .tabs {
@@ -200,8 +207,17 @@
   background: var(--color-surface-2);
 }
 
+.typeMenuTrigger {
+  display: none;
+}
+
 @container (max-width: 559px) {
   .tabList {
     display: none;
+  }
+  .typeMenuTrigger {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
   }
 }

--- a/src/views/BrowseApiModal.module.css
+++ b/src/views/BrowseApiModal.module.css
@@ -41,7 +41,7 @@
 }
 
 .tab[data-hovered]:not([data-selected]) {
-  background: var(--color-border);
+  background: var(--color-border-strong);
 }
 
 .tab[data-selected] {
@@ -76,6 +76,8 @@
 .results {
   flex: 1;
   min-height: 0;
+  display: flex;
+  flex-direction: column;
   overflow-y: auto;
   padding: var(--space-1) 0;
 }
@@ -131,7 +133,6 @@
 .stateError {
   color: var(--color-danger);
   background: var(--color-danger-bg-hover);
-  border-bottom: 1px solid var(--color-border);
 }
 
 .statePane {
@@ -155,7 +156,7 @@
   line-height: 1.4;
 }
 
-.sourceTrigger {
+.menuTrigger {
   font: inherit;
   font-family: var(--font-body);
   font-size: var(--fs-sm);
@@ -167,21 +168,21 @@
   cursor: pointer;
 }
 
-.sourceTrigger[data-hovered] {
+.menuTrigger[data-hovered] {
   background: var(--color-surface-2);
   border-color: var(--color-border-strong);
 }
 
-.sourceTrigger[data-pressed] {
+.menuTrigger[data-pressed] {
   background: var(--color-border);
 }
 
-.sourceTrigger[data-focus-visible] {
+.menuTrigger[data-focus-visible] {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
 }
 
-.sourcePopover {
+.menuPopover {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
@@ -189,12 +190,12 @@
   outline: none;
 }
 
-.sourceMenu {
+.menu {
   padding: var(--space-1);
   outline: none;
 }
 
-.sourceItem {
+.menuItem {
   padding: var(--space-1) var(--space-3);
   border-radius: var(--radius-sm);
   font-size: var(--fs-sm);
@@ -202,8 +203,8 @@
   outline: none;
 }
 
-.sourceItem[data-hovered],
-.sourceItem[data-focused] {
+.menuItem[data-hovered],
+.menuItem[data-focused] {
   background: var(--color-surface-2);
 }
 

--- a/src/views/BrowseApiModal.module.css
+++ b/src/views/BrowseApiModal.module.css
@@ -34,7 +34,7 @@
 }
 
 .tab[data-hovered]:not([data-selected]) {
-  background: var(--color-surface);
+  background: var(--color-border);
 }
 
 .tab[data-selected] {
@@ -121,6 +121,19 @@
   color: var(--color-text-muted);
 }
 
+.stateError {
+  color: var(--color-danger);
+  background: var(--color-danger-bg-hover);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.statePane {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .errorActions {
   margin-top: var(--space-2);
 }
@@ -145,6 +158,15 @@
   background: var(--color-surface);
   color: var(--color-text);
   cursor: pointer;
+}
+
+.sourceTrigger[data-hovered] {
+  background: var(--color-surface-2);
+  border-color: var(--color-border-strong);
+}
+
+.sourceTrigger[data-pressed] {
+  background: var(--color-border);
 }
 
 .sourceTrigger[data-focus-visible] {

--- a/src/views/BrowseApiModal.module.css
+++ b/src/views/BrowseApiModal.module.css
@@ -1,3 +1,62 @@
+.layout {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+  container-type: inline-size;
+}
+
+.tabs {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+.tabList {
+  width: 10rem;
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  padding: var(--space-2) var(--space-2);
+  gap: var(--space-1);
+  border-right: 1px solid var(--color-border);
+  background: var(--color-surface-2);
+  outline: none;
+}
+
+.tab {
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  font: inherit;
+  font-family: var(--font-body);
+  color: var(--color-text);
+  cursor: pointer;
+  outline: none;
+}
+
+.tab[data-hovered]:not([data-selected]) {
+  background: var(--color-surface);
+}
+
+.tab[data-selected] {
+  background: var(--color-accent);
+  color: var(--color-accent-fg);
+  font-weight: 600;
+}
+
+.tab[data-focus-visible] {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.tabPanel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  outline: none;
+}
+
 .searchRow {
   padding: var(--space-3) var(--space-4);
   border-bottom: 1px solid var(--color-border);
@@ -66,12 +125,6 @@
   margin-top: var(--space-2);
 }
 
-.toggles {
-  display: flex;
-  gap: var(--space-3);
-  flex-wrap: wrap;
-}
-
 .footer {
   margin: 0;
   padding: var(--space-3) var(--space-4);
@@ -80,4 +133,53 @@
   font-size: var(--fs-sm);
   color: var(--color-text-muted);
   line-height: 1.4;
+}
+
+.sourceTrigger {
+  font: inherit;
+  font-family: var(--font-body);
+  font-size: var(--fs-sm);
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.sourceTrigger[data-focus-visible] {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.sourcePopover {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  outline: none;
+}
+
+.sourceMenu {
+  padding: var(--space-1);
+  outline: none;
+}
+
+.sourceItem {
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-sm);
+  cursor: pointer;
+  outline: none;
+}
+
+.sourceItem[data-hovered],
+.sourceItem[data-focused] {
+  background: var(--color-surface-2);
+}
+
+@container (max-width: 559px) {
+  .tabList {
+    display: none;
+  }
 }

--- a/src/views/BrowseApiModal.test.tsx
+++ b/src/views/BrowseApiModal.test.tsx
@@ -33,7 +33,19 @@ const makeClient = (seeds: Seeds = {}) => {
 const wrap = (ui: ReactNode, client: QueryClient) =>
   render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
 
+const openSourceMenu = async () => {
+  await userEvent.click(screen.getByRole("button", { name: /^Source:/ }));
+};
+
 describe("<BrowseApiModal>", () => {
+  test("renders the registered types as a vertical tablist in registry order", async () => {
+    const client = makeClient({ items: { "2024": { count: 0, results: [] } } });
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs.map((t) => t.textContent)).toEqual(["Items", "Spells"]);
+  });
+
   test("shows index entries once the items list loads", async () => {
     const entryA = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
     const entryB = magicItemIndexEntryFactory.build({ name: "Cloak of Protection" });
@@ -59,7 +71,7 @@ describe("<BrowseApiModal>", () => {
     expect(screen.queryByRole("button", { name: /Cloak of Protection/ })).not.toBeInTheDocument();
   });
 
-  test("switching ruleset loads a different items list", async () => {
+  test("switching source loads a different items list", async () => {
     const v2024 = magicItemIndexEntryFactory.build({ name: "Ring A" });
     const v2014 = magicItemIndexEntryFactory.build({ name: "Ring Z" });
     const client = makeClient({
@@ -72,13 +84,14 @@ describe("<BrowseApiModal>", () => {
     wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
 
     await screen.findByRole("button", { name: /Ring A/ });
-    await userEvent.click(screen.getByRole("radio", { name: "2014" }));
+    await openSourceMenu();
+    await userEvent.click(screen.getByRole("menuitem", { name: "2014" }));
 
     await waitFor(() => expect(screen.getByRole("button", { name: /Ring Z/ })).toBeInTheDocument());
     expect(screen.queryByRole("button", { name: /Ring A/ })).not.toBeInTheDocument();
   });
 
-  test("switching kind to Spells swaps the list source", async () => {
+  test("switching to the Spells tab swaps the list source", async () => {
     const item = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
     const spell = spellIndexEntryFactory.build({ name: "Fireball" });
     const client = makeClient({
@@ -89,12 +102,32 @@ describe("<BrowseApiModal>", () => {
     wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
 
     await screen.findByRole("button", { name: /Bag of Holding/ });
-    await userEvent.click(screen.getByRole("radio", { name: "Spells" }));
+    await userEvent.click(screen.getByRole("tab", { name: "Spells" }));
 
     await waitFor(() =>
       expect(screen.getByRole("button", { name: /Fireball/ })).toBeInTheDocument(),
     );
     expect(screen.queryByRole("button", { name: /Bag of Holding/ })).not.toBeInTheDocument();
+  });
+
+  test("switching tabs clears the search query", async () => {
+    const item = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
+    const spell = spellIndexEntryFactory.build({ name: "Fireball" });
+    const client = makeClient({
+      items: { "2024": { count: 1, results: [item] } },
+      spells: { "2024": { count: 1, results: [spell] } },
+    });
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    await screen.findByRole("button", { name: /Bag of Holding/ });
+    await userEvent.type(screen.getByRole("searchbox"), "bag");
+
+    await userEvent.click(screen.getByRole("tab", { name: "Spells" }));
+
+    const spellsSearch = await screen.findByRole("searchbox");
+    expect(spellsSearch).toHaveValue("");
+    expect(spellsSearch).toHaveAttribute("placeholder", "Search spells…");
   });
 
   test("clicking an item POSTs a card with kind:item", async () => {
@@ -132,7 +165,7 @@ describe("<BrowseApiModal>", () => {
 
     wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={onSelected} />, client);
 
-    await userEvent.click(screen.getByRole("radio", { name: "Spells" }));
+    await userEvent.click(screen.getByRole("tab", { name: "Spells" }));
     await userEvent.click(await screen.findByRole("button", { name: /Fireball/ }));
 
     await waitFor(() => expect(onPost).toHaveBeenCalled());
@@ -204,7 +237,7 @@ describe("<BrowseApiModal>", () => {
 
     wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
 
-    await userEvent.click(screen.getByRole("radio", { name: "Spells" }));
+    await userEvent.click(screen.getByRole("tab", { name: "Spells" }));
     const cantripRow = await screen.findByRole("button", { name: /Light/ });
     expect(cantripRow).toHaveTextContent("Evocation cantrip");
     const leveledRow = screen.getByRole("button", { name: /Fireball/ });

--- a/src/views/BrowseApiModal.test.tsx
+++ b/src/views/BrowseApiModal.test.tsx
@@ -44,7 +44,7 @@ describe("<BrowseApiModal>", () => {
     wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
 
     const tabs = screen.getAllByRole("tab");
-    expect(tabs.map((t) => t.textContent)).toEqual(["Items", "Spells"]);
+    expect(tabs.map((t) => t.textContent)).toEqual(["Magic Items", "Spells"]);
   });
 
   test("shows index entries once the items list loads", async () => {

--- a/src/views/BrowseApiModal.test.tsx
+++ b/src/views/BrowseApiModal.test.tsx
@@ -4,6 +4,7 @@ import { HttpResponse, http } from "msw";
 import type { ReactNode } from "react";
 import { describe, expect, test, vi } from "vitest";
 import type { MagicItemIndex, Ruleset } from "../api/endpoints/magicItems";
+import * as magicItemsEndpoint from "../api/endpoints/magicItems";
 import type { SpellIndex } from "../api/endpoints/spells";
 import { magicItemIndexEntryFactory, spellIndexEntryFactory } from "../api/factories";
 import { makeCardRow } from "../test/factories";
@@ -193,8 +194,6 @@ describe("<BrowseApiModal>", () => {
     await userEvent.click(await screen.findByRole("button", { name: /Flame Tongue/ }));
 
     await waitFor(() => expect(onPost).toHaveBeenCalledTimes(1));
-    await new Promise((r) => setTimeout(r, 50));
-    expect(onPost).toHaveBeenCalledTimes(1);
   });
 
   test("Escape calls onClose", async () => {
@@ -251,5 +250,53 @@ describe("<BrowseApiModal>", () => {
       "href",
       "https://www.dndbeyond.com/srd",
     );
+  });
+
+  test("source menu lists exactly the active type's supportedSources", async () => {
+    const client = makeClient({ items: { "2024": { count: 0, results: [] } } });
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    await openSourceMenu();
+    const items = screen.getAllByRole("menuitem");
+    expect(items.map((el) => el.textContent)).toEqual(["2024", "2014"]);
+  });
+
+  test("pick error clears when switching tabs", async () => {
+    const item = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
+    const spell = spellIndexEntryFactory.build({ name: "Fireball" });
+    const client = makeClient({
+      items: { "2024": { count: 1, results: [item] } },
+      spells: { "2024": { count: 1, results: [spell] } },
+    });
+    server.use(http.post(`${SB_URL}/rest/v1/cards`, () => HttpResponse.error()));
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    await userEvent.click(await screen.findByRole("button", { name: /Bag of Holding/ }));
+    await screen.findByRole("alert");
+
+    await userEvent.click(screen.getByRole("tab", { name: "Spells" }));
+
+    await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
+  });
+
+  test("renders a loading state while the items index is fetching", async () => {
+    vi.spyOn(magicItemsEndpoint, "fetchMagicItemIndex").mockReturnValue(
+      new Promise<MagicItemIndex>(() => {}),
+    );
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    expect(await screen.findByRole("status")).toHaveTextContent("Loading…");
+  });
+
+  test("shows a Retry button when the items index fails to load", async () => {
+    vi.spyOn(magicItemsEndpoint, "fetchMagicItemIndex").mockRejectedValue(new Error("boom"));
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    expect(await screen.findByRole("button", { name: "Retry" })).toBeInTheDocument();
   });
 });

--- a/src/views/BrowseApiModal.tsx
+++ b/src/views/BrowseApiModal.tsx
@@ -1,10 +1,19 @@
-import { useMemo, useState } from "react";
-import { TextField } from "react-aria-components";
+import { useEffect, useMemo, useState } from "react";
+import {
+  Menu,
+  MenuItem,
+  MenuTrigger,
+  Popover,
+  Button as RACButton,
+  Tab,
+  TabList,
+  TabPanel,
+  Tabs,
+  TextField,
+} from "react-aria-components";
+import { CONTENT_TYPES, type ContentType } from "../api/content-types";
 import type { Ruleset } from "../api/endpoints/magicItems";
-import { useMagicItemIndex, useSpellIndex } from "../api/hooks";
-import { magicItemDetailToCard } from "../api/mappers/magicItems";
-import { spellDetailToCard } from "../api/mappers/spells";
-import type { MagicItem, Spell } from "../data/srd-schema";
+import type { Card } from "../cards/types";
 import { useSaveCard } from "../decks/mutations";
 import { Button } from "../lib/ui/Button";
 import { DialogHeader } from "../lib/ui/DialogHeader";
@@ -12,30 +21,7 @@ import { DialogShell } from "../lib/ui/DialogShell";
 import { Input } from "../lib/ui/Input";
 import { Link } from "../lib/ui/Link";
 import { LoadingState } from "../lib/ui/LoadingState";
-import { ToggleButton } from "../lib/ui/ToggleButton";
-import { ToggleButtonGroup } from "../lib/ui/ToggleButtonGroup";
 import styles from "./BrowseApiModal.module.css";
-
-type Kind = "items" | "spells";
-
-type Pickable = { kind: "items"; entry: MagicItem } | { kind: "spells"; entry: Spell };
-
-const ordinal = (n: number): string => {
-  if (n === 1) return "1st";
-  if (n === 2) return "2nd";
-  if (n === 3) return "3rd";
-  return `${n}th`;
-};
-
-const capitalize = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
-
-const itemMeta = (item: MagicItem): string => capitalize(item.rarity.name);
-
-const spellMeta = (spell: Spell): string => {
-  const school = spell.school.name.toLowerCase();
-  if (spell.level === 0) return `${capitalize(school)} cantrip`;
-  return `${ordinal(spell.level)}-level ${school}`;
-};
 
 type Props = {
   deckId: string;
@@ -44,39 +30,37 @@ type Props = {
 };
 
 export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
-  const [kind, setKind] = useState<Kind>("items");
-  const [ruleset, setRuleset] = useState<Ruleset>("2024");
+  const [typeId, setTypeId] = useState<string>(() => CONTENT_TYPES[0]?.id ?? "");
+  const activeType = CONTENT_TYPES.find((t) => t.id === typeId) ?? CONTENT_TYPES[0];
+  if (!activeType) {
+    throw new Error("CONTENT_TYPES is empty");
+  }
+
+  const [source, setSource] = useState<Ruleset>("2024");
+  useEffect(() => {
+    if (!activeType.supportedSources.includes(source)) {
+      const fallback = activeType.supportedSources[0];
+      if (fallback) setSource(fallback);
+    }
+  }, [activeType, source]);
+
   const [query, setQuery] = useState("");
   const [pickingKey, setPickingKey] = useState<string | null>(null);
   const [pickError, setPickError] = useState<string | null>(null);
 
-  const itemIndex = useMagicItemIndex(ruleset);
-  const spellIndex = useSpellIndex(ruleset);
-  const index = kind === "items" ? itemIndex : spellIndex;
+  const handleTabChange = (next: string) => {
+    if (next === typeId) return;
+    setTypeId(next);
+    setQuery("");
+    setPickError(null);
+  };
+
   const saveCard = useSaveCard();
-
-  const filtered = useMemo<Pickable[]>(() => {
-    const q = query.trim().toLowerCase();
-    const matches = (name: string) => q === "" || name.toLowerCase().includes(q);
-    if (kind === "items") {
-      return (itemIndex.data?.results ?? [])
-        .filter((e) => matches(e.name))
-        .map((entry) => ({ kind: "items", entry }));
-    }
-    return (spellIndex.data?.results ?? [])
-      .filter((e) => matches(e.name))
-      .map((entry) => ({ kind: "spells", entry }));
-  }, [kind, itemIndex.data, spellIndex.data, query]);
-
-  const handlePick = async (item: Pickable) => {
+  const handlePick = async (rowKey: string, card: Card) => {
     if (pickingKey !== null) return;
-    setPickingKey(item.entry.key);
+    setPickingKey(rowKey);
     setPickError(null);
     try {
-      const card =
-        item.kind === "items"
-          ? magicItemDetailToCard({ ...item.entry, ruleset })
-          : spellDetailToCard({ ...item.entry, ruleset });
       await saveCard.mutateAsync({ card, deckId, isNew: true });
       onSelected(card.id);
     } catch (err) {
@@ -88,11 +72,6 @@ export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
     }
   };
 
-  const placeholder = kind === "items" ? "Search items…" : "Search spells…";
-  const emptyMessage =
-    kind === "items" ? "No items match your search." : "No spells match your search.";
-  const errorMessage = "Couldn't load the list.";
-
   return (
     <DialogShell
       isOpen
@@ -100,101 +79,58 @@ export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
         if (!open) onClose();
       }}
       aria-label="Browse SRD"
-      size="md"
+      size="lg"
       height={{ fixed: "min(70vh, 640px)" }}
       bleed
     >
       {() => (
         <>
           <DialogHeader title="Browse SRD" onClose={onClose}>
-            <div className={styles.toggles}>
-              <ToggleButtonGroup
-                aria-label="Browse kind"
-                selectionMode="single"
-                disallowEmptySelection
-                selectedKeys={[kind]}
-                onSelectionChange={(keys) => {
-                  const next = Array.from(keys)[0];
-                  if (next === "items" || next === "spells") setKind(next);
-                }}
-              >
-                <ToggleButton id="items">Items</ToggleButton>
-                <ToggleButton id="spells">Spells</ToggleButton>
-              </ToggleButtonGroup>
-              <ToggleButtonGroup
-                aria-label="Ruleset"
-                selectionMode="single"
-                disallowEmptySelection
-                selectedKeys={[ruleset]}
-                onSelectionChange={(keys) => {
-                  const next = Array.from(keys)[0];
-                  if (next === "2014" || next === "2024") setRuleset(next);
-                }}
-              >
-                <ToggleButton id="2014">2014</ToggleButton>
-                <ToggleButton id="2024">2024</ToggleButton>
-              </ToggleButtonGroup>
-            </div>
+            <SourceMenu
+              source={source}
+              options={activeType.supportedSources}
+              onChange={setSource}
+            />
           </DialogHeader>
 
-          <div className={styles.searchRow}>
-            <TextField aria-label={placeholder} className={styles.searchField}>
-              <Input
-                type="search"
-                placeholder={placeholder}
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                autoFocus
-              />
-            </TextField>
-          </div>
-
-          <div className={styles.results}>
-            {index.isLoading && <LoadingState />}
-            {index.isError && (
-              <div className={styles.state} role="alert">
-                {errorMessage}
-                <div className={styles.errorActions}>
-                  <Button variant="secondary" size="sm" onPress={() => index.refetch()}>
-                    Retry
-                  </Button>
-                </div>
-              </div>
-            )}
-            {index.isSuccess && filtered.length === 0 && (
-              <div className={styles.state}>{emptyMessage}</div>
-            )}
-            {pickError && (
-              <div className={styles.state} role="alert">
-                {pickError}
-              </div>
-            )}
-            {index.isSuccess &&
-              filtered.map((item) => {
-                const meta = item.kind === "items" ? itemMeta(item.entry) : spellMeta(item.entry);
-                return (
-                  <button
-                    key={item.entry.key}
-                    type="button"
-                    className={styles.row}
-                    onClick={() => handlePick(item)}
-                    disabled={pickingKey !== null}
-                  >
-                    <span className={styles.rowName}>{item.entry.name}</span>
-                    <span className={styles.rowMeta}>
-                      {pickingKey === item.entry.key ? "Loading…" : meta}
-                    </span>
-                  </button>
-                );
-              })}
+          <div className={styles.layout}>
+            <Tabs
+              orientation="vertical"
+              selectedKey={typeId}
+              onSelectionChange={(k) => handleTabChange(String(k))}
+              className={styles.tabs}
+            >
+              <TabList aria-label="Content type" className={styles.tabList}>
+                {CONTENT_TYPES.map((t) => (
+                  <Tab key={t.id} id={t.id} className={styles.tab}>
+                    {t.label}
+                  </Tab>
+                ))}
+              </TabList>
+              {CONTENT_TYPES.map((t) => (
+                <TabPanel key={t.id} id={t.id} className={styles.tabPanel}>
+                  {t.id === typeId && (
+                    <TypePanel
+                      type={t}
+                      source={source}
+                      query={query}
+                      onQueryChange={setQuery}
+                      pickingKey={pickingKey}
+                      pickError={pickError}
+                      onPick={handlePick}
+                    />
+                  )}
+                </TabPanel>
+              ))}
+            </Tabs>
           </div>
 
           <p className={styles.footer}>
-            Only{" "}
+            All content shown is from the{" "}
             <Link href="https://www.dndbeyond.com/srd" target="_blank" rel="noopener noreferrer">
               SRD
             </Link>{" "}
-            spells and items are available — content by Wizards of the Coast, licensed under{" "}
+            — content by Wizards of the Coast, licensed under{" "}
             <Link
               href="https://creativecommons.org/licenses/by/4.0/"
               target="_blank"
@@ -207,5 +143,108 @@ export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
         </>
       )}
     </DialogShell>
+  );
+}
+
+function SourceMenu({
+  source,
+  options,
+  onChange,
+}: {
+  source: Ruleset;
+  options: readonly Ruleset[];
+  onChange: (next: Ruleset) => void;
+}) {
+  return (
+    <MenuTrigger>
+      <RACButton aria-label={`Source: SRD ${source}`} className={styles.sourceTrigger}>
+        Source: SRD {source} <span aria-hidden="true">▾</span>
+      </RACButton>
+      <Popover className={styles.sourcePopover} placement="bottom end">
+        <Menu className={styles.sourceMenu} onAction={(key) => onChange(String(key) as Ruleset)}>
+          {options.map((opt) => (
+            <MenuItem key={opt} id={opt} className={styles.sourceItem}>
+              {opt}
+            </MenuItem>
+          ))}
+        </Menu>
+      </Popover>
+    </MenuTrigger>
+  );
+}
+
+type TypePanelProps = {
+  type: ContentType;
+  source: Ruleset;
+  query: string;
+  onQueryChange: (q: string) => void;
+  pickingKey: string | null;
+  pickError: string | null;
+  onPick: (rowKey: string, card: Card) => void;
+};
+
+function TypePanel({
+  type,
+  source,
+  query,
+  onQueryChange,
+  pickingKey,
+  pickError,
+  onPick,
+}: TypePanelProps) {
+  const results = type.useResults(source, query);
+  const emptyMessage = useMemo(
+    () => `No ${type.label.toLowerCase()} match your search.`,
+    [type.label],
+  );
+
+  return (
+    <>
+      <div className={styles.searchRow}>
+        <TextField aria-label={type.searchPlaceholder} className={styles.searchField}>
+          <Input
+            type="search"
+            placeholder={type.searchPlaceholder}
+            value={query}
+            onChange={(e) => onQueryChange(e.target.value)}
+            autoFocus
+          />
+        </TextField>
+      </div>
+
+      <div className={styles.results}>
+        {results.isLoading && <LoadingState />}
+        {results.isError && (
+          <div className={styles.state} role="alert">
+            Couldn't load the list.
+            <div className={styles.errorActions}>
+              <Button variant="secondary" size="sm" onPress={() => results.refetch()}>
+                Retry
+              </Button>
+            </div>
+          </div>
+        )}
+        {!results.isLoading && !results.isError && results.rows.length === 0 && (
+          <div className={styles.state}>{emptyMessage}</div>
+        )}
+        {pickError && (
+          <div className={styles.state} role="alert">
+            {pickError}
+          </div>
+        )}
+        {results.rows.map((row) => (
+          <button
+            key={row.key}
+            type="button"
+            className={styles.row}
+            onClick={() => onPick(row.key, row.toCard())}
+            disabled={pickingKey !== null}
+          >
+            <span className={styles.rowName}>{row.name}</span>
+            <span className={styles.rowMeta}>{pickingKey === row.key ? "Loading…" : row.meta}</span>
+          </button>
+        ))}
+      </div>
+    </>
   );
 }

--- a/src/views/BrowseApiModal.tsx
+++ b/src/views/BrowseApiModal.tsx
@@ -96,7 +96,7 @@ export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
               onSelectionChange={(k) => handleTabChange(String(k))}
               className={styles.tabs}
             >
-              <TabList aria-label="Content type" className={styles.tabList}>
+              <TabList aria-label="Content types" className={styles.tabList}>
                 {CONTENT_TYPES.map((t) => (
                   <Tab key={t.id} id={t.id} className={styles.tab}>
                     {t.label}
@@ -152,7 +152,7 @@ function SourceMenu({
   return (
     <MenuTrigger>
       <RACButton aria-label={`Source: SRD ${source}`} className={styles.sourceTrigger}>
-        Source: SRD {source} <span aria-hidden="true">▾</span>
+        Source: {source} <span aria-hidden="true">▾</span>
       </RACButton>
       <Popover className={styles.sourcePopover} placement="bottom end">
         <Menu className={styles.sourceMenu} onAction={(key) => onChange(String(key) as Ruleset)}>
@@ -192,7 +192,7 @@ function TypePanel({
   return (
     <>
       <div className={styles.searchRow}>
-        <TextField aria-label={type.searchPlaceholder} className={styles.searchField}>
+        <TextField aria-label="Search" className={styles.searchField}>
           <Input
             type="search"
             placeholder={type.searchPlaceholder}
@@ -204,9 +204,13 @@ function TypePanel({
       </div>
 
       <div className={styles.results}>
-        {results.isLoading && <LoadingState />}
+        {results.isLoading && (
+          <div className={styles.statePane}>
+            <LoadingState />
+          </div>
+        )}
         {results.isError && (
-          <div className={styles.state} role="alert">
+          <div className={`${styles.state} ${styles.stateError}`} role="alert">
             Couldn't load the list.
             <div className={styles.errorActions}>
               <Button variant="secondary" size="sm" onPress={() => results.refetch()}>
@@ -219,7 +223,7 @@ function TypePanel({
           <div className={styles.state}>{emptyMessage}</div>
         )}
         {pickError && (
-          <div className={styles.state} role="alert">
+          <div className={`${styles.state} ${styles.stateError}`} role="alert">
             {pickError}
           </div>
         )}

--- a/src/views/BrowseApiModal.tsx
+++ b/src/views/BrowseApiModal.tsx
@@ -36,7 +36,7 @@ export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
     throw new Error("CONTENT_TYPES is empty");
   }
 
-  const [source, setSource] = useState<Ruleset>("2024");
+  const [source, setSource] = useState<Ruleset>(() => activeType.supportedSources[0] ?? "2024");
   useEffect(() => {
     if (!activeType.supportedSources.includes(source)) {
       const fallback = activeType.supportedSources[0];
@@ -109,17 +109,15 @@ export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
               </TabList>
               {CONTENT_TYPES.map((t) => (
                 <TabPanel key={t.id} id={t.id} className={styles.tabPanel}>
-                  {t.id === typeId && (
-                    <TypePanel
-                      type={t}
-                      source={source}
-                      query={query}
-                      onQueryChange={setQuery}
-                      pickingKey={pickingKey}
-                      pickError={pickError}
-                      onPick={handlePick}
-                    />
-                  )}
+                  <TypePanel
+                    type={t}
+                    source={source}
+                    query={query}
+                    onQueryChange={setQuery}
+                    pickingKey={pickingKey}
+                    pickError={pickError}
+                    onPick={handlePick}
+                  />
                 </TabPanel>
               ))}
             </Tabs>

--- a/src/views/BrowseApiModal.tsx
+++ b/src/views/BrowseApiModal.tsx
@@ -80,8 +80,9 @@ export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
       bleed
     >
       {() => (
-        <>
+        <div className={styles.modalContainer}>
           <DialogHeader title="Browse SRD" onClose={onClose}>
+            <TypeMenu activeId={typeId} onChange={handleTabChange} />
             <SourceMenu
               source={source}
               options={activeType.supportedSources}
@@ -134,7 +135,7 @@ export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
             </Link>
             .
           </p>
-        </>
+        </div>
       )}
     </DialogShell>
   );
@@ -159,6 +160,29 @@ function SourceMenu({
           {options.map((opt) => (
             <MenuItem key={opt} id={opt} className={styles.sourceItem}>
               {opt}
+            </MenuItem>
+          ))}
+        </Menu>
+      </Popover>
+    </MenuTrigger>
+  );
+}
+
+function TypeMenu({ activeId, onChange }: { activeId: string; onChange: (next: string) => void }) {
+  const active = CONTENT_TYPES.find((t) => t.id === activeId) ?? CONTENT_TYPES[0];
+  return (
+    <MenuTrigger>
+      <RACButton
+        aria-label={`Type: ${active.label}`}
+        className={`${styles.sourceTrigger} ${styles.typeMenuTrigger}`}
+      >
+        {active.label} <span aria-hidden="true">▾</span>
+      </RACButton>
+      <Popover className={styles.sourcePopover} placement="bottom end">
+        <Menu className={styles.sourceMenu} onAction={(key) => onChange(String(key))}>
+          {CONTENT_TYPES.map((t) => (
+            <MenuItem key={t.id} id={t.id} className={styles.sourceItem}>
+              {t.label}
             </MenuItem>
           ))}
         </Menu>

--- a/src/views/BrowseApiModal.tsx
+++ b/src/views/BrowseApiModal.tsx
@@ -152,13 +152,13 @@ function SourceMenu({
 }) {
   return (
     <MenuTrigger>
-      <RACButton aria-label={`Source: SRD ${source}`} className={styles.sourceTrigger}>
+      <RACButton aria-label={`Source: SRD ${source}`} className={styles.menuTrigger}>
         Source: {source} <span aria-hidden="true">▾</span>
       </RACButton>
-      <Popover className={styles.sourcePopover} placement="bottom end">
-        <Menu className={styles.sourceMenu} onAction={(key) => onChange(String(key) as Ruleset)}>
+      <Popover className={styles.menuPopover} placement="bottom end">
+        <Menu className={styles.menu} onAction={(key) => onChange(String(key) as Ruleset)}>
           {options.map((opt) => (
-            <MenuItem key={opt} id={opt} className={styles.sourceItem}>
+            <MenuItem key={opt} id={opt} className={styles.menuItem}>
               {opt}
             </MenuItem>
           ))}
@@ -174,14 +174,14 @@ function TypeMenu({ activeId, onChange }: { activeId: string; onChange: (next: s
     <MenuTrigger>
       <RACButton
         aria-label={`Type: ${active.label}`}
-        className={`${styles.sourceTrigger} ${styles.typeMenuTrigger}`}
+        className={`${styles.menuTrigger} ${styles.typeMenuTrigger}`}
       >
-        {active.label} <span aria-hidden="true">▾</span>
+        Type: {active.label} <span aria-hidden="true">▾</span>
       </RACButton>
-      <Popover className={styles.sourcePopover} placement="bottom end">
-        <Menu className={styles.sourceMenu} onAction={(key) => onChange(String(key))}>
+      <Popover className={styles.menuPopover} placement="bottom end">
+        <Menu className={styles.menu} onAction={(key) => onChange(String(key))}>
           {CONTENT_TYPES.map((t) => (
-            <MenuItem key={t.id} id={t.id} className={styles.sourceItem}>
+            <MenuItem key={t.id} id={t.id} className={styles.menuItem}>
               {t.label}
             </MenuItem>
           ))}
@@ -234,17 +234,21 @@ function TypePanel({
           </div>
         )}
         {results.isError && (
-          <div className={`${styles.state} ${styles.stateError}`} role="alert">
-            Couldn't load the list.
-            <div className={styles.errorActions}>
-              <Button variant="secondary" size="sm" onPress={() => results.refetch()}>
-                Retry
-              </Button>
+          <div className={styles.statePane}>
+            <div className={`${styles.state} ${styles.stateError}`} role="alert">
+              Couldn't load the list.
+              <div className={styles.errorActions}>
+                <Button variant="secondary" size="sm" onPress={() => results.refetch()}>
+                  Retry
+                </Button>
+              </div>
             </div>
           </div>
         )}
         {!results.isLoading && !results.isError && results.rows.length === 0 && (
-          <div className={styles.state}>{emptyMessage}</div>
+          <div className={styles.statePane}>
+            <div className={styles.state}>{emptyMessage}</div>
+          </div>
         )}
         {pickError && (
           <div className={`${styles.state} ${styles.stateError}`} role="alert">

--- a/src/views/BrowseApiModal.tsx
+++ b/src/views/BrowseApiModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Menu,
   MenuItem,
@@ -30,17 +30,13 @@ type Props = {
 };
 
 export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
-  const [typeId, setTypeId] = useState<string>(() => CONTENT_TYPES[0]?.id ?? "");
+  const [typeId, setTypeId] = useState<string>(CONTENT_TYPES[0].id);
   const activeType = CONTENT_TYPES.find((t) => t.id === typeId) ?? CONTENT_TYPES[0];
-  if (!activeType) {
-    throw new Error("CONTENT_TYPES is empty");
-  }
 
-  const [source, setSource] = useState<Ruleset>(() => activeType.supportedSources[0] ?? "2024");
+  const [source, setSource] = useState<Ruleset>(activeType.supportedSources[0]);
   useEffect(() => {
     if (!activeType.supportedSources.includes(source)) {
-      const fallback = activeType.supportedSources[0];
-      if (fallback) setSource(fallback);
+      setSource(activeType.supportedSources[0]);
     }
   }, [activeType, source]);
 
@@ -191,10 +187,7 @@ function TypePanel({
   onPick,
 }: TypePanelProps) {
   const results = type.useResults(source, query);
-  const emptyMessage = useMemo(
-    () => `No ${type.label.toLowerCase()} match your search.`,
-    [type.label],
-  );
+  const emptyMessage = `No ${type.label.toLowerCase()} match your search.`;
 
   return (
     <>


### PR DESCRIPTION
### Description

Reworks the "Browse SRD" modal so adding new content types in the future is purely additive. Today's four sibling toggles (Magic Items / Spells / 2014 / 2024) don't scale — when monsters / effects / feats land they'll need a new layout, and the modal hardcodes a `Kind = "items" | "spells"` union and switches on it in several places.

**Visual change:**

- Vertical `Tabs` sidebar of content types (left rail).
- Single source dropdown in the header (`MenuTrigger` + `Menu`, same pattern as `UserMenu.tsx`).
- Container query at 560px: below that the sidebar hides and a second `MenuTrigger` ("Type: …") appears next to the source dropdown.

**Architecture change:**

- New `src/api/content-types/` registry. Each type module (`items.ts`, `spells.ts`) closes over its entry shape and exports a `ContentType` with `useResults(source, query)`, `supportedSources`, label, and placeholder.
- The modal iterates `CONTENT_TYPES` to render tabs / panels — never sees `MagicItem` or `Spell` directly. Adding monsters later is _create `monsters.ts`, append to the array_ — no modal changes.
- `Card` payload is byte-identical to today's; `useSaveCard` keeps receiving the same shape. No DB / RLS / schema change.

Spec and plan are committed in the same branch:

- `docs/superpowers/specs/2026-05-09-srd-browse-rework-design.md`
- `docs/superpowers/plans/2026-05-09-srd-browse-rework.md`

### How can this be tested?

- Open a deck and click "Browse SRD". Confirm the Magic Items tab is selected, search filters the list, the source dropdown switches between 2024 / 2014, and clicking a row adds the card and closes the modal. Escape closes the modal.
- Switch to the Spells tab — placeholder text + rows swap, the search query clears.
- Trigger a save error (e.g. drop the network mid-pick) — pickError appears below the search field; switching tabs clears it.
- Resize the browser narrow enough that the modal is below ~560px wide — the sidebar collapses and the type dropdown appears next to source in the header.
- New unit tests (`src/views/BrowseApiModal.test.tsx`) cover: tablist order, tab switch clears query + pickError, source-menu options, pick-error clear on tab switch, loading state (`vi.spyOn` with a never-resolving promise), and the Retry button on fetch error.

### Additional Context

**Deferred from this PR (intentionally):**

- **Sidebar item counts.** Loading every type's bundled JSON to display `.length` is more network than the value justifies; trivial to add later.
- **Per-type attribute filters** (rarity, spell level, school, CR). Out of scope — the rework is about the type/source axes.
- **Cross-type "All" view.** Browsing without intent is rare from a deck-building flow; can land later if usage shows otherwise.
- **Renaming the dialog** to something other than "Browse SRD" — stays as-is until a non-SRD source actually ships.

**Things a reviewer might do a double-take on:**

- `CONTENT_TYPES` is typed `readonly [ContentType, ...ContentType[]]` (non-empty tuple), and `supportedSources` similarly. This lets `[0]` return a non-`undefined` value at the type level, which is why the modal has no runtime "registry empty" guard.
- Each type module closes over its entry shape inside `useResults` rather than exposing a generic `ContentType<TEntry>`. Earlier sketches typed the array as `ContentType<unknown>[]`, which doesn't compile (`rowMeta` and `toCard` are contravariant in `TEntry`). The closure approach makes the registry plain `ContentType[]` with no entry type leaking out.
- `levelTag` is exported from `src/api/mappers/spells.ts` and reused by the spells content-type module so the browse row meta and the spell card's header tag share one source of truth.
- The container-query `container-type: inline-size` lives on a `.modalContainer` wrapper inside `BrowseApiModal`, not on `DialogShell` — adding it there would change layout containment for every dialog consumer (`IconPickerDialog`, etc.).
- Reviewed locally by multiple rounds of dispatched review subagents (test-focused, UX-focused, code-quality-focused). Findings landed across the last several commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)