### PR TITLE
Ban `!` non-null assertions; add `invariant()` helper

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -15,7 +15,7 @@
     "rules": {
       "recommended": true,
       "style": {
-        "noNonNullAssertion": "off"
+        "noNonNullAssertion": "error"
       }
     }
   },

--- a/e2e/print-pagination.spec.ts
+++ b/e2e/print-pagination.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { invariant } from "../src/lib/invariant";
 import { longItem, seedDeck, TEST_DECK_ID } from "./fixtures";
 
 test("print view paginates an oversized item across multiple physical cards at 4-up", async ({
@@ -16,12 +17,15 @@ test("print view paginates an oversized item across multiple physical cards at 4
   await expect(paginationIndicators.first()).toHaveText(`Card 1 of ${total}`);
   await expect(paginationIndicators.last()).toHaveText(`Card ${total} of ${total}`);
 
-  for (const tag of longItem.headerTags!) {
+  invariant(longItem.headerTags, "longItem fixture should define headerTags");
+  invariant(longItem.footerTags, "longItem fixture should define footerTags");
+
+  for (const tag of longItem.headerTags) {
     const occurrences = await sheet.getByText(tag, { exact: true }).count();
     expect(occurrences).toBe(1);
   }
 
-  for (const tag of longItem.footerTags!) {
+  for (const tag of longItem.footerTags) {
     const occurrences = await sheet.getByText(tag, { exact: true }).count();
     expect(occurrences).toBe(1);
   }

--- a/src/cards/layoutPaginator.test.ts
+++ b/src/cards/layoutPaginator.test.ts
@@ -171,7 +171,7 @@ describe("layoutPaginate", () => {
   });
 
   test("clears the mounted container after pagination so the measurer can reuse it", () => {
-    let mounted: HTMLElement | null = null;
+    const ref: { current: HTMLElement | null } = { current: null };
     layoutPaginate({
       bodyHtml: "<div>x</div>",
       width: 100,
@@ -183,12 +183,12 @@ describe("layoutPaginate", () => {
         document.body.appendChild(c);
         setRect(c, 0, 30);
         setRect(c.children[0], 0, 30);
-        mounted = c;
+        ref.current = c;
         return c;
       },
     });
-    invariant(mounted, "mount callback should have populated `mounted`");
-    expect(mounted.children.length).toBe(0);
-    mounted.remove();
+    invariant(ref.current, "mount callback should have populated ref.current");
+    expect(ref.current.children.length).toBe(0);
+    ref.current.remove();
   });
 });

--- a/src/cards/layoutPaginator.test.ts
+++ b/src/cards/layoutPaginator.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, vi } from "vitest";
+import { invariant } from "../lib/invariant";
 import { layoutPaginate } from "./layoutPaginator";
 import * as sliceAtModule from "./sliceAt";
 
@@ -186,8 +187,8 @@ describe("layoutPaginate", () => {
         return c;
       },
     });
-    expect(mounted).not.toBeNull();
-    expect(mounted!.children.length).toBe(0);
-    mounted!.remove();
+    invariant(mounted, "mount callback should have populated `mounted`");
+    expect(mounted.children.length).toBe(0);
+    mounted.remove();
   });
 });

--- a/src/cards/pairSlots.test.ts
+++ b/src/cards/pairSlots.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { invariant } from "../lib/invariant";
 import type { PhysicalCard } from "./expandCard";
 import { itemCardFactory } from "./factories";
 import { pairSlots } from "./pairSlots";
