### PR TITLE
refactor: tokenize AuthCallback; clean up test setup and factories

### DIFF
--- a/src/auth/AuthCallback.module.css
+++ b/src/auth/AuthCallback.module.css
@@ -1,0 +1,4 @@
+.statusPanel {
+  text-align: center;
+  padding: var(--space-6);
+}

--- a/src/auth/AuthCallback.tsx
+++ b/src/auth/AuthCallback.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { supabase } from "../api/supabase";
 import { pluralize } from "../lib/pluralize";
 import { useSetNextAnnouncement } from "../lib/ui/Announcement";
+import styles from "./AuthCallback.module.css";
 import { clear, readPending, stash, tryResume } from "./anonImport";
 import { ImportAccountDialog } from "./ImportAccountDialog";
 import { readNextFromUrl } from "./safeNext";
@@ -148,7 +149,7 @@ export function AuthCallback() {
 
   if (phase === "importing") {
     return (
-      <section style={{ textAlign: "center", padding: "4rem" }} role="status" aria-live="polite">
+      <section className={styles.statusPanel} role="status" aria-live="polite">
         <h2>Bringing your decks over</h2>
         <p>
           Imported {progress.imported} of {progress.total} decks…
@@ -159,7 +160,7 @@ export function AuthCallback() {
 
   if (phase === "error") {
     return (
-      <section style={{ textAlign: "center", padding: "4rem" }}>
+      <section className={styles.statusPanel}>
         <p>{errorMessage}</p>
         <p>
           <Link to="/login">Back to sign-in</Link>
@@ -169,7 +170,7 @@ export function AuthCallback() {
   }
 
   return (
-    <section style={{ textAlign: "center", padding: "4rem" }}>
+    <section className={styles.statusPanel}>
       <p>Signing you in…</p>
     </section>
   );

--- a/src/cards/Card.test.tsx
+++ b/src/cards/Card.test.tsx
@@ -35,18 +35,17 @@ describe("<Card>", () => {
     expect(screen.getByText("Second paragraph.")).toBeInTheDocument();
   });
 
-  test("renders the heuristic-picked icon when iconKey is unset", () => {
-    const card = itemCardFactory.build();
+  test("uses pickIconKey when card.iconKey is unset", () => {
+    const card = itemCardFactory.build({ name: "Flame Tongue Trident" });
     render(<Card card={card} cardsPerPage={4} />);
-    const slot = screen.getByTestId("card-icon");
-    expect(slot.querySelector("svg")).not.toBeNull();
+    expect(screen.getByTestId("card-icon")).toHaveAttribute("data-icon-key", "trident");
   });
 
-  test("renders the explicit override icon when iconKey is set", () => {
-    const card = itemCardFactory.build({ iconKey: "trident" });
+  test("uses card.iconKey when set, ignoring the name heuristic", () => {
+    // "Vorpal Sword" would otherwise pick "broadsword"; the explicit iconKey wins.
+    const card = itemCardFactory.build({ name: "Vorpal Sword", iconKey: "trident" });
     render(<Card card={card} cardsPerPage={4} />);
-    const slot = screen.getByTestId("card-icon");
-    expect(slot.querySelector("svg")).not.toBeNull();
+    expect(screen.getByTestId("card-icon")).toHaveAttribute("data-icon-key", "trident");
   });
 
   test("does not crash for a stale or unknown iconKey", () => {
@@ -54,27 +53,22 @@ describe("<Card>", () => {
     expect(() => render(<Card card={card} cardsPerPage={4} />)).not.toThrow();
   });
 
-  test("renders the heuristic-picked icon for a spell card with iconKey unset", () => {
-    const card = spellCardFactory.build();
+  test("uses pickIconKey for spell cards too", () => {
+    const card = spellCardFactory.build({ name: "Fireball" });
     render(<Card card={card} cardsPerPage={4} />);
-    const slot = screen.getByTestId("card-icon");
-    expect(slot.querySelector("svg")).not.toBeNull();
+    expect(screen.getByTestId("card-icon")).toHaveAttribute("data-icon-key", "fireball");
   });
 
   test("renders a rounded-square frame for an item card", () => {
     const card = itemCardFactory.build();
     render(<Card card={card} cardsPerPage={4} />);
-    const frame = screen.getByTestId("card-icon-frame");
-    expect(frame).toHaveAttribute("data-frame", "square");
-    expect(frame.querySelector("rect")).not.toBeNull();
+    expect(screen.getByTestId("card-icon-frame")).toHaveAttribute("data-frame", "square");
   });
 
   test("renders a hexagon frame for a spell card", () => {
     const card = spellCardFactory.build();
     render(<Card card={card} cardsPerPage={4} />);
-    const frame = screen.getByTestId("card-icon-frame");
-    expect(frame).toHaveAttribute("data-frame", "hex");
-    expect(frame.querySelector("polygon")).not.toBeNull();
+    expect(screen.getByTestId("card-icon-frame")).toHaveAttribute("data-frame", "hex");
   });
 });
 

--- a/src/cards/Card.test.tsx
+++ b/src/cards/Card.test.tsx
@@ -36,39 +36,26 @@ describe("<Card>", () => {
   });
 
   test("renders the heuristic-picked icon when iconKey is unset", () => {
-    const card = itemCardFactory.build({
-      name: "Flame Tongue Trident",
-      iconKey: undefined,
-    });
+    const card = itemCardFactory.build();
     render(<Card card={card} cardsPerPage={4} />);
     const slot = screen.getByTestId("card-icon");
     expect(slot.querySelector("svg")).not.toBeNull();
   });
 
   test("renders the explicit override icon when iconKey is set", () => {
-    const card = itemCardFactory.build({
-      name: "Anything",
-      iconKey: "trident",
-    });
+    const card = itemCardFactory.build({ iconKey: "trident" });
     render(<Card card={card} cardsPerPage={4} />);
     const slot = screen.getByTestId("card-icon");
     expect(slot.querySelector("svg")).not.toBeNull();
   });
 
   test("does not crash for a stale or unknown iconKey", () => {
-    const card = itemCardFactory.build({
-      name: "X",
-      iconKey: "definitely-removed-icon",
-    });
+    const card = itemCardFactory.build({ iconKey: "definitely-removed-icon" });
     expect(() => render(<Card card={card} cardsPerPage={4} />)).not.toThrow();
   });
 
   test("renders the heuristic-picked icon for a spell card with iconKey unset", () => {
-    const card = spellCardFactory.build({
-      name: "Fireball",
-      headerTags: ["3rd-level evocation"],
-      iconKey: undefined,
-    });
+    const card = spellCardFactory.build();
     render(<Card card={card} cardsPerPage={4} />);
     const slot = screen.getByTestId("card-icon");
     expect(slot.querySelector("svg")).not.toBeNull();

--- a/src/cards/Card.tsx
+++ b/src/cards/Card.tsx
@@ -28,7 +28,12 @@ export function Card({ card, cardsPerPage, pagination, bodyHtml }: Props) {
   return (
     <div className={`${styles.card} ${layoutClass}`} data-role="card-root">
       <div className={styles.header}>
-        <div className={styles.icon} data-testid="card-icon" aria-hidden="true">
+        <div
+          className={styles.icon}
+          data-testid="card-icon"
+          data-icon-key={iconKey}
+          aria-hidden="true"
+        >
           <FramedIcon kind={card.kind} iconKey={iconKey} />
         </div>
         <h3 className={styles.title}>{card.name}</h3>

--- a/src/cards/iconRules.test.ts
+++ b/src/cards/iconRules.test.ts
@@ -37,39 +37,23 @@ describe("pickIconKey", () => {
   });
 
   test("Axe variants pick 'battle-axe'", () => {
-    expect(pickIconKey(itemCardFactory.build({ name: "Battleaxe", headerTags: [] }))).toBe(
-      "battle-axe",
-    );
-    expect(pickIconKey(itemCardFactory.build({ name: "Greataxe of Vorpal", headerTags: [] }))).toBe(
-      "battle-axe",
-    );
-    expect(pickIconKey(itemCardFactory.build({ name: "Handaxe", headerTags: [] }))).toBe(
-      "battle-axe",
-    );
+    expect(pickIconKey(itemCardFactory.build({ name: "Battleaxe" }))).toBe("battle-axe");
+    expect(pickIconKey(itemCardFactory.build({ name: "Greataxe of Vorpal" }))).toBe("battle-axe");
+    expect(pickIconKey(itemCardFactory.build({ name: "Handaxe" }))).toBe("battle-axe");
   });
 
   test("Hammer variants pick 'warhammer'", () => {
-    expect(
-      pickIconKey(itemCardFactory.build({ name: "Warhammer of Thunder", headerTags: [] })),
-    ).toBe("warhammer");
-    expect(pickIconKey(itemCardFactory.build({ name: "Maul +1", headerTags: [] }))).toBe(
-      "warhammer",
-    );
+    expect(pickIconKey(itemCardFactory.build({ name: "Warhammer of Thunder" }))).toBe("warhammer");
+    expect(pickIconKey(itemCardFactory.build({ name: "Maul +1" }))).toBe("warhammer");
   });
 
   test("Bow variants pick 'bow-arrow' (not the broadsword catch-all)", () => {
-    expect(pickIconKey(itemCardFactory.build({ name: "Elven Longbow", headerTags: [] }))).toBe(
-      "bow-arrow",
-    );
-    expect(pickIconKey(itemCardFactory.build({ name: "Shortbow", headerTags: [] }))).toBe(
-      "bow-arrow",
-    );
+    expect(pickIconKey(itemCardFactory.build({ name: "Elven Longbow" }))).toBe("bow-arrow");
+    expect(pickIconKey(itemCardFactory.build({ name: "Shortbow" }))).toBe("bow-arrow");
   });
 
   test("Crossbow picks 'crossbow', not 'bow-arrow'", () => {
-    expect(pickIconKey(itemCardFactory.build({ name: "Crossbow of Speed", headerTags: [] }))).toBe(
-      "crossbow",
-    );
+    expect(pickIconKey(itemCardFactory.build({ name: "Crossbow of Speed" }))).toBe("crossbow");
   });
 
   test("Generic weapon catch-all picks 'broadsword'", () => {
@@ -155,7 +139,7 @@ describe("pickIconKey", () => {
   });
 
   test("Case-insensitive matching", () => {
-    const card = itemCardFactory.build({ name: "POTION OF HEALING", headerTags: [] });
+    const card = itemCardFactory.build({ name: "POTION OF HEALING" });
     expect(pickIconKey(card)).toBe("potion-ball");
   });
 });

--- a/src/cards/iconRules.test.ts
+++ b/src/cards/iconRules.test.ts
@@ -180,228 +180,53 @@ describe("pickSpellIconKey — school detection", () => {
 });
 
 describe("pickSpellIconKey — name keyword rules (run before school)", () => {
-  test("Fireball → fireball (specific icon, overrides generic fire rule)", () => {
-    const card = spellCardFactory.build({
-      name: "Fireball",
-      headerTags: ["3rd-level evocation"],
-    });
-    expect(pickSpellIconKey(card)).toBe("fireball");
+  // Default factory headerTags ("1 action", "60 feet", "Instantaneous") don't
+  // trigger any name rule, so name alone determines the iconKey for these.
+  test.each([
+    // Specific-name overrides that beat more generic patterns later in the list
+    { name: "Faerie Fire", expected: "sun" },
+    { name: "Sacred Flame", expected: "holy-symbol" },
+    { name: "Fireball", expected: "fireball" },
+    // Element / damage-type rules
+    { name: "Wall of Fire", expected: "fire-flower" },
+    { name: "Lightning Bolt", expected: "lightning-arc" },
+    { name: "Thunderwave", expected: "lightning-arc" },
+    { name: "Cone of Cold", expected: "ice-cube" },
+    { name: "Cloudkill", expected: "poison-cloud" },
+    // Healing / divine — note: heal rule fires before power-word, so
+    // "Power Word Heal" intentionally lands on caduceus, not skull.
+    { name: "Cure Wounds", expected: "caduceus" },
+    { name: "Bless", expected: "holy-symbol" },
+    { name: "Searing Smite", expected: "holy-symbol" },
+    { name: "Power Word Heal", expected: "caduceus" },
+    { name: "Power Word Kill", expected: "skull-crossed-bones" },
+    // Protection / movement
+    { name: "Shield", expected: "magic-shield" },
+    { name: "Fly", expected: "feathered-wing" },
+    { name: "Feather Fall", expected: "feathered-wing" },
+    // Mind effects
+    { name: "Sleep", expected: "night-sleep" },
+    { name: "Charm Person", expected: "charm" },
+    { name: "Hold Person", expected: "charm" },
+    { name: "Cause Fear", expected: "evil-eyes" },
+    { name: "Bestow Curse", expected: "cursed-star" },
+    // Conjuration / detection / light
+    { name: "Find Familiar", expected: "magic-portal" },
+    { name: "Misty Step", expected: "magic-portal" },
+    { name: "Detect Magic", expected: "evil-eyes" },
+    { name: "Daylight", expected: "sun" },
+    { name: "Moonbeam", expected: "moon" },
+  ])("'$name' picks '$expected'", ({ name, expected }) => {
+    const card = spellCardFactory.build({ name });
+    expect(pickSpellIconKey(card)).toBe(expected);
   });
 
-  test("Wall of Fire → fire-flower (generic fire rule still fires for non-Fireball spells)", () => {
-    const card = spellCardFactory.build({
-      name: "Wall of Fire",
-      headerTags: ["4th-level evocation"],
-    });
-    expect(pickSpellIconKey(card)).toBe("fire-flower");
-  });
-
-  test("Lightning Bolt → lightning-arc", () => {
-    const card = spellCardFactory.build({
-      name: "Lightning Bolt",
-      headerTags: ["3rd-level evocation"],
-    });
-    expect(pickSpellIconKey(card)).toBe("lightning-arc");
-  });
-
-  test("Thunderwave → lightning-arc", () => {
-    const card = spellCardFactory.build({
-      name: "Thunderwave",
-      headerTags: ["1st-level evocation"],
-    });
-    expect(pickSpellIconKey(card)).toBe("lightning-arc");
-  });
-
-  test("Cone of Cold → ice-cube", () => {
-    const card = spellCardFactory.build({
-      name: "Cone of Cold",
-      headerTags: ["5th-level evocation"],
-    });
-    expect(pickSpellIconKey(card)).toBe("ice-cube");
-  });
-
-  test("Cloudkill → poison-cloud", () => {
-    const card = spellCardFactory.build({
-      name: "Cloudkill",
-      headerTags: ["5th-level conjuration"],
-    });
-    expect(pickSpellIconKey(card)).toBe("poison-cloud");
-  });
-
-  test("Cure Wounds → caduceus", () => {
-    const card = spellCardFactory.build({
-      name: "Cure Wounds",
-      headerTags: ["1st-level abjuration"],
-    });
-    expect(pickSpellIconKey(card)).toBe("caduceus");
-  });
-
-  test("Bless → holy-symbol", () => {
-    const card = spellCardFactory.build({
-      name: "Bless",
-      headerTags: ["1st-level enchantment"],
-    });
-    expect(pickSpellIconKey(card)).toBe("holy-symbol");
-  });
-
-  test("Shield (the spell) → magic-shield", () => {
-    const card = spellCardFactory.build({
-      name: "Shield",
-      headerTags: ["1st-level abjuration"],
-    });
-    expect(pickSpellIconKey(card)).toBe("magic-shield");
-  });
-
-  test("Fly → feathered-wing", () => {
-    const card = spellCardFactory.build({
-      name: "Fly",
-      headerTags: ["3rd-level transmutation"],
-    });
-    expect(pickSpellIconKey(card)).toBe("feathered-wing");
-  });
-
-  test("Sleep → night-sleep", () => {
-    const card = spellCardFactory.build({
-      name: "Sleep",
-      headerTags: ["1st-level enchantment"],
-    });
-    expect(pickSpellIconKey(card)).toBe("night-sleep");
-  });
-
-  test("Charm Person → charm", () => {
-    const card = spellCardFactory.build({
-      name: "Charm Person",
-      headerTags: ["1st-level enchantment"],
-    });
-    expect(pickSpellIconKey(card)).toBe("charm");
-  });
-
-  test("Hold Person → charm", () => {
-    const card = spellCardFactory.build({
-      name: "Hold Person",
-      headerTags: ["2nd-level enchantment"],
-    });
-    expect(pickSpellIconKey(card)).toBe("charm");
-  });
-
-  test("Cause Fear → evil-eyes", () => {
-    const card = spellCardFactory.build({
-      name: "Cause Fear",
-      headerTags: ["1st-level necromancy"],
-    });
-    expect(pickSpellIconKey(card)).toBe("evil-eyes");
-  });
-
-  test("Bestow Curse → cursed-star", () => {
-    const card = spellCardFactory.build({
-      name: "Bestow Curse",
-      headerTags: ["3rd-level necromancy"],
-    });
-    expect(pickSpellIconKey(card)).toBe("cursed-star");
-  });
-
-  test("Find Familiar → magic-portal", () => {
-    const card = spellCardFactory.build({
-      name: "Find Familiar",
-      headerTags: ["1st-level conjuration"],
-    });
-    expect(pickSpellIconKey(card)).toBe("magic-portal");
-  });
-
-  test("Misty Step → magic-portal", () => {
-    const card = spellCardFactory.build({
-      name: "Misty Step",
-      headerTags: ["2nd-level conjuration"],
-    });
-    expect(pickSpellIconKey(card)).toBe("magic-portal");
-  });
-
-  test("Daylight → sun (and Lightning Bolt is unaffected — order check)", () => {
-    expect(
-      pickSpellIconKey(
-        spellCardFactory.build({ name: "Daylight", headerTags: ["3rd-level evocation"] }),
-      ),
-    ).toBe("sun");
-    expect(
-      pickSpellIconKey(
-        spellCardFactory.build({
-          name: "Lightning Bolt",
-          headerTags: ["3rd-level evocation"],
-        }),
-      ),
-    ).toBe("lightning-arc");
-  });
-
-  test("Moonbeam → moon", () => {
-    const card = spellCardFactory.build({
-      name: "Moonbeam",
-      headerTags: ["2nd-level evocation"],
-    });
-    expect(pickSpellIconKey(card)).toBe("moon");
-  });
-
-  test("Detect Magic → evil-eyes", () => {
-    const card = spellCardFactory.build({
-      name: "Detect Magic",
-      headerTags: ["1st-level divination"],
-    });
-    expect(pickSpellIconKey(card)).toBe("evil-eyes");
-  });
-
-  test("school-only fallback works when no name keyword matches (Counterspell → abjuration → magic-shield)", () => {
+  test("falls through to school dispatch when no name keyword matches (Counterspell → abjuration)", () => {
     const card = spellCardFactory.build({
       name: "Counterspell",
       headerTags: ["3rd-level abjuration"],
     });
     expect(pickSpellIconKey(card)).toBe("magic-shield");
-  });
-
-  test("Faerie Fire → sun (override beats fire rule)", () => {
-    const card = spellCardFactory.build({
-      name: "Faerie Fire",
-      headerTags: ["1st-level evocation"],
-    });
-    expect(pickSpellIconKey(card)).toBe("sun");
-  });
-
-  test("Sacred Flame → holy-symbol (override beats fire rule)", () => {
-    const card = spellCardFactory.build({
-      name: "Sacred Flame",
-      headerTags: ["Evocation cantrip"],
-    });
-    expect(pickSpellIconKey(card)).toBe("holy-symbol");
-  });
-
-  test("Power Word Kill → skull-crossed-bones", () => {
-    const card = spellCardFactory.build({
-      name: "Power Word Kill",
-      headerTags: ["9th-level enchantment"],
-    });
-    expect(pickSpellIconKey(card)).toBe("skull-crossed-bones");
-  });
-
-  test("Power Word Heal → caduceus (heal rule wins over power-word)", () => {
-    const card = spellCardFactory.build({
-      name: "Power Word Heal",
-      headerTags: ["9th-level evocation"],
-    });
-    expect(pickSpellIconKey(card)).toBe("caduceus");
-  });
-
-  test("Feather Fall → feathered-wing", () => {
-    const card = spellCardFactory.build({
-      name: "Feather Fall",
-      headerTags: ["1st-level transmutation"],
-    });
-    expect(pickSpellIconKey(card)).toBe("feathered-wing");
-  });
-
-  test("Searing Smite → holy-symbol", () => {
-    const card = spellCardFactory.build({
-      name: "Searing Smite",
-      headerTags: ["1st-level evocation"],
-    });
-    expect(pickSpellIconKey(card)).toBe("holy-symbol");
   });
 });
 

--- a/src/decks/mutations.test.tsx
+++ b/src/decks/mutations.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { HttpResponse, http } from "msw";
+import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import type { Card } from "../cards/types";
 import { makeCardRow, makeDeckRow } from "../test/factories";
@@ -17,8 +18,7 @@ const SB = "http://localhost:54321";
 
 function makeWrapper() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  // biome-ignore lint/suspicious/noExplicitAny: test wrapper
-  return ({ children }: { children: any }) => (
+  return ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>{children}</QueryClientProvider>
   );
 }

--- a/src/decks/queries.test.tsx
+++ b/src/decks/queries.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { HttpResponse, http } from "msw";
+import type { ReactNode } from "react";
 import { describe, expect, it } from "vitest";
 import { makeCardRow, makeDeckSummary, makePublicDeck } from "../test/factories";
 import { server } from "../test/msw";
@@ -10,8 +11,7 @@ const SB = "http://localhost:54321";
 
 function wrapper() {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  // biome-ignore lint/suspicious/noExplicitAny: test wrapper
-  return ({ children }: { children: any }) => (
+  return ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>{children}</QueryClientProvider>
   );
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -31,12 +31,13 @@ vi.stubEnv(
 // returns 0 for clientWidth/clientHeight; without these stubs the Virtualizer
 // either falls back to Infinity (NaN math in GridLayout) or sees a 0x0
 // container and renders no items.
-class ResizeObserverMock {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
+class ResizeObserverMock implements ResizeObserver {
+  constructor(_callback: ResizeObserverCallback) {}
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
 }
-globalThis.ResizeObserver ??= ResizeObserverMock as unknown as typeof ResizeObserver;
+globalThis.ResizeObserver ??= ResizeObserverMock;
 
 // Hard-coded dimensions are large enough for ~150 60px tiles to land in the
 // initial visible window — the actual layout in browsers is responsive.


### PR DESCRIPTION
### Description

Cleanup pass against findings from a recent repo-wide tech-debt review.

**`src/auth/AuthCallback.tsx` — design-system tokens.** The three transient status sections (`importing` / `error` / "Signing you in…") used `style={{ textAlign: "center", padding: "4rem" }}`, in violation of CLAUDE.md's "screen UI references CSS tokens" rule. Moved to a `.statusPanel` class in the new `AuthCallback.module.css`. Padding dropped from `4rem` to `var(--space-6)` (2rem) — the screen-token space scale tops out at `--space-6`, so this nudges the design toward the existing scale rather than introducing a new `--space-7`.

**Factory discipline in two test files.** Project rule: factories pass no values the test doesn't assert on. Removed unused `name` / redundant `iconKey: undefined` overrides in 4 icon-related tests in `Card.test.tsx`, plus redundant `headerTags: []` in 6 cases in `iconRules.test.ts` where the rule fires on `name` alone (default factory tags don't trigger any rule for those names).

**`iconRules.test.ts` spell name-keyword block → `test.each` table.** Twenty-seven near-duplicate tests of the form `(name, headerTag) → iconKey` collapsed into a single 26-row table keyed on `(name, expected)`. The level/school tags those tests carried were not load-bearing — default factory tags don't fire any spell name rule, so `name` alone determines the iconKey. Counterspell stays standalone because its assertion genuinely depends on the school tag falling through to school dispatch. The block dropped from ~225 lines to ~50.

**`Card.test.tsx` — actually verify icon selection.** The four icon-selection tests previously asserted `slot.querySelector("svg") !== null`, which matches the *frame* SVG and would pass even if no icon were resolved. `Card.tsx` now exposes `data-icon-key={iconKey}` on the (already aria-hidden, decorative) icon container, and the tests assert that attribute directly — closing a real coverage gap and dropping the brittle `querySelector` chains. The two frame-shape tests now assert only `data-frame` (the `querySelector("rect"|"polygon")` checks were redundant — `FramedIcon` couples the SVG element to the `data-frame` value, and `CardBack.test.tsx` already followed this pattern).

**`src/test/setup.ts` — typed ResizeObserver mock.** `ResizeObserverMock` now `implements ResizeObserver` with a typed constructor; the `as unknown as typeof ResizeObserver` double-cast is gone.

**Test wrappers in `decks/{queries,mutations}.test.tsx`.** Replaced `{ children: any }` (and the `// biome-ignore lint/suspicious/noExplicitAny` lines) with `{ children: ReactNode }`.

### How can this be tested?

- **Manual:** trigger an OAuth callback flow that lands on one of the three status sections (e.g. mid-import progress or a forced `error_code` path) and confirm the panel renders centered with reasonable padding. Net visual change is `4rem` → `2rem` padding on three transient screens — a small reduction.
- **Test changes:** the spell-rules table in `iconRules.test.ts` exercises the same name-keyword cases as before (27 tests → 26 table rows + 1 standalone Counterspell test). The `Card.test.tsx` icon-selection tests are now stronger than before (verify the chosen iconKey via `data-icon-key`); the previous assertions only checked SVG presence and would have passed even on icon-resolution failure.

### Additional Context

**Things a reviewer might do a double-take on:**

- The `iconRules.test.ts` spell-keyword table drops the `headerTags: ["Nth-level <school>"]` override that each test carried. Looks like information loss — but for the name-rule tests, the default factory tags (`["1 action", "60 feet", "Instantaneous"]`) don't fire any rule, so only `name` matters. Counterspell is the one case that depends on the school tag (no name rule matches "Counterspell", so it falls through to school dispatch on the abjuration tag), and it stays as a standalone test.
- The `pickIconKey` (item) block in `iconRules.test.ts` was *not* converted to a table even though it's similar in shape. Those tests have descriptive names ("Trident in the name picks 'trident', not 'broadsword'") that carry intent a flat row would lose. Only the highly-repetitive spell name-keyword block was tabularized.
- For the AuthCallback padding decision, the existing space scale tops out at `--space-6: 2rem`. Three options were on the table: drop to `2rem`, add a new `--space-7: 4rem`, or keep `4rem` as a literal in CSS. Went with option 1 — these are transient panels and a one-off token would have polluted the scale.
- The new `data-icon-key` attribute on the icon container is a test affordance, but it also doubles as a useful debug signal when inspecting a rendered card. The container was already `aria-hidden="true"` (decorative), so there's no a11y impact from the new attribute.
- The full tech-debt review doc (`TECH_DEBT.md`) lives locally and is intentionally **not** part of this PR. Two high-impact items remain (Supabase RPC `invariant()` guards, BrowseApiModal split) plus a handful of optional medium items.