### PR TITLE
feat(chrome): rebrand to Deckwright

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# D&D Cards
+# Deckwright
 
-A browser app for creating and printing **D&D 5e item cards** with a legibility-first design.
+A browser app for creating and printing **D&D 5e item and spell cards** with a legibility-first design. Lives at [deckwright.org](https://deckwright.org).
 
 ## Run locally
 

--- a/index.html
+++ b/index.html
@@ -4,23 +4,23 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <title>Readable D&amp;D Cards</title>
+    <title>Deckwright — readable D&amp;D 5e cards</title>
     <meta
       name="description"
-      content="Build, browse, and print readable D&amp;D 5e item and spell cards. Includes the open 5.1 and 5.2 content (2014 + 2024 rules), with editing and 2- or 4-per-page printing."
+      content="Deckwright — build, browse, and print readable D&amp;D 5e item and spell cards. Includes the open 5.1 and 5.2 content (2014 + 2024 rules), with editing and 2- or 4-per-page printing."
     />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Readable D&amp;D Cards" />
+    <meta property="og:title" content="Deckwright — readable D&amp;D 5e cards" />
     <meta
       property="og:description"
-      content="Build, browse, and print readable D&amp;D 5e item and spell cards. Includes the open 5.1 and 5.2 content (2014 + 2024 rules), with editing and 2- or 4-per-page printing."
+      content="Deckwright — build, browse, and print readable D&amp;D 5e item and spell cards. Includes the open 5.1 and 5.2 content (2014 + 2024 rules), with editing and 2- or 4-per-page printing."
     />
     <meta property="og:image" content="/og.png" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Readable D&amp;D Cards" />
+    <meta name="twitter:title" content="Deckwright — readable D&amp;D 5e cards" />
     <meta
       name="twitter:description"
-      content="Build, browse, and print readable D&amp;D 5e item and spell cards. Includes the open 5.1 and 5.2 content (2014 + 2024 rules), with editing and 2- or 4-per-page printing."
+      content="Deckwright — build, browse, and print readable D&amp;D 5e item and spell cards. Includes the open 5.1 and 5.2 content (2014 + 2024 rules), with editing and 2- or 4-per-page printing."
     />
     <meta name="twitter:image" content="/og.png" />
   </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "dnd-cards",
+  "name": "deckwright",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dnd-cards",
+      "name": "deckwright",
       "version": "0.0.0",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dnd-cards",
+  "name": "deckwright",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/src/app/Root.tsx
+++ b/src/app/Root.tsx
@@ -14,7 +14,12 @@ export function Root() {
             <Link to="/" className={styles.brand}>
               Deckwright
             </Link>
-            <span className={styles.tagline}>readable D&amp;D cards</span>
+            <span className={styles.tagline}>
+              <span aria-hidden="true" className={styles.taglineSeparator}>
+                ·
+              </span>
+              readable D&amp;D cards
+            </span>
           </div>
           <DeckBreadcrumb />
           <div className={styles.spacer} />

--- a/src/app/Root.tsx
+++ b/src/app/Root.tsx
@@ -10,9 +10,12 @@ export function Root() {
     <AnnouncementProvider>
       <div className={styles.shell}>
         <header className={styles.header}>
-          <Link to="/" className={styles.brand}>
-            Deckwright
-          </Link>
+          <div className={styles.brandGroup}>
+            <Link to="/" className={styles.brand}>
+              Deckwright
+            </Link>
+            <span className={styles.tagline}>readable D&amp;D cards</span>
+          </div>
           <DeckBreadcrumb />
           <div className={styles.spacer} />
           <UserMenu />

--- a/src/app/Root.tsx
+++ b/src/app/Root.tsx
@@ -11,7 +11,7 @@ export function Root() {
       <div className={styles.shell}>
         <header className={styles.header}>
           <Link to="/" className={styles.brand}>
-            D&amp;D Cards
+            Deckwright
           </Link>
           <DeckBreadcrumb />
           <div className={styles.spacer} />

--- a/src/app/root.module.css
+++ b/src/app/root.module.css
@@ -42,10 +42,8 @@
   white-space: nowrap;
 }
 
-.tagline::before {
-  content: "·";
+.taglineSeparator {
   margin-right: var(--space-2);
-  color: var(--color-text-muted);
 }
 
 @media (max-width: 640px) {

--- a/src/app/root.module.css
+++ b/src/app/root.module.css
@@ -13,6 +13,13 @@
   border-bottom: 1px solid var(--color-border);
 }
 
+.brandGroup {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
 .brand {
   font-family: var(--font-display);
   font-weight: 600;
@@ -27,6 +34,24 @@
 .brand:focus-visible {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
+}
+
+.tagline {
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.tagline::before {
+  content: "·";
+  margin-right: var(--space-2);
+  color: var(--color-text-muted);
+}
+
+@media (max-width: 640px) {
+  .tagline {
+    display: none;
+  }
 }
 
 .link {

--- a/src/auth/AuthCallback.test.tsx
+++ b/src/auth/AuthCallback.test.tsx
@@ -80,7 +80,7 @@ describe("AuthCallback", () => {
     );
     await waitFor(() =>
       expect(
-        screen.getByRole("heading", { name: /you already have a dnd-cards account/i }),
+        screen.getByRole("heading", { name: /you already have a Deckwright account/i }),
       ).toBeInTheDocument(),
     );
     expect(screen.getByRole("button", { name: /yes, import 2 decks/i })).toBeInTheDocument();
@@ -88,7 +88,7 @@ describe("AuthCallback", () => {
 
   it("on import click: stashes pendingAnonImport, signs out, signInWithOAuth with stashed provider", async () => {
     setLocation({ hash: "#error_code=identity_already_exists", search: "?next=/" });
-    window.localStorage.setItem("dndCards.lastProvider", "github");
+    window.localStorage.setItem("deckwright.lastProvider", "github");
     vi.spyOn(supabase, "rpc").mockImplementation((() =>
       Promise.resolve({ data: [{ id: "d1" }], error: null })) as never);
     const signOutSpy = vi
@@ -107,7 +107,7 @@ describe("AuthCallback", () => {
     );
     await userEvent.click(await screen.findByRole("button", { name: /yes, import 1 deck$/i }));
     await waitFor(() => expect(signOutSpy).toHaveBeenCalled());
-    const stash = window.localStorage.getItem("dndCards.pendingAnonImport");
+    const stash = window.localStorage.getItem("deckwright.pendingAnonImport");
     expect(stash).not.toBeNull();
     expect(JSON.parse(stash as string)).toMatchObject({
       version: 2,
@@ -144,7 +144,7 @@ describe("AuthCallback", () => {
     await waitFor(() => expect(screen.getByText(/couldn't start the import/i)).toBeInTheDocument());
     expect(signOutSpy).not.toHaveBeenCalled();
     expect(oauthSpy).not.toHaveBeenCalled();
-    expect(window.localStorage.getItem("dndCards.pendingAnonImport")).toBeNull();
+    expect(window.localStorage.getItem("deckwright.pendingAnonImport")).toBeNull();
   });
 
   it("on dismiss (X / Esc): navigates without signOut or signInWithOAuth", async () => {
@@ -193,14 +193,14 @@ describe("AuthCallback", () => {
     await userEvent.click(
       await screen.findByRole("button", { name: /skip — leave decks behind/i }),
     );
-    expect(window.localStorage.getItem("dndCards.pendingAnonImport")).toBeNull();
+    expect(window.localStorage.getItem("deckwright.pendingAnonImport")).toBeNull();
     expect(signOutSpy).toHaveBeenCalled();
     expect(oauthSpy).toHaveBeenCalled();
   });
 
   it("on clean success (non-anon authenticated, no error, no pending): navigates to next and clears lastProvider", async () => {
     setLocation({ search: "?next=/some/path" });
-    window.localStorage.setItem("dndCards.lastProvider", "google");
+    window.localStorage.setItem("deckwright.lastProvider", "google");
     render(
       wrap(<AuthCallback />, {
         status: "authenticated",
@@ -209,12 +209,12 @@ describe("AuthCallback", () => {
       }),
     );
     await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: "/some/path" }));
-    expect(window.localStorage.getItem("dndCards.lastProvider")).toBeNull();
+    expect(window.localStorage.getItem("deckwright.lastProvider")).toBeNull();
   });
 
   it("when pendingAnonImport exists and session is non-anon: runs import then navigates", async () => {
     window.localStorage.setItem(
-      "dndCards.pendingAnonImport",
+      "deckwright.pendingAnonImport",
       JSON.stringify({ version: 2, anonDeckIds: ["d1"], importedDeckIds: [] }),
     );
     setLocation({});
@@ -244,7 +244,7 @@ describe("AuthCallback", () => {
       }),
     );
     await waitFor(() => expect(navigate).toHaveBeenCalled());
-    expect(window.localStorage.getItem("dndCards.pendingAnonImport")).toBeNull();
+    expect(window.localStorage.getItem("deckwright.pendingAnonImport")).toBeNull();
   });
 
   it("does not re-enter tryResume when session re-renders mid-import", async () => {
@@ -254,7 +254,7 @@ describe("AuthCallback", () => {
     // AuthCallback's effect re-runs. Without a guard, a second tryResume
     // races with the first and every imported deck is duplicated.
     window.localStorage.setItem(
-      "dndCards.pendingAnonImport",
+      "deckwright.pendingAnonImport",
       JSON.stringify({ version: 2, anonDeckIds: ["d1"], importedDeckIds: [] }),
     );
     setLocation({});

--- a/src/auth/AuthCallback.tsx
+++ b/src/auth/AuthCallback.tsx
@@ -6,6 +6,7 @@ import { useSetNextAnnouncement } from "../lib/ui/Announcement";
 import styles from "./AuthCallback.module.css";
 import { clear, readPending, stash, tryResume } from "./anonImport";
 import { ImportAccountDialog } from "./ImportAccountDialog";
+import { clearLastProvider, readLastProvider } from "./lastProvider";
 import { readNextFromUrl } from "./safeNext";
 import { useSession } from "./useSession";
 
@@ -13,11 +14,6 @@ function parseLinkError(): string | null {
   const hash = new URLSearchParams(window.location.hash.replace(/^#/, ""));
   const search = new URLSearchParams(window.location.search);
   return hash.get("error_code") ?? search.get("error_code");
-}
-
-function lastProvider(): "google" | "github" {
-  const v = window.localStorage.getItem("dndCards.lastProvider");
-  return v === "github" ? "github" : "google";
 }
 
 export function AuthCallback() {
@@ -83,7 +79,7 @@ export function AuthCallback() {
               `Imported ${result.importedCount} of ${pluralize(result.total, "deck")}. We'll try again next time you sign in.`,
             );
           }
-          window.localStorage.removeItem("dndCards.lastProvider");
+          clearLastProvider();
           navigate({ to: readNextFromUrl() });
         } catch {
           setAnnouncement(
@@ -97,7 +93,7 @@ export function AuthCallback() {
 
     if (!session.user.is_anonymous) {
       setAnnouncement("Signed in");
-      window.localStorage.removeItem("dndCards.lastProvider");
+      clearLastProvider();
     }
     navigate({ to: readNextFromUrl() });
   }, [session, navigate, setAnnouncement]);
@@ -114,7 +110,7 @@ export function AuthCallback() {
     stash({ version: 2, anonDeckIds, importedDeckIds: [] });
     const next = readNextFromUrl();
     const redirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`;
-    const provider = lastProvider();
+    const provider = readLastProvider();
     await supabase.auth.signOut();
     await supabase.auth.signInWithOAuth({ provider, options: { redirectTo } });
   };
@@ -123,7 +119,7 @@ export function AuthCallback() {
     clear();
     const next = readNextFromUrl();
     const redirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`;
-    const provider = lastProvider();
+    const provider = readLastProvider();
     await supabase.auth.signOut();
     await supabase.auth.signInWithOAuth({ provider, options: { redirectTo } });
   };
@@ -131,7 +127,7 @@ export function AuthCallback() {
   const onCancel = () => {
     // The anon session is preserved by linkIdentity failures, so dismissing
     // the dialog returns the user to their anon home with decks intact.
-    window.localStorage.removeItem("dndCards.lastProvider");
+    clearLastProvider();
     navigate({ to: "/" });
   };
 

--- a/src/auth/ImportAccountDialog.test.tsx
+++ b/src/auth/ImportAccountDialog.test.tsx
@@ -24,7 +24,7 @@ describe("<ImportAccountDialog>", () => {
       <ImportAccountDialog isOpen deckCount={3} onImport={noop} onSkip={noop} onCancel={noop} />,
     );
     expect(
-      screen.getByRole("heading", { name: /you already have a dnd-cards account/i }),
+      screen.getByRole("heading", { name: /you already have a Deckwright account/i }),
     ).toBeInTheDocument();
     expect(screen.getByText(/bring your/)).toHaveTextContent("3 decks");
     expect(screen.getByText(/cannot be recovered/i)).toBeInTheDocument();

--- a/src/auth/ImportAccountDialog.tsx
+++ b/src/auth/ImportAccountDialog.tsx
@@ -46,7 +46,7 @@ export function ImportAccountDialog({ isOpen, deckCount, onImport, onSkip, onCan
           />
           <div className={styles.body}>
             <p>
-              An account on Deckwright is already linked to that identity. Want to bring your{" "}
+              A Deckwright account is already linked to that identity. Want to bring your{" "}
               {pluralize(deckCount, "deck")} into that account?
             </p>
             <p className={styles.warning}>

--- a/src/auth/ImportAccountDialog.tsx
+++ b/src/auth/ImportAccountDialog.tsx
@@ -35,18 +35,18 @@ export function ImportAccountDialog({ isOpen, deckCount, onImport, onSkip, onCan
       onOpenChange={(open) => {
         if (!open) onCancel();
       }}
-      aria-label="You already have a dnd-cards account"
+      aria-label="You already have a Deckwright account"
     >
       {() => (
         <>
           <DialogHeader
-            title="You already have a dnd-cards account"
+            title="You already have a Deckwright account"
             onClose={onCancel}
             closeLabel="Cancel"
           />
           <div className={styles.body}>
             <p>
-              An account on dnd-cards is already linked to that identity. Want to bring your{" "}
+              An account on Deckwright is already linked to that identity. Want to bring your{" "}
               {pluralize(deckCount, "deck")} into that account?
             </p>
             <p className={styles.warning}>

--- a/src/auth/LoginView.test.tsx
+++ b/src/auth/LoginView.test.tsx
@@ -149,7 +149,7 @@ describe("LoginView OAuth branching", () => {
       expect(linkSpy).toHaveBeenCalledWith(expect.objectContaining({ provider: "google" })),
     );
     expect(oauthSpy).not.toHaveBeenCalled();
-    expect(window.localStorage.getItem("dndCards.lastProvider")).toBe("google");
+    expect(window.localStorage.getItem("deckwright.lastProvider")).toBe("google");
   });
 
   it("calls signInWithOAuth when user is anonymous with zero decks", async () => {
@@ -225,7 +225,7 @@ describe("LoginView dev path conflict", () => {
 
     await waitFor(() =>
       expect(
-        screen.getByRole("heading", { name: /you already have a dnd-cards account/i }),
+        screen.getByRole("heading", { name: /you already have a Deckwright account/i }),
       ).toBeInTheDocument(),
     );
     expect(screen.getByRole("button", { name: /yes, import 3 decks/i })).toBeInTheDocument();
@@ -297,7 +297,7 @@ describe("LoginView dev path conflict", () => {
 
     await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: "/" }));
     expect(setItemSpy).toHaveBeenCalledWith(
-      "dndCards.pendingAnonImport",
+      "deckwright.pendingAnonImport",
       expect.stringContaining('"anonDeckIds":["d1"]'),
     );
     expect(signOutSpy).toHaveBeenCalled();
@@ -319,7 +319,7 @@ describe("LoginView dev path conflict", () => {
       http.post(`${SB_URL}/rest/v1/rpc/list_my_decks`, () => HttpResponse.json([{ id: "d1" }])),
     );
     window.localStorage.setItem(
-      "dndCards.pendingAnonImport",
+      "deckwright.pendingAnonImport",
       JSON.stringify({ version: 1, anonUuid: "anon-old", importedDeckIds: [] }),
     );
 
@@ -336,7 +336,7 @@ describe("LoginView dev path conflict", () => {
     );
 
     await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: "/" }));
-    expect(window.localStorage.getItem("dndCards.pendingAnonImport")).toBeNull();
+    expect(window.localStorage.getItem("deckwright.pendingAnonImport")).toBeNull();
     expect(signOutSpy).toHaveBeenCalled();
     expect(signInSpy).toHaveBeenCalledWith({ email: "dev@local", password: "devpass" });
   });
@@ -368,7 +368,7 @@ describe("LoginView dev path conflict", () => {
 
     await waitFor(() =>
       expect(
-        screen.queryByRole("heading", { name: /you already have a dnd-cards account/i }),
+        screen.queryByRole("heading", { name: /you already have a Deckwright account/i }),
       ).not.toBeInTheDocument(),
     );
     expect(signOutSpy).not.toHaveBeenCalled();
@@ -397,7 +397,7 @@ describe("LoginView dev path conflict", () => {
 
     await waitFor(() => expect(signInSpy).toHaveBeenCalled());
     expect(
-      screen.queryByRole("heading", { name: /you already have a dnd-cards account/i }),
+      screen.queryByRole("heading", { name: /you already have a Deckwright account/i }),
     ).not.toBeInTheDocument();
     await waitFor(() => expect(navigate).toHaveBeenCalledWith({ to: "/" }));
   });

--- a/src/auth/LoginView.tsx
+++ b/src/auth/LoginView.tsx
@@ -9,6 +9,7 @@ import { OAuthButton } from "../lib/ui/OAuthButton";
 import { clear, stash, tryResume } from "./anonImport";
 import { ImportAccountDialog } from "./ImportAccountDialog";
 import styles from "./LoginView.module.css";
+import { writeLastProvider } from "./lastProvider";
 import { readNextFromUrl } from "./safeNext";
 import { useSession } from "./useSession";
 
@@ -46,7 +47,7 @@ export function LoginView() {
           staleTime: 0,
         });
         if ((decks?.length ?? 0) > 0) {
-          window.localStorage.setItem("dndCards.lastProvider", provider);
+          writeLastProvider(provider);
           await supabase.auth.linkIdentity({ provider, options: { redirectTo } });
           return;
         }

--- a/src/auth/anonImport.test.ts
+++ b/src/auth/anonImport.test.ts
@@ -29,13 +29,13 @@ describe("anonImport storage", () => {
   });
 
   it("returns null and does not throw on a malformed value", () => {
-    window.localStorage.setItem("dndCards.pendingAnonImport", "not json");
+    window.localStorage.setItem("deckwright.pendingAnonImport", "not json");
     expect(readPending()).toBeNull();
   });
 
   it("returns null on a stashed v1 payload (silently dropped)", () => {
     window.localStorage.setItem(
-      "dndCards.pendingAnonImport",
+      "deckwright.pendingAnonImport",
       JSON.stringify({
         version: 1,
         anonUuid: "00000000-0000-0000-0000-000000000001",
@@ -47,10 +47,26 @@ describe("anonImport storage", () => {
 
   it("returns null on a stashed value with an unknown version", () => {
     window.localStorage.setItem(
-      "dndCards.pendingAnonImport",
+      "deckwright.pendingAnonImport",
       JSON.stringify({ version: 999, anonDeckIds: [], importedDeckIds: [] }),
     );
     expect(readPending()).toBeNull();
+  });
+
+  it("reads a payload stashed under the legacy dndCards key", () => {
+    const payload: PendingAnonImport = {
+      version: 2,
+      anonDeckIds: ["legacy-1"],
+      importedDeckIds: [],
+    };
+    window.localStorage.setItem("dndCards.pendingAnonImport", JSON.stringify(payload));
+    expect(readPending()).toEqual(payload);
+  });
+
+  it("stash drops any legacy dndCards key alongside the new write", () => {
+    window.localStorage.setItem("dndCards.pendingAnonImport", "stale");
+    stash({ version: 2, anonDeckIds: ["d1"], importedDeckIds: [] });
+    expect(window.localStorage.getItem("dndCards.pendingAnonImport")).toBeNull();
   });
 });
 

--- a/src/auth/anonImport.test.ts
+++ b/src/auth/anonImport.test.ts
@@ -65,8 +65,14 @@ describe("anonImport storage", () => {
 
   it("stash drops any legacy dndCards key alongside the new write", () => {
     window.localStorage.setItem("dndCards.pendingAnonImport", "stale");
-    stash({ version: 2, anonDeckIds: ["d1"], importedDeckIds: [] });
+    const payload: PendingAnonImport = {
+      version: 2,
+      anonDeckIds: ["d1"],
+      importedDeckIds: [],
+    };
+    stash(payload);
     expect(window.localStorage.getItem("dndCards.pendingAnonImport")).toBeNull();
+    expect(readPending()).toEqual(payload);
   });
 });
 

--- a/src/auth/anonImport.ts
+++ b/src/auth/anonImport.ts
@@ -1,7 +1,8 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "../api/database.types";
 
-const STORAGE_KEY = "dndCards.pendingAnonImport";
+const STORAGE_KEY = "deckwright.pendingAnonImport";
+const LEGACY_STORAGE_KEY = "dndCards.pendingAnonImport";
 
 export type PendingAnonImport = {
   version: 2;
@@ -11,14 +12,17 @@ export type PendingAnonImport = {
 
 export function stash(payload: PendingAnonImport): void {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  window.localStorage.removeItem(LEGACY_STORAGE_KEY);
 }
 
 export function clear(): void {
   window.localStorage.removeItem(STORAGE_KEY);
+  window.localStorage.removeItem(LEGACY_STORAGE_KEY);
 }
 
 export function readPending(): PendingAnonImport | null {
-  const raw = window.localStorage.getItem(STORAGE_KEY);
+  const raw =
+    window.localStorage.getItem(STORAGE_KEY) ?? window.localStorage.getItem(LEGACY_STORAGE_KEY);
   if (!raw) return null;
   try {
     const parsed = JSON.parse(raw) as { version?: number };

--- a/src/auth/lastProvider.test.ts
+++ b/src/auth/lastProvider.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { clearLastProvider, readLastProvider, writeLastProvider } from "./lastProvider";
+
+describe("lastProvider storage", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("defaults to google when nothing is stored", () => {
+    expect(readLastProvider()).toBe("google");
+  });
+
+  it("round-trips a github write", () => {
+    writeLastProvider("github");
+    expect(readLastProvider()).toBe("github");
+  });
+
+  it("reads a value stashed under the legacy dndCards key", () => {
+    window.localStorage.setItem("dndCards.lastProvider", "github");
+    expect(readLastProvider()).toBe("github");
+  });
+
+  it("writeLastProvider drops any legacy dndCards key", () => {
+    window.localStorage.setItem("dndCards.lastProvider", "github");
+    writeLastProvider("google");
+    expect(window.localStorage.getItem("dndCards.lastProvider")).toBeNull();
+    expect(readLastProvider()).toBe("google");
+  });
+
+  it("clearLastProvider removes both new and legacy keys", () => {
+    window.localStorage.setItem("dndCards.lastProvider", "github");
+    writeLastProvider("github");
+    clearLastProvider();
+    expect(window.localStorage.getItem("deckwright.lastProvider")).toBeNull();
+    expect(window.localStorage.getItem("dndCards.lastProvider")).toBeNull();
+  });
+});

--- a/src/auth/lastProvider.ts
+++ b/src/auth/lastProvider.ts
@@ -1,0 +1,17 @@
+const KEY = "deckwright.lastProvider";
+const LEGACY_KEY = "dndCards.lastProvider";
+
+export function readLastProvider(): "google" | "github" {
+  const v = window.localStorage.getItem(KEY) ?? window.localStorage.getItem(LEGACY_KEY);
+  return v === "github" ? "github" : "google";
+}
+
+export function writeLastProvider(provider: "google" | "github"): void {
+  window.localStorage.setItem(KEY, provider);
+  window.localStorage.removeItem(LEGACY_KEY);
+}
+
+export function clearLastProvider(): void {
+  window.localStorage.removeItem(KEY);
+  window.localStorage.removeItem(LEGACY_KEY);
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,26 +1,33 @@
 import "@testing-library/jest-dom/vitest";
-import { setCustomIconsLoader } from "@iconify/react";
 import { cleanup } from "@testing-library/react";
+import { createElement } from "react";
 import { afterAll, afterEach, beforeAll, vi } from "vitest";
 import { SB_URL, server } from "./msw";
 
-// Iconify schedules a setTimeout-driven retry fetch against its default API
-// provider when asked for an icon that isn't in the local store. Under
-// vitest, that timer can fire after the jsdom environment is torn down —
-// React then tries to read `window` inside `dispatchSetState` and the run
-// dies with an unhandled "window is not defined" error. Registering a
-// synchronous custom loader for our only prefix routes the lookup through
-// us instead, so iconify never touches the API path.
-const STUB_ICON_BODY = "<path d='M0 0h512v512H0z'/>";
-setCustomIconsLoader(
-  (icons) => ({
-    prefix: "game-icons",
-    width: 512,
-    height: 512,
-    icons: Object.fromEntries(icons.map((name) => [name, { body: STUB_ICON_BODY }])),
-  }),
-  "game-icons",
-);
+// Mock @iconify/react's Icon component. Iconify's real Icon, when mounted
+// with a string ref ("game-icons:trident") whose data isn't already in
+// storage, calls loadIcons(...) which schedules a setTimeout(0) to dispatch
+// the resulting setState. If that timer fires after vitest has torn down
+// jsdom (between test files), React's dispatchSetState reads `window`,
+// finds nothing, and the run dies with an unhandled "window is not defined".
+// Tests assert on wrapper attributes (data-icon-key, data-frame, aria-*),
+// not on iconify's internal SVG output, so a stub Icon is safe.
+//
+// Only Icon is replaced — addCollection / iconLoaded / listIcons stay real
+// because IconPickerDialog uses listIcons("", "game-icons") to enumerate
+// available icons, and resolveIcon's dev-time warning calls iconLoaded.
+vi.mock("@iconify/react", async () => {
+  const actual = await vi.importActual<typeof import("@iconify/react")>("@iconify/react");
+  return {
+    ...actual,
+    Icon: ({ icon, ...props }: { icon: string | { body: string } } & Record<string, unknown>) =>
+      createElement("svg", {
+        ...props,
+        "data-icon-ref": typeof icon === "string" ? icon : "inline",
+        "aria-hidden": "true",
+      }),
+  };
+});
 
 // Replace the ~4000-icon game-icons bundle with a tiny fixture so picker
 // tests don't pay full-collection filter/render cost on every keystroke.

--- a/src/views/HomeView.test.tsx
+++ b/src/views/HomeView.test.tsx
@@ -155,7 +155,7 @@ describe("HomeView with anon user", () => {
   });
 
   it("does NOT open the FirstDeckDialog if it has already been seen", async () => {
-    window.localStorage.setItem("dndCards.firstDeckExplainerSeen", "1");
+    window.localStorage.setItem("deckwright.firstDeckExplainerSeen", "1");
     const inserted = makeDeckRow.build({ name: "Untitled deck", owner_id: "anon-1" });
     server.use(
       http.post(`${SB}/rest/v1/rpc/list_my_decks`, () => HttpResponse.json([])),

--- a/src/views/HomeView.tsx
+++ b/src/views/HomeView.tsx
@@ -32,8 +32,14 @@ export function HomeView() {
   const maybeShowFirstDeckExplainer = () => {
     if (session.status !== "authenticated") return false;
     if (!session.user.is_anonymous) return false;
-    if (window.localStorage.getItem("dndCards.firstDeckExplainerSeen")) return false;
-    window.localStorage.setItem("dndCards.firstDeckExplainerSeen", "1");
+    if (
+      window.localStorage.getItem("deckwright.firstDeckExplainerSeen") ??
+      window.localStorage.getItem("dndCards.firstDeckExplainerSeen")
+    ) {
+      return false;
+    }
+    window.localStorage.setItem("deckwright.firstDeckExplainerSeen", "1");
+    window.localStorage.removeItem("dndCards.firstDeckExplainerSeen");
     setShowFirstDeckDialog(true);
     return true;
   };


### PR DESCRIPTION
### Description

Rebrands the site from "Readable D&D Cards" to **Deckwright** (the user purchased `deckwright.org`). "-wright" is an old-fashioned tradesman suffix (wainwright, cartwright) — fits the D&D vibe and evokes "building decks of cards."

**Visible brand surfaces (all updated):**
- Header wordmark (`src/app/Root.tsx`) with a small subdued tagline `· readable D&D cards` next to it on desktop, hidden below 640px to keep mobile chrome tight.
- HTML `<title>`, `og:*`, `twitter:*`, and `meta name="description"` in `index.html` — all carry "Deckwright — readable D&D 5e cards" with the longer descriptor in the body.
- `package.json` name + `package-lock.json` refresh.
- `README.md` H1 + lede.
- Auth "you already have an account" dialog (`src/auth/ImportAccountDialog.tsx`): copy + `aria-label` + title all updated; matching test regexes follow.

**localStorage key migration:** Three keys move from `dndCards.*` to `deckwright.*` with a one-shot legacy fallback so existing users don't lose stashed state:
- `lastProvider` (OAuth provider hint) — extracted into new `src/auth/lastProvider.ts` (`read` / `write` / `clear`). Reads try the new key, fall back to legacy. Writes set new + remove legacy. Clears remove both. Replaces inline access at four call sites in `AuthCallback.tsx` and one write in `LoginView.tsx`.
- `pendingAnonImport` (anon→signed-in deck import queue) — same fallback shape inlined into `src/auth/anonImport.ts` (`readPending` / `stash` / `clear`).
- `firstDeckExplainerSeen` (one-time UI explainer flag) — inlined in `src/views/HomeView.tsx`; helper extraction wasn't worth it for a single call site.

**Footer GitHub link intentionally untouched.** `src/app/Footer.tsx` still points at `/dnd-cards` because the repo isn't renamed yet. GitHub redirects old URLs, so it works regardless — easy follow-up when the repo rename happens.

### Screenshots

- [ ] Desktop screenshot of the new header (wordmark + tagline)
- [ ] Mobile width screenshot (tagline hidden, wordmark only)
- [ ] Auth `ImportAccountDialog` showing new copy

### How can this be tested?

**Manually:**
1. Open the site — header should read **DECKWRIGHT · readable D&D cards** on desktop. Resize narrower than ~640px — only the wordmark should remain.
2. `view-source:` and confirm `<title>`, `og:*`, `twitter:*`, `meta description` carry the new brand.
3. Trigger the OAuth-already-linked path (sign in with an OAuth provider whose identity is already attached to another Deckwright account). The dialog heading should read "You already have a Deckwright account."
4. Existing-user migration smoke test: in DevTools, seed `localStorage.setItem("dndCards.lastProvider", "github")` then sign in via a flow that reads `lastProvider` — the value should be honored and the key migrated to `deckwright.lastProvider`. Same exercise works for `dndCards.pendingAnonImport` (seed a v2 payload) and `dndCards.firstDeckExplainerSeen` (seed `"1"`, create your first deck as anon, confirm the explainer doesn't show).

**Automated:**
- New `src/auth/lastProvider.test.ts` (5 tests) covers the read-fallback, write-drops-legacy, and clear-removes-both paths.
- Extended `src/auth/anonImport.test.ts` adds parallel coverage for the `pendingAnonImport` legacy fallback (legacy read-through + stash-drops-legacy, asserting the new key holds the payload).
- All existing tests in `auth/` updated to the new key names; heading-regex assertions in `ImportAccountDialog.test.tsx`, `AuthCallback.test.tsx`, `LoginView.test.tsx` updated to the new "Deckwright account" copy.

### Additional Context

**Things a reviewer might do a double-take on:**

- **Tagline separator is a real `<span aria-hidden="true">·</span>`**, not a CSS `::before` pseudo-element. First pass used `::before { content: "·" }`; reviewer flagged that `content` text is announced inconsistently across screen readers. The visible result is identical.
- **Three storage keys, two patterns.** `lastProvider` got its own helper module because it has four call sites and one of them is a non-trivial migration. `pendingAnonImport` already lived behind helpers in `anonImport.ts` so the fallback got inlined there. `firstDeckExplainerSeen` has a single call site and inline migration was cheaper than a third helper. Reviewer flagged the asymmetry as a Minor nit; left as-is — three is the wrong amount to abstract.
- **Legacy fallback has no documented removal date.** All three migrations will live forever in the codebase as written. Acceptable for now since the legacy keys cost ~3 lines each and the user base is small, but worth a calendar reminder to clean up in ~6 months.
- **Footer GitHub link is the only string still saying "dnd-cards"** outside of intentional legacy-key references and historical doc filenames (`docs/superpowers/specs/2026-04-19-dnd-cards-design.md` etc., which are stable identifiers).
- **`deckwright.org` is registered (Cloudflare) but DNS may not be pointed at the deploy yet.** README links it as the canonical home; if that's a problem before launch, the link is one line.
- **`og.png` image is out of scope** — still shows the old brand. Regenerate via `npm run gen:og` when ready.

The branch was reviewed by a code-reviewer agent before this PR. Verdict was "Ready to merge"; the four addressable Minor nits were folded into commit `1d723b4` (test assertion strengthening, separator a11y fix, dialog copy tweak, lockfile refresh).