### PR TITLE
fix(test): deterministic debounce assertion via data-pending

### DIFF
--- a/e2e/layout-pagination.spec.ts
+++ b/e2e/layout-pagination.spec.ts
@@ -52,24 +52,22 @@ test("a multi-row table splits at row boundaries with <thead> repeated on each c
   }
 });
 
-test("editor preview re-paginates after the debounce window on body edits", async ({ page }) => {
+test("editor preview re-paginates after body edits, via the debounce", async ({ page }) => {
   await seedDeck(page, [longItem]);
   await page.goto(`/deck/${TEST_DECK_ID}/edit/${longItem.id}`);
 
   const counts = page.getByTestId("preview-counts");
-  // Wait for the multi-card layout to settle before reading initial state.
+  // Wait for the multi-card layout to settle before editing so the repaint
+  // we assert below isn't actually the initial render finishing.
   await expect(counts).toContainText(/^\d+ cards \(4 per page\)/);
-  const initialCounts = await counts.innerText();
+  await expect(counts).toHaveAttribute("data-pending", "false");
 
-  // Replace the body with something tiny — counts should drop to a single
-  // card, but not before the debounce window elapses.
   const bodyField = page.getByRole("textbox", { name: /^Body/ });
   await bodyField.fill("Tiny body.");
 
-  // Within 100 ms of the edit, counts should not have repainted.
-  await page.waitForTimeout(100);
-  expect(await counts.innerText()).toBe(initialCounts);
-
-  // After the debounce window (300 ms), counts updates to "1 card".
-  await expect(counts).toHaveText("1 card", { timeout: 2000 });
+  // Edit enters the debounce window before the repaint settles.
+  await expect(counts).toHaveAttribute("data-pending", "true");
+  // Debounced repaint eventually settles to the new pagination.
+  await expect(counts).toHaveText("1 card");
+  await expect(counts).toHaveAttribute("data-pending", "false");
 });

--- a/src/cards/useExpandedCards.test.tsx
+++ b/src/cards/useExpandedCards.test.tsx
@@ -59,20 +59,24 @@ describe("useExpandedCards", () => {
         { initialProps: { items: itemsA } },
       );
       expect(result.current.physicalCards).toHaveLength(1);
+      expect(result.current.isPending).toBe(false);
 
       rerender({ items: itemsB });
       // Still showing the pre-change pagination immediately after rerender.
       expect(result.current.physicalCards).toHaveLength(1);
+      expect(result.current.isPending).toBe(true);
 
       act(() => {
         vi.advanceTimersByTime(299);
       });
       expect(result.current.physicalCards).toHaveLength(1);
+      expect(result.current.isPending).toBe(true);
 
       act(() => {
         vi.advanceTimersByTime(1);
       });
       expect(result.current.physicalCards).toHaveLength(2);
+      expect(result.current.isPending).toBe(false);
     });
 
     test("debounceMs of 0 is synchronous (no extra render lag)", () => {
@@ -83,10 +87,12 @@ describe("useExpandedCards", () => {
         { initialProps: { items: itemsA } },
       );
       expect(result.current.physicalCards).toHaveLength(1);
+      expect(result.current.isPending).toBe(false);
 
       rerender({ items: itemsB });
-      // Synchronous: change visible immediately on next render.
+      // Synchronous: change visible immediately on next render, never pending.
       expect(result.current.physicalCards).toHaveLength(2);
+      expect(result.current.isPending).toBe(false);
     });
   });
 });

--- a/src/cards/useExpandedCards.ts
+++ b/src/cards/useExpandedCards.ts
@@ -26,16 +26,17 @@ export function useExpandedCards(
   items: RenderableCard[],
   cardsPerPage: CardsPerPage,
   opts: UseExpandedCardsOpts = {},
-): { physicalCards: PhysicalCard[] } {
+): { physicalCards: PhysicalCard[]; isPending: boolean } {
   const measurer = useSyncExternalStore(subscribe, () => getMeasurer(cardsPerPage));
   const debounceMs = opts.debounceMs ?? 0;
   const debouncedItems = useDebouncedValue(items, debounceMs);
   const effectiveItems = debounceMs > 0 ? debouncedItems : items;
+  const isPending = debounceMs > 0 && items !== debouncedItems;
 
   const physicalCards = useMemo<PhysicalCard[]>(
     () => effectiveItems.flatMap((item) => expandCard(item, measurer)),
     [effectiveItems, measurer],
   );
 
-  return { physicalCards };
+  return { physicalCards, isPending };
 }

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -75,17 +75,14 @@ export function EditorView({ deckId, cardId }: Props) {
   }, [initial]);
 
   const measurementItems = useMemo(() => (draft ? [draft] : []), [draft]);