@@ -30,7 +31,9 @@ describe("pairSlots", () => {
     const card = itemCardFactory.build();
     const slots = pairSlots([physical(card)], { contentOnBack: true });
     expect(slots).toHaveLength(1);
-    expect(slots[0]!.back).toBeUndefined();
+    const [slot0] = slots;
+    invariant(slot0, "expected slots[0]");
+    expect(slot0.back).toBeUndefined();
   });
 
   test("single 2-page card collapses to one paired slot", () => {
@@ -38,8 +41,10 @@ describe("pairSlots", () => {
     const cards = [physical(card, 1, 2), physical(card, 2, 2)];
     const slots = pairSlots(cards, { contentOnBack: true });
     expect(slots).toHaveLength(1);
-    expect(slots[0]!.front.pagination?.page).toBe(1);
-    expect(slots[0]!.back?.pagination?.page).toBe(2);
+    const [slot0] = slots;
+    invariant(slot0, "expected slots[0]");
+    expect(slot0.front.pagination?.page).toBe(1);
+    expect(slot0.back?.pagination?.page).toBe(2);
   });
 
   test("single 3-page card produces two slots, last with no back", () => {
@@ -47,10 +52,13 @@ describe("pairSlots", () => {
     const cards = [physical(card, 1, 3), physical(card, 2, 3), physical(card, 3, 3)];
     const slots = pairSlots(cards, { contentOnBack: true });
     expect(slots).toHaveLength(2);
-    expect(slots[0]!.front.pagination?.page).toBe(1);
-    expect(slots[0]!.back?.pagination?.page).toBe(2);
-    expect(slots[1]!.front.pagination?.page).toBe(3);
-    expect(slots[1]!.back).toBeUndefined();
+    const [slot0, slot1] = slots;
+    invariant(slot0, "expected slots[0]");
+    invariant(slot1, "expected slots[1]");
+    expect(slot0.front.pagination?.page).toBe(1);
+    expect(slot0.back?.pagination?.page).toBe(2);
+    expect(slot1.front.pagination?.page).toBe(3);
+    expect(slot1.back).toBeUndefined();
   });
 
   test("single 4-page card produces two paired slots", () => {
@@ -63,10 +71,13 @@ describe("pairSlots", () => {
     ];
     const slots = pairSlots(cards, { contentOnBack: true });
     expect(slots).toHaveLength(2);
-    expect(slots[0]!.front.pagination?.page).toBe(1);
-    expect(slots[0]!.back?.pagination?.page).toBe(2);
-    expect(slots[1]!.front.pagination?.page).toBe(3);
-    expect(slots[1]!.back?.pagination?.page).toBe(4);
+    const [slot0, slot1] = slots;
+    invariant(slot0, "expected slots[0]");
+    invariant(slot1, "expected slots[1]");
+    expect(slot0.front.pagination?.page).toBe(1);
+    expect(slot0.back?.pagination?.page).toBe(2);
+    expect(slot1.front.pagination?.page).toBe(3);
+    expect(slot1.back?.pagination?.page).toBe(4);
   });
 
   test("two distinct 1-page cards stay unpaired", () => {
@@ -76,10 +87,13 @@ describe("pairSlots", () => {
       contentOnBack: true,
     });
     expect(slots).toHaveLength(2);
-    expect(slots[0]!.front.card).toBe(cardA);
-    expect(slots[0]!.back).toBeUndefined();
-    expect(slots[1]!.front.card).toBe(cardB);
-    expect(slots[1]!.back).toBeUndefined();
+    const [slot0, slot1] = slots;
+    invariant(slot0, "expected slots[0]");
+    invariant(slot1, "expected slots[1]");
+    expect(slot0.front.card).toBe(cardA);
+    expect(slot0.back).toBeUndefined();
+    expect(slot1.front.card).toBe(cardB);
+    expect(slot1.back).toBeUndefined();
   });
 
   test("two consecutive 2-page cards each pair within their own card", () => {
@@ -93,9 +107,12 @@ describe("pairSlots", () => {
     ];
     const slots = pairSlots(cards, { contentOnBack: true });
     expect(slots).toHaveLength(2);
-    expect(slots[0]!.front.card).toBe(cardA);
-    expect(slots[0]!.back?.card).toBe(cardA);
-    expect(slots[1]!.front.card).toBe(cardB);
-    expect(slots[1]!.back?.card).toBe(cardB);
+    const [slot0, slot1] = slots;
+    invariant(slot0, "expected slots[0]");
+    invariant(slot1, "expected slots[1]");
+    expect(slot0.front.card).toBe(cardA);
+    expect(slot0.back?.card).toBe(cardA);
+    expect(slot1.front.card).toBe(cardB);
+    expect(slot1.back?.card).toBe(cardB);
   });
 });

--- a/src/cards/pairSlots.ts
+++ b/src/cards/pairSlots.ts
@@ -1,3 +1,4 @@
+import { invariant } from "../lib/invariant";
 import type { PhysicalCard } from "./expandCard";
 
 export type PrintSlot = {
@@ -12,7 +13,8 @@ export function pairSlots(cards: PhysicalCard[], opts: { contentOnBack: boolean 
 
   const slots: PrintSlot[] = [];
   for (let i = 0; i < cards.length; i++) {
-    const front = cards[i]!;
+    const front = cards[i];
+    invariant(front, "loop bound guarantees cards[i] is defined");
     const next = cards[i + 1];
     if (next && next.card.id === front.card.id) {
       slots.push({ front, back: next });

--- a/src/lib/invariant.test.ts
+++ b/src/lib/invariant.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { invariant } from "./invariant";
+
+describe("invariant", () => {
+  it("returns silently when the condition is truthy", () => {
+    expect(() => invariant(1, "should not throw")).not.toThrow();
+    expect(() => invariant("x", "should not throw")).not.toThrow();
+    expect(() => invariant({}, "should not throw")).not.toThrow();
+  });
+
+  it("throws with a prefixed message when the condition is falsy", () => {
+    expect(() => invariant(false, "boom")).toThrow("Invariant failed: boom");
+    expect(() => invariant(0, "zero")).toThrow("Invariant failed: zero");
+    expect(() => invariant(null, "null")).toThrow("Invariant failed: null");
+    expect(() => invariant(undefined, "missing")).toThrow("Invariant failed: missing");
+  });
+
+  it("narrows the type for code after the call", () => {
+    const x: string | null = "hello" as string | null;
+    invariant(x, "x must be set");
+    expect(x.length).toBe(5);
+  });
+});

--- a/src/lib/invariant.ts
+++ b/src/lib/invariant.ts
@@ -1,0 +1,5 @@
+export function invariant(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(`Invariant failed: ${message}`);
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import { ensureIcons } from "./cards/resolveIcon";
+import { invariant } from "./lib/invariant";
 import "./index.css";
 import "@fontsource-variable/inter/index.css";
 import "@fontsource/cinzel/500.css";
@@ -9,7 +10,9 @@ import "@fontsource/cinzel/600.css";
 
 void ensureIcons();
 
-createRoot(document.getElementById("root")!).render(
+const rootEl = document.getElementById("root");
+invariant(rootEl, "#root element missing from index.html");
+createRoot(rootEl).render(
   <StrictMode>
     <App />
   </StrictMode>,

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -7,6 +7,7 @@ import { useExpandedCards } from "../cards/useExpandedCards";
 import { useDeleteCard, useSaveCard } from "../decks/mutations";
 import { useDeckCards } from "../decks/queries";
 import { newId } from "../lib/id";
+import { invariant } from "../lib/invariant";
 import { nowIso } from "../lib/time";
 import { Button } from "../lib/ui/Button";
 import { LoadingState } from "../lib/ui/LoadingState";
@@ -24,7 +25,9 @@ type Bucket = { perPage: number; count: number };
 
 function countsLabel(buckets: Bucket[]): string {
   if (buckets.length === 0) return "0 cards";
-  const first = buckets[0]!.count;
+  const head = buckets[0];
+  invariant(head, "buckets is non-empty after the length guard");
+  const first = head.count;
   const allEqual = buckets.every((b) => b.count === first);
   if (allEqual) {
     return `${first} card${first === 1 ? "" : "s"}`;

--- a/src/views/PrintView.test.tsx
+++ b/src/views/PrintView.test.tsx
@@ -4,6 +4,7 @@ import { HttpResponse, http } from "msw";
 import type { ReactNode } from "react";
 import { describe, expect, test, vi } from "vitest";
 import * as layoutPaginatorModule from "../cards/layoutPaginator";
+import { invariant } from "../lib/invariant";
 import { makeCardRow, makeItemPayload } from "../test/factories";
 import { SB_URL as SB, server } from "../test/msw";
 import { render, screen, waitFor } from "../test/render";
@@ -107,8 +108,8 @@ describe("<PrintView>", () => {
     render(wrap(<PrintView deckId="d1" />));
     await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
     await userEvent.click(screen.getByRole("switch", { name: /print backs/i }));
-    const backPage = document.querySelector('[data-page-side="back"]') as HTMLElement;
-    expect(backPage).not.toBeNull();
+    const backPage = document.querySelector<HTMLElement>('[data-page-side="back"]');
+    invariant(backPage, "expected back page element");
     // Read the rendered slot order from the back page's data-card-id attrs and
     // assert it matches the imposition rule: [A, B, C, D] front → [B, A, D, C] back.
     // The back page's direct children are the slot divs in DOM (= CSS grid) order.
@@ -117,7 +118,9 @@ describe("<PrintView>", () => {
     const slotIds = slots.map(
       (s) => s.querySelector<HTMLElement>("[data-card-id]")?.dataset.cardId ?? null,
     );
-    expect(slotIds).toEqual([cards[1]!.id, cards[0]!.id, cards[3]!.id, cards[2]!.id]);
+    const [c0, c1, c2, c3] = cards;
+    invariant(c0 && c1 && c2 && c3, "expected 4 cards");
+    expect(slotIds).toEqual([c1.id, c0.id, c3.id, c2.id]);
   });
 
   test("partial last front page produces a back page with only the populated slots filled", async () => {
@@ -128,8 +131,8 @@ describe("<PrintView>", () => {
     render(wrap(<PrintView deckId="d1" />));
     await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
     await userEvent.click(screen.getByRole("switch", { name: /print backs/i }));
-    const backPage = document.querySelector('[data-page-side="back"]') as HTMLElement;
-    expect(backPage).not.toBeNull();
+    const backPage = document.querySelector<HTMLElement>('[data-page-side="back"]');
+    invariant(backPage, "expected back page element");
     // 3 fronts → 3 back tiles; the 4th slot is an empty .slot div.
     expect(backPage.querySelectorAll('[data-role="card-back-root"]')).toHaveLength(3);
   });
@@ -220,11 +223,13 @@ describe("<PrintView>", () => {
     // Front: two populated slots — twoPager pg1 (slot 0), onePager (slot 1).
     // Back imposition (4-up, cols=2): back-slot 0 = back-of front-slot-1 (onePager → icon),
     //                                 back-slot 1 = back-of front-slot-0 (twoPager pg2).
-    const backPage = document.querySelector('[data-page-side="back"]') as HTMLElement;
-    expect(backPage).not.toBeNull();
+    const backPage = document.querySelector<HTMLElement>('[data-page-side="back"]');
+    invariant(backPage, "expected back page element");
     const slots = Array.from(backPage.children) as HTMLElement[];
-    expect(slots[0]!.querySelector('[data-role="card-back-root"]')).not.toBeNull();
-    expect(slots[1]!.querySelector('[data-role="card-body"]')).toHaveTextContent("TWO-pg2");
+    const [slot0, slot1] = slots;
+    invariant(slot0 && slot1, "expected at least 2 back slots");
+    expect(slot0.querySelector('[data-role="card-back-root"]')).not.toBeNull();
+    expect(slot1.querySelector('[data-role="card-body"]')).toHaveTextContent("TWO-pg2");
   });
 
   test("4-page card paired flow at 4-up", async () => {
@@ -242,15 +247,21 @@ describe("<PrintView>", () => {
     // Front: slot 0 = pg1, slot 1 = pg3.
     // Back imposition: back-slot 0 = back-of front-slot-1 (pg4),
     //                  back-slot 1 = back-of front-slot-0 (pg2).
-    const frontPage = document.querySelector('[data-page-side="front"]') as HTMLElement;
+    const frontPage = document.querySelector<HTMLElement>('[data-page-side="front"]');
+    invariant(frontPage, "expected front page element");
     const frontSlots = Array.from(frontPage.children) as HTMLElement[];
-    expect(frontSlots[0]!.querySelector('[data-role="card-body"]')).toHaveTextContent("pg1");
-    expect(frontSlots[1]!.querySelector('[data-role="card-body"]')).toHaveTextContent("pg3");
+    const [front0, front1] = frontSlots;
+    invariant(front0 && front1, "expected at least 2 front slots");
+    expect(front0.querySelector('[data-role="card-body"]')).toHaveTextContent("pg1");
+    expect(front1.querySelector('[data-role="card-body"]')).toHaveTextContent("pg3");
 
-    const backPage = document.querySelector('[data-page-side="back"]') as HTMLElement;
+    const backPage = document.querySelector<HTMLElement>('[data-page-side="back"]');
+    invariant(backPage, "expected back page element");
     const backSlots = Array.from(backPage.children) as HTMLElement[];
-    expect(backSlots[0]!.querySelector('[data-role="card-body"]')).toHaveTextContent("pg4");
-    expect(backSlots[1]!.querySelector('[data-role="card-body"]')).toHaveTextContent("pg2");
+    const [back0, back1] = backSlots;
+    invariant(back0 && back1, "expected at least 2 back slots");
+    expect(back0.querySelector('[data-role="card-body"]')).toHaveTextContent("pg4");
+    expect(back1.querySelector('[data-role="card-body"]')).toHaveTextContent("pg2");
   });
 
   test("3-page card paired flow at 4-up — last back slot falls back to icon", async () => {
@@ -268,10 +279,13 @@ describe("<PrintView>", () => {
     // Front: slot 0 = pg1, slot 1 = pg3.
     // Back imposition: back-slot 0 = back-of front-slot-1 (pg3 → no back → icon),
     //                  back-slot 1 = back-of front-slot-0 (pg2).
-    const backPage = document.querySelector('[data-page-side="back"]') as HTMLElement;
+    const backPage = document.querySelector<HTMLElement>('[data-page-side="back"]');
+    invariant(backPage, "expected back page element");
     const backSlots = Array.from(backPage.children) as HTMLElement[];
-    expect(backSlots[0]!.querySelector('[data-role="card-back-root"]')).not.toBeNull();
-    expect(backSlots[1]!.querySelector('[data-role="card-body"]')).toHaveTextContent("pg2");
+    const [back0, back1] = backSlots;
+    invariant(back0 && back1, "expected at least 2 back slots");
+    expect(back0.querySelector('[data-role="card-back-root"]')).not.toBeNull();
+    expect(back1.querySelector('[data-role="card-body"]')).toHaveTextContent("pg2");
   });
 
   test("'Continue content on back' selected state persists across disable/re-enable", async () => {
@@ -298,8 +312,11 @@ describe("<PrintView>", () => {
     expect(continueOnBack).not.toBeDisabled();
     expect(continueOnBack).toBeChecked();
     // Paired flow resumes: pg2 lands on the back.
-    const backPage = document.querySelector('[data-page-side="back"]') as HTMLElement;
+    const backPage = document.querySelector<HTMLElement>('[data-page-side="back"]');
+    invariant(backPage, "expected back page element");
     const backSlots = Array.from(backPage.children) as HTMLElement[];
-    expect(backSlots[1]!.querySelector('[data-role="card-body"]')).toHaveTextContent("pg2");
+    const [, back1] = backSlots;
+    invariant(back1, "expected at least 2 back slots");
+    expect(back1.querySelector('[data-role="card-body"]')).toHaveTextContent("pg2");
   });
 });


### PR DESCRIPTION
Closes #61.

## Summary

- New `src/lib/invariant.ts`: `invariant(condition, message): asserts condition` — throws `Error("Invariant failed: <msg>")` on falsy, narrows the type via `asserts condition` on truthy. One file, no dep.
- All 35 `!` non-null assertion sites in the repo are gone — production sites get a real runtime guard with a named failure message; tests get `invariant()` ahead of the assertions, with the redundant `expect(x).not.toBeNull()` removed where the invariant subsumes it.
- `biome.json` flips `style.noNonNullAssertion` from `"off"` to `"error"`, so any future `!` is a lint error.

## What changed

| Site | Note |
|---|---|
| `src/main.tsx` | Guarded `document.getElementById("root")` lookup. |
| `src/views/EditorView.tsx` | Replaces `buckets[0]!.count` with an invariant-narrowed access after the existing length guard. |
| `src/cards/pairSlots.ts` | Production loop site (originally missed by the issue's count of 34, caught by Biome after the rule flip). |
| `src/cards/pairSlots.test.ts` | Destructure + invariant per slot, 21 sites cleared. |
| `src/cards/layoutPaginator.test.ts` | Switched a `let mounted: HTMLElement \| null` mutated-in-callback to a `{ current: HTMLElement \| null }` ref-object — TS can't narrow the `let` form through a callback mutation, so `invariant(mounted, …)` would have narrowed to `never`. |
| `src/views/PrintView.test.tsx` | Replaced `as HTMLElement` casts (which lied about nullability) with `querySelector<HTMLElement>(…) + invariant(…)`. |
| `e2e/print-pagination.spec.ts` | Two more sites in e2e — caught after `npm run lint` (which scopes to `src scripts e2e`) flagged them. |
| `biome.json` | `noNonNullAssertion: "error"` |

## How to test

- `npm test` — 509 tests pass across 66 files.
- `npm run lint` — clean.
- `npm run build` — clean.
- Manual smoke: `npm run dev`, open the editor (`/deck/<id>/edit/<cardId>`) and the print view (`/deck/<id>/print`); both render normally.

## Why a homegrown helper

Per the issue: it's one file, no value in pulling in `tiny-invariant`. The signature matches `tiny-invariant`'s, so swapping later would be a one-line import change if we ever wanted to.