-  const { physicalCards: chunks4Up, isPending: isPending4 } = useExpandedCards(
+  const { physicalCards: chunks4Up, isPending: previewPending } = useExpandedCards(
     measurementItems,
     4,
     { debounceMs: 300 },
   );
-  const { physicalCards: chunks2Up, isPending: isPending2 } = useExpandedCards(
-    measurementItems,
-    2,
-    { debounceMs: 300 },
-  );
-  const previewPending = isPending4 || isPending2;
+  const { physicalCards: chunks2Up } = useExpandedCards(measurementItems, 2, {
+    debounceMs: 300,
+  });
 
   const [previewPage, setPreviewPage] = useState(0);
   const [browseOpen, setBrowseOpen] = useState(false);

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -75,12 +75,17 @@ export function EditorView({ deckId, cardId }: Props) {
   }, [initial]);
 
   const measurementItems = useMemo(() => (draft ? [draft] : []), [draft]);
-  const { physicalCards: chunks4Up } = useExpandedCards(measurementItems, 4, {
-    debounceMs: 300,
-  });
-  const { physicalCards: chunks2Up } = useExpandedCards(measurementItems, 2, {
-    debounceMs: 300,
-  });
+  const { physicalCards: chunks4Up, isPending: isPending4 } = useExpandedCards(
+    measurementItems,
+    4,
+    { debounceMs: 300 },
+  );
+  const { physicalCards: chunks2Up, isPending: isPending2 } = useExpandedCards(
+    measurementItems,
+    2,
+    { debounceMs: 300 },
+  );
+  const previewPending = isPending4 || isPending2;
 
   const [previewPage, setPreviewPage] = useState(0);
   const [browseOpen, setBrowseOpen] = useState(false);
@@ -170,7 +175,11 @@ export function EditorView({ deckId, cardId }: Props) {
             </Button>
           </div>
         )}
-        <div className={styles.counts} data-testid="preview-counts">
+        <div
+          className={styles.counts}
+          data-testid="preview-counts"
+          data-pending={previewPending ? "true" : "false"}
+        >
           {label}
         </div>
       </div>


### PR DESCRIPTION
### Description

Fixes a load-induced flake in the editor preview re-pagination e2e test (`e2e/layout-pagination.spec.ts:55`). The original assertion depended on `await page.waitForTimeout(100)` resolving before the 300ms debounce expired — a ~200ms margin that any CPU contention could eat, causing the negative assertion ("counts hasn't repainted yet") to run after the debounce had already fired.

**Repro on my machine:** running the e2e suite with vitest in parallel reproduced the flake at ~7% (1/15 runs). On CI the e2e job runs solo so the rate is lower, and `playwright.config.ts` retries once on CI, which silently masks single slips.

**Fix — deterministic DOM marker instead of timing:**

- `useExpandedCards` now returns `{ physicalCards, isPending }` where `isPending = debounceMs > 0 && items !== debouncedItems`. Reference equality is the right semantic — `useDebouncedValue` swaps the stored reference only when its timer fires.
- `EditorView` destructures pending from the 4-up `useExpandedCards` call and writes it on `preview-counts` as `data-pending="true"|"false"`. (The 2-up call uses the same `measurementItems` and `debounceMs`, so the two flags move in lockstep — pulling pending from one is equivalent and clearer than `||`-ing.)
- The e2e test asserts `data-pending="false"` before the edit, `"true"` after `fill()`, then `"false"` again once counts settle to `"1 card"`. No timing reliance.

This preserves the integration coverage the old assertion provided: the test still fails if someone removes the debounce wiring from `EditorView`, not just if it stops working entirely. The pure debounce-timing semantics (300ms means 300ms) are owned by the unit test in `useExpandedCards.test.tsx` with fake timers.

### How can this be tested?

**Automated:**
- Extended the fake-timer tests in `src/cards/useExpandedCards.test.tsx` to assert the full `isPending` lifecycle: false initially → true on rerender → still true at 299ms → false at 300ms, plus stays-false-when-`debounceMs: 0`.
- Rewrote the e2e assertion in `e2e/layout-pagination.spec.ts:55` to use the marker.

**Manual repeat-stress on the worktree:**
- Full vitest suite: 40 sequential runs, 0 flakes (verified the icon teardown fix in `3b9e737` while I was at it).
- Full e2e suite: 15 sequential runs, 1 flake on the test this PR fixes; after the fix, 0 flakes.
- Target test alone: 20 reps via `--repeat-each` and 15 reps under concurrent vitest CPU load — all pass.

### Additional Context

- **Earlier icon flake (CI run [25646428467](https://github.com/ChristopherChudzicki/dnd-cards/actions/runs/25646428467/job/75276114151)) is a separate fix already on `main`** (commit `3b9e737`, `fix(test): mock @iconify/react Icon to eliminate setTimeout-after-teardown flake`). This PR is for a different e2e flake surfaced while verifying that icon fix holds.
- **`data-pending` is currently consumed only by the e2e**, but it's an honest semantic state (debounce in flight) — ready to feed a future "thinking…" UI cue without further plumbing.
- **`useExpandedCards` API addition is backwards-compatible.** `PrintView` destructures only `physicalCards`; nothing else consumes the hook.
- **String `"true"|"false"` rather than a JSX boolean** so the Playwright `toHaveAttribute` comparison is unambiguous.
- **Reviewed by a code-reviewer subagent** — verdict "Ready to merge", no Critical or Important issues. The one Minor nit (`isPending4 || isPending2` redundancy) is folded into commit `881a4ba`.