### PR TITLE
feat(TagInput): inline editing + mid-list insertion

### DIFF
--- a/docs/superpowers/plans/2026-05-12-tag-input-editing.md
+++ b/docs/superpowers/plans/2026-05-12-tag-input-editing.md
@@ -1,0 +1,1995 @@
+# TagInput Inline Editing & Mid-list Insertion — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite `src/lib/ui/TagInput.tsx` to support in-place chip editing and mid-list insertion via gap slots, while preserving the public API and existing append behavior.
+
+**Architecture:** Drop `react-aria-components` `TagGroup`/`TagList`/`Tag`. Build a focus-managed list with a pure reducer for `mode` state (idle / editing / inserting) and a roving-tabindex slot model (gaps interleaved with chips, trailing input as the end-insert slot). Read the full spec at `docs/superpowers/specs/2026-05-12-tag-input-editing-design.md` before starting — it is the source of truth.
+
+**Tech Stack:** React 19, TypeScript, CSS modules, Vitest + RTL + `@testing-library/user-event`.
+
+**Working directory:** `/Users/cchudzicki/dev/dnd-cards/.worktrees/tag-input-edit` (already a feature worktree). Run all commands from this directory.
+
+**File structure:**
+- `src/lib/ui/TagInput.tsx` — modified: the component, slot rendering, keyboard handlers, focus management.
+- `src/lib/ui/TagInput.module.css` — modified: add `.gap`, `.chipEdit`, `.trailingHidden`, `.srOnly` plus tweaks.
+- `src/lib/ui/TagInput.test.tsx` — modified: 10 preserved tests stay; 31 new tests added across tasks.
+- `src/lib/ui/TagInput.reducer.ts` — **created**: pure reducer + helpers + types (independently testable).
+- `src/lib/ui/TagInput.reducer.test.ts` — **created**: reducer unit tests.
+
+---
+
+## Task 1: Pure reducer + helpers
+
+**Files:**
+- Create: `src/lib/ui/TagInput.reducer.ts`
+- Create: `src/lib/ui/TagInput.reducer.test.ts`
+
+The reducer owns transitions for `mode` and `activeSlot`. The component owns `value` (controlled prop). Each reducer call returns `{ state, nextValue? }`; the component applies `nextValue` via `onChange`.
+
+Why a separate file: the state machine has many branches (commit semantics, index adjustment after commit) that are awkward to test through the component. A pure reducer unit-tests cleanly.
+
+- [ ] **Step 1: Create the reducer file**
+
+Create `src/lib/ui/TagInput.reducer.ts`:
+
+```ts
+export type Mode =
+  | { readonly kind: "idle" }
+  | {
+      readonly kind: "editing";
+      readonly index: number;
+      readonly draft: string;
+      readonly original: string;
+    }
+  | { readonly kind: "inserting"; readonly at: number; readonly draft: string };
+
+export type State = {
+  readonly mode: Mode;
+  readonly activeSlot: number;
+};
+
+export type Action =
+  | { readonly type: "openEdit"; readonly index: number; readonly value: readonly string[] }
+  | { readonly type: "openInsert"; readonly at: number; readonly initialDraft?: string }
+  | { readonly type: "updateDraft"; readonly draft: string }
+  | { readonly type: "commit" }
+  | {
+      readonly type: "commitAndOpenEdit";
+      readonly index: number;
+      readonly value: readonly string[];
+    }
+  | {
+      readonly type: "commitAndOpenInsert";
+      readonly at: number;
+      readonly initialDraft?: string;
+    }
+  | { readonly type: "cancel" }
+  | { readonly type: "removeChip"; readonly index: number }
+  | { readonly type: "setActiveSlot"; readonly slot: number };
+
+export type Result = {
+  readonly state: State;
+  readonly nextValue?: string[];
+};
+
+export function initialState(value: readonly string[]): State {
+  return { mode: { kind: "idle" }, activeSlot: value.length * 2 };
+}
+
+export function normalizeDraft(draft: string): string {
+  return draft.replace(/[\n\r]/g, " ").trim();
+}
+
+type CommitOutcome =
+  | { kind: "noop"; activeSlot: number }
+  | { kind: "update"; value: string[]; activeSlot: number }
+  | { kind: "remove"; value: string[]; removedIndex: number; activeSlot: number }
+  | { kind: "insert"; value: string[]; insertedAt: number; activeSlot: number };
+
+function applyCommit(mode: Mode, value: readonly string[]): CommitOutcome {
+  if (mode.kind === "idle") {
+    return { kind: "noop", activeSlot: value.length * 2 };
+  }
+  const normalized = normalizeDraft(mode.draft);
+  if (mode.kind === "editing") {
+    if (normalized === "") {
+      const next = [...value.slice(0, mode.index), ...value.slice(mode.index + 1)];
+      return {
+        kind: "remove",
+        value: next,
+        removedIndex: mode.index,
+        activeSlot: next.length === 0 ? 0 : mode.index * 2,
+      };
+    }
+    if (normalized === value[mode.index]) {
+      return { kind: "noop", activeSlot: mode.index * 2 + 1 };
+    }
+    const next = [...value];
+    next[mode.index] = normalized;
+    return { kind: "update", value: next, activeSlot: mode.index * 2 + 1 };
+  }
+  if (normalized === "") {
+    return { kind: "noop", activeSlot: mode.at * 2 };
+  }
+  const next = [...value.slice(0, mode.at), normalized, ...value.slice(mode.at)];
+  return {
+    kind: "insert",
+    value: next,
+    insertedAt: mode.at,
+    activeSlot: mode.at * 2 + 2,
+  };
+}
+
+function adjustIndex(target: number, outcome: CommitOutcome): number {
+  if (outcome.kind === "remove") {
+    return target > outcome.removedIndex ? target - 1 : target;
+  }
+  if (outcome.kind === "insert") {
+    return target >= outcome.insertedAt ? target + 1 : target;
+  }
+  return target;
+}
+
+export function tagInputReducer(
+  state: State,
+  action: Action,
+  value: readonly string[],
+): Result {
+  switch (action.type) {
+    case "openEdit": {
+      const v = action.value;
+      const original = v[action.index] ?? "";
+      return {
+        state: {
+          mode: {
+            kind: "editing",
+            index: action.index,
+            draft: original,
+            original,
+          },
+          activeSlot: action.index * 2 + 1,
+        },
+      };
+    }
+    case "openInsert": {
+      const draft = action.initialDraft ?? "";
+      return {
+        state: {
+          mode: { kind: "inserting", at: action.at, draft },
+          activeSlot: action.at * 2,
+        },
+      };
+    }
+    case "updateDraft": {
+      if (state.mode.kind === "editing") {
+        return {
+          state: { ...state, mode: { ...state.mode, draft: action.draft } },
+        };
+      }
+      if (state.mode.kind === "inserting") {
+        return {
+          state: { ...state, mode: { ...state.mode, draft: action.draft } },
+        };
+      }
+      return { state };
+    }
+    case "commit": {
+      const outcome = applyCommit(state.mode, value);
+      const nextState: State = {
+        mode: { kind: "idle" },
+        activeSlot: outcome.activeSlot,
+      };
+      return outcome.kind === "noop"
+        ? { state: nextState }
+        : { state: nextState, nextValue: outcome.value };
+    }
+    case "commitAndOpenEdit": {
+      const outcome = applyCommit(state.mode, value);
+      const postValue = outcome.kind === "noop" ? action.value : outcome.value;
+      const targetIndex = adjustIndex(action.index, outcome);
+      if (targetIndex < 0 || targetIndex >= postValue.length) {
+        const nextState: State = {
+          mode: { kind: "idle" },
+          activeSlot: outcome.activeSlot,
+        };
+        return outcome.kind === "noop"
+          ? { state: nextState }
+          : { state: nextState, nextValue: outcome.value };
+      }
+      const original = postValue[targetIndex] ?? "";
+      const nextState: State = {
+        mode: {
+          kind: "editing",
+          index: targetIndex,
+          draft: original,
+          original,
+        },
+        activeSlot: targetIndex * 2 + 1,
+      };
+      return outcome.kind === "noop"
+        ? { state: nextState }
+        : { state: nextState, nextValue: outcome.value };
+    }
+    case "commitAndOpenInsert": {
+      const outcome = applyCommit(state.mode, value);
+      const targetAt = adjustIndex(action.at, outcome);
+      const draft = action.initialDraft ?? "";
+      const nextState: State = {
+        mode: { kind: "inserting", at: targetAt, draft },
+        activeSlot: targetAt * 2,
+      };
+      return outcome.kind === "noop"
+        ? { state: nextState }
+        : { state: nextState, nextValue: outcome.value };
+    }
+    case "cancel": {
+      if (state.mode.kind === "editing") {
+        return {
+          state: {
+            mode: { kind: "idle" },
+            activeSlot: state.mode.index * 2 + 1,
+          },
+        };
+      }
+      if (state.mode.kind === "inserting") {
+        return {
+          state: {
+            mode: { kind: "idle" },
+            activeSlot: state.mode.at * 2,
+          },
+        };
+      }
+      return { state };
+    }
+    case "removeChip": {
+      const v = [...value.slice(0, action.index), ...value.slice(action.index + 1)];
+      return {
+        state: {
+          mode: { kind: "idle" },
+          activeSlot: v.length === 0 ? 0 : action.index * 2,
+        },
+        nextValue: v,
+      };
+    }
+    case "setActiveSlot": {
+      return { state: { ...state, activeSlot: action.slot } };
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Write reducer unit tests (and confirm they fail before the file is exported)**
+
+Create `src/lib/ui/TagInput.reducer.test.ts`:
+
+```ts
+import { describe, expect, test } from "vitest";
+import {
+  type State,
+  initialState,
+  normalizeDraft,
+  tagInputReducer,
+} from "./TagInput.reducer";
+
+const VALUE = ["a", "b", "c"];
+
+function idle(activeSlot = VALUE.length * 2): State {
+  return { mode: { kind: "idle" }, activeSlot };
+}
+
+describe("normalizeDraft", () => {
+  test("collapses newlines to spaces then trims", () => {
+    expect(normalizeDraft("  foo\nbar\r baz  ")).toBe("foo bar  baz");
+  });
+  test("trims pure whitespace to empty", () => {
+    expect(normalizeDraft("   ")).toBe("");
+  });
+});
+
+describe("tagInputReducer", () => {
+  test("openEdit captures original and moves activeSlot to chip", () => {
+    const { state } = tagInputReducer(initialState(VALUE), {
+      type: "openEdit",
+      index: 1,
+      value: VALUE,
+    }, VALUE);
+    expect(state.mode).toEqual({
+      kind: "editing",
+      index: 1,
+      draft: "b",
+      original: "b",
+    });
+    expect(state.activeSlot).toBe(3);
+  });
+
+  test("openInsert enters inserting at the gap with initialDraft", () => {
+    const { state } = tagInputReducer(initialState(VALUE), {
+      type: "openInsert",
+      at: 2,
+      initialDraft: "x",
+    }, VALUE);
+    expect(state.mode).toEqual({ kind: "inserting", at: 2, draft: "x" });
+    expect(state.activeSlot).toBe(4);
+  });
+
+  test("updateDraft mutates editing.draft", () => {
+    let result = tagInputReducer(initialState(VALUE), {
+      type: "openEdit",
+      index: 0,
+      value: VALUE,
+    }, VALUE);
+    result = tagInputReducer(result.state, { type: "updateDraft", draft: "A" }, VALUE);
+    expect(result.state.mode).toEqual({
+      kind: "editing",
+      index: 0,
+      draft: "A",
+      original: "a",
+    });
+  });
+
+  test("commit on non-empty edit updates value", () => {
+    const open = tagInputReducer(initialState(VALUE), {
+      type: "openEdit",
+      index: 1,
+      value: VALUE,
+    }, VALUE);
+    const typed = tagInputReducer(open.state, { type: "updateDraft", draft: "B" }, VALUE);
+    const committed = tagInputReducer(typed.state, { type: "commit" }, VALUE);
+    expect(committed.nextValue).toEqual(["a", "B", "c"]);
+    expect(committed.state).toEqual(idle(3));
+  });
+
+  test("commit on empty edit removes the chip and points active to the gap", () => {
+    const open = tagInputReducer(initialState(VALUE), {
+      type: "openEdit",
+      index: 1,
+      value: VALUE,
+    }, VALUE);
+    const typed = tagInputReducer(open.state, { type: "updateDraft", draft: "" }, VALUE);
+    const committed = tagInputReducer(typed.state, { type: "commit" }, VALUE);
+    expect(committed.nextValue).toEqual(["a", "c"]);
+    expect(committed.state).toEqual({ mode: { kind: "idle" }, activeSlot: 2 });
+  });
+
+  test("commit on whitespace-only edit removes the chip", () => {
+    const open = tagInputReducer(initialState(VALUE), {
+      type: "openEdit",
+      index: 0,
+      value: VALUE,
+    }, VALUE);
+    const typed = tagInputReducer(open.state, { type: "updateDraft", draft: "   " }, VALUE);
+    const committed = tagInputReducer(typed.state, { type: "commit" }, VALUE);
+    expect(committed.nextValue).toEqual(["b", "c"]);
+  });
+
+  test("commit on no-change edit is a noop with nextValue undefined", () => {
+    const open = tagInputReducer(initialState(VALUE), {
+      type: "openEdit",
+      index: 0,
+      value: VALUE,
+    }, VALUE);
+    const committed = tagInputReducer(open.state, { type: "commit" }, VALUE);
+    expect(committed.nextValue).toBeUndefined();
+    expect(committed.state).toEqual(idle(1));
+  });
+
+  test("commit on non-empty insert places value at index and advances active", () => {
+    const open = tagInputReducer(initialState(VALUE), {
+      type: "openInsert",
+      at: 1,
+      initialDraft: "X",
+    }, VALUE);
+    const committed = tagInputReducer(open.state, { type: "commit" }, VALUE);
+    expect(committed.nextValue).toEqual(["a", "X", "b", "c"]);
+    expect(committed.state).toEqual({ mode: { kind: "idle" }, activeSlot: 4 });
+  });
+
+  test("commit on empty insert is a noop", () => {
+    const open = tagInputReducer(initialState(VALUE), {
+      type: "openInsert",
+      at: 1,
+    }, VALUE);
+    const committed = tagInputReducer(open.state, { type: "commit" }, VALUE);
+    expect(committed.nextValue).toBeUndefined();
+    expect(committed.state).toEqual({ mode: { kind: "idle" }, activeSlot: 2 });
+  });
+
+  test("commitAndOpenEdit on empty-edit-removal adjusts target index left of removed", () => {
+    // edit chip 2 (c), clear, click chip 0 (a). a still at index 0.
+    const open = tagInputReducer(initialState(VALUE), {
+      type: "openEdit",
+      index: 2,
+      value: VALUE,
+    }, VALUE);
+    const typed = tagInputReducer(open.state, { type: "updateDraft", draft: "" }, VALUE);
+    const trans = tagInputReducer(typed.state, {
+      type: "commitAndOpenEdit",
+      index: 0,
+      value: VALUE,
+    }, VALUE);
+    expect(trans.nextValue).toEqual(["a", "b"]);
+    expect(trans.state.mode).toEqual({
+      kind: "editing",
+      index: 0,
+      draft: "a",
+      original: "a",
+    });
+  });
+
+  test("commitAndOpenEdit on empty-edit-removal adjusts target index right of removed (shift -1)", () => {
+    // edit chip 0 (a), clear, click chip 2 (c). c now at index 1.
+    const open = tagInputReducer(initialState(VALUE), {
+      type: "openEdit",
+      index: 0,
+      value: VALUE,
+    }, VALUE);
+    const typed = tagInputReducer(open.state, { type: "updateDraft", draft: "" }, VALUE);
+    const trans = tagInputReducer(typed.state, {
+      type: "commitAndOpenEdit",
+      index: 2,
+      value: VALUE,
+    }, VALUE);
+    expect(trans.nextValue).toEqual(["b", "c"]);
+    expect(trans.state.mode).toEqual({
+      kind: "editing",
+      index: 1,
+      draft: "c",
+      original: "c",
+    });
+  });
+
+  test("commitAndOpenInsert after successful insert shifts insert position right (+1)", () => {
+    // insert "X" at 1, then click gap 2; gap 2 should become gap 3.
+    const open = tagInputReducer(initialState(VALUE), {
+      type: "openInsert",
+      at: 1,
+      initialDraft: "X",
+    }, VALUE);
+    const trans = tagInputReducer(open.state, {
+      type: "commitAndOpenInsert",
+      at: 2,
+    }, VALUE);
+    expect(trans.nextValue).toEqual(["a", "X", "b", "c"]);
+    expect(trans.state.mode).toEqual({ kind: "inserting", at: 3, draft: "" });
+    expect(trans.state.activeSlot).toBe(6);
+  });
+
+  test("cancel from editing returns to idle with active on the chip slot", () => {
+    const open = tagInputReducer(initialState(VALUE), {
+      type: "openEdit",
+      index: 1,
+      value: VALUE,
+    }, VALUE);
+    const cancelled = tagInputReducer(open.state, { type: "cancel" }, VALUE);
+    expect(cancelled.nextValue).toBeUndefined();
+    expect(cancelled.state).toEqual(idle(3));
+  });
+
+  test("cancel from inserting returns to idle with active on the gap", () => {
+    const open = tagInputReducer(initialState(VALUE), {
+      type: "openInsert",
+      at: 1,
+    }, VALUE);
+    const cancelled = tagInputReducer(open.state, { type: "cancel" }, VALUE);
+    expect(cancelled.state).toEqual(idle(2));
+  });
+
+  test("removeChip removes index, moves active to gap at that index", () => {
+    const removed = tagInputReducer(initialState(VALUE), {
+      type: "removeChip",
+      index: 1,
+    }, VALUE);
+    expect(removed.nextValue).toEqual(["a", "c"]);
+    expect(removed.state).toEqual({ mode: { kind: "idle" }, activeSlot: 2 });
+  });
+
+  test("removeChip from a single-element value lands active on trailing input (slot 0)", () => {
+    const removed = tagInputReducer(initialState(["a"]), {
+      type: "removeChip",
+      index: 0,
+    }, ["a"]);
+    expect(removed.nextValue).toEqual([]);
+    expect(removed.state).toEqual({ mode: { kind: "idle" }, activeSlot: 0 });
+  });
+
+  test("setActiveSlot only changes activeSlot, leaves mode untouched", () => {
+    const open = tagInputReducer(initialState(VALUE), {
+      type: "openEdit",
+      index: 1,
+      value: VALUE,
+    }, VALUE);
+    const moved = tagInputReducer(open.state, { type: "setActiveSlot", slot: 0 }, VALUE);
+    expect(moved.state.mode).toEqual(open.state.mode);
+    expect(moved.state.activeSlot).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 3: Run the reducer tests**
+
+Run: `npm test -- src/lib/ui/TagInput.reducer.test.ts`
+
+Expected: All ~16 tests pass.
+
+- [ ] **Step 4: Run the typecheck**
+
+Run: `npx tsc --noEmit`
+
+Expected: Clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/ui/TagInput.reducer.ts src/lib/ui/TagInput.reducer.test.ts
+git commit -m "feat(TagInput): add pure reducer for edit/insert state machine"
+```
+
+---
+
+## Task 2: Slot-based component skeleton (preserve baseline + add gap insertion)
+
+**Files:**
+- Modify: `src/lib/ui/TagInput.tsx` (complete rewrite of the file, keep same public API)
+- Modify: `src/lib/ui/TagInput.module.css`
+- Modify: `src/lib/ui/TagInput.test.tsx` (no test deletions; this task does not add new tests yet — Task 3 onward does)
+
+Goal: replace `TagGroup`/`Tag`/`TagList` with the slot model. Render gaps + chips + trailing input. Wire chip × removal, gap clicks → insert input (single insert at a time), trailing input append. Keep all 10 existing tests green. No chip editing yet — that's Task 3.
+
+- [ ] **Step 1: Rewrite TagInput.tsx**
+
+Replace the entire contents of `src/lib/ui/TagInput.tsx` with:
+
+```tsx
+import {
+  type ChangeEvent,
+  type KeyboardEvent,
+  type PointerEvent,
+  useCallback,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
+import {
+  type Action,
+  type State,
+  initialState,
+  tagInputReducer,
+} from "./TagInput.reducer";
+import styles from "./TagInput.module.css";
+
+export type TagInputProps = {
+  id?: string;
+  className?: string;
+  value: string[];
+  onChange: (next: string[]) => void;
+  placeholder?: string;
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
+  "aria-describedby"?: string;
+};
+
+export function TagInput({
+  id,
+  className,
+  value,
+  onChange,
+  placeholder,
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
+  "aria-describedby": ariaDescribedBy,
+}: TagInputProps) {
+  const [state, dispatchRaw] = useReducer(
+    (s: State, a: Action) => tagInputReducer(s, a, value).state,
+    value,
+    initialState,
+  );
+
+  const trailingInputRef = useRef<HTMLInputElement | null>(null);
+  const [trailingDraft, setTrailingDraft] = useState("");
+
+  const dispatch = useCallback(
+    (action: Action) => {
+      const result = tagInputReducer(state, action, value);
+      if (result.nextValue !== undefined) {
+        onChange(result.nextValue);
+      }
+      dispatchRaw(action);
+    },
+    [state, value, onChange],
+  );
+
+  const commitTrailing = useCallback(() => {
+    const trimmed = trailingDraft.replace(/[\n\r]/g, " ").trim();
+    if (trimmed === "") return;
+    onChange([...value, trimmed]);
+    setTrailingDraft("");
+  }, [trailingDraft, value, onChange]);
+
+  const inserting =
+    state.mode.kind === "inserting" ? state.mode : null;
+
+  const handleInsertChange = (e: ChangeEvent<HTMLInputElement>) => {
+    dispatch({ type: "updateDraft", draft: e.target.value });
+  };
+
+  const handleInsertKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      dispatch({ type: "commit" });
+    } else if (e.key === "Escape") {
+      e.stopPropagation();
+      dispatch({ type: "cancel" });
+    }
+  };
+
+  const handleInsertBlur = () => {
+    dispatch({ type: "commit" });
+  };
+
+  const handleTrailingKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      commitTrailing();
+    } else if (e.key === "Backspace" && trailingDraft === "" && value.length > 0) {
+      e.preventDefault();
+      dispatch({ type: "removeChip", index: value.length - 1 });
+    }
+  };
+
+  const handleTrailingBlur = () => {
+    commitTrailing();
+  };
+
+  const handleGapPointerDown = (at: number) => (e: PointerEvent) => {
+    e.preventDefault();
+    commitTrailing();
+    dispatch({ type: "commitAndOpenInsert", at });
+  };
+
+  const handleRemoveClick = (index: number) => () => {
+    dispatch({ type: "removeChip", index });
+  };
+
+  const isInsertingAt = (at: number): boolean =>
+    inserting !== null && inserting.at === at;
+
+  return (
+    <div
+      className={[styles.wrapper, className].filter(Boolean).join(" ")}
+      role="group"
+      aria-label={ariaLabelledBy ? undefined : ariaLabel ?? "Tags"}
+      aria-labelledby={ariaLabelledBy}
+      aria-describedby={ariaDescribedBy}
+    >
+      <ul role="list" className={styles.list}>
+        {value.flatMap((label, i) => {
+          const slotChildren = [
+            <li
+              key={`gap-${i}`}
+              role="presentation"
+              className={styles.gap}
+              aria-hidden={!isInsertingAt(i)}
+            >
+              {isInsertingAt(i) ? (
+                <input
+                  className={styles.chipEdit}
+                  // biome-ignore lint/a11y/noAutofocus: explicit focus is required when the gap input mounts
+                  autoFocus
+                  value={inserting?.draft ?? ""}
+                  onChange={handleInsertChange}
+                  onKeyDown={handleInsertKeyDown}
+                  onBlur={handleInsertBlur}
+                  aria-label={
+                    i === 0 ? "Insert tag at start" : `Insert tag before ${value[i]}`
+                  }
+                />
+              ) : (
+                <button
+                  type="button"
+                  className={styles.gapButton}
+                  tabIndex={-1}
+                  aria-label={
+                    i === 0 ? "Insert tag at start" : `Insert tag before ${value[i]}`
+                  }
+                  onPointerDown={handleGapPointerDown(i)}
+                />
+              )}
+            </li>,
+            <li key={`chip-${i}`} role="listitem" className={styles.tag}>
+              <span className={styles.tagText}>{label}</span>
+              <button
+                type="button"
+                slot="remove"
+                tabIndex={-1}
+                aria-label={`Remove ${label}`}
+                className={styles.remove}
+                onClick={handleRemoveClick(i)}
+              >
+                ×
+              </button>
+            </li>,
+          ];
+          return slotChildren;
+        })}
+      </ul>
+      <input
+        ref={trailingInputRef}
+        id={id}
+        type="text"
+        aria-label={ariaLabelledBy ? undefined : ariaLabel ?? "Tags"}
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={ariaDescribedBy}
+        className={[styles.input, inserting !== null ? styles.trailingHidden : ""]
+          .filter(Boolean)
+          .join(" ")}
+        value={trailingDraft}
+        onChange={(e) => setTrailingDraft(e.target.value)}
+        onKeyDown={handleTrailingKeyDown}
+        onBlur={handleTrailingBlur}
+        placeholder={value.length === 0 ? placeholder : undefined}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Update CSS**
+
+Replace the contents of `src/lib/ui/TagInput.module.css` with:
+
+```css
+.wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text);
+  min-height: calc(var(--fs-md) + var(--space-2) * 2 + 2px);
+}
+
+.wrapper:focus-within {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.list {
+  display: contents;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 0 var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-2);
+  font: inherit;
+  font-size: var(--fs-sm);
+  line-height: 1.6;
+  outline: none;
+  cursor: text;
+}
+
+.tag[data-focused] {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 1px;
+}
+
+.tagText {
+  white-space: nowrap;
+}
+
+.remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.2em;
+  height: 1.2em;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-muted);
+  font: inherit;
+  cursor: pointer;
+}
+
+.remove:hover {
+  color: var(--color-text);
+  background: var(--color-surface);
+}
+
+.remove:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 1px;
+}
+
+.gap {
+  display: inline-flex;
+  align-items: stretch;
+  position: relative;
+  width: 0;
+}
+
+.gapButton {
+  position: absolute;
+  inset-block: -2px;
+  inset-inline: -4px;
+  width: 8px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: text;
+}
+
+@media (pointer: coarse) {
+  .gapButton {
+    inset-inline: -6px;
+    width: 12px;
+  }
+}
+
+.gapButton:hover::before,
+.gapButton:focus-visible::before {
+  content: "";
+  position: absolute;
+  inset-block: 0;
+  left: 50%;
+  width: 1px;
+  background: var(--color-focus-ring);
+  transform: translateX(-0.5px);
+}
+
+.gapButton:focus-visible {
+  outline: none;
+}
+
+.input,
+.chipEdit {
+  flex: 1;
+  min-width: 8ch;
+  border: 0;
+  outline: 0;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-family: var(--font-body);
+  font-size: var(--fs-md);
+}
+
+.chipEdit {
+  width: 8ch;
+  flex: 0 0 auto;
+  field-sizing: content;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-2);
+  font-size: var(--fs-sm);
+  line-height: 1.6;
+}
+
+.trailingHidden {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+```
+
+- [ ] **Step 3: Run the existing tests and confirm they still pass**
+
+Run: `npm test -- src/lib/ui/TagInput.test.tsx`
+
+Expected: All 10 existing tests pass. If "clicking the per-tag remove button" or "Backspace on empty input removes the last chip" fail, the cause is most likely (a) the × button's `aria-label` not matching or (b) the trailing input not handling the Backspace path. Verify the test selectors match the new DOM.
+
+- [ ] **Step 4: Run the typecheck**
+
+Run: `npx tsc --noEmit`
+
+Expected: Clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/ui/TagInput.tsx src/lib/ui/TagInput.module.css
+git commit -m "refactor(TagInput): replace TagGroup with slot model, retain baseline behavior"
+```
+
+---
+
+## Task 3: Click-chip-to-edit + edit semantics
+
+**Files:**
+- Modify: `src/lib/ui/TagInput.tsx`
+- Modify: `src/lib/ui/TagInput.test.tsx`
+
+Goal: click on a chip enters edit mode; Enter commits, Escape reverts, blur commits, empty/whitespace removes, × wins, chip↔chip / chip↔gap transitions commit-before-open, paste collapses newlines, all commits trim. Adds tests 1–11.
+
+- [ ] **Step 1: Write test "Click chip enters edit mode with text pre-filled and selected"**
+
+Add to `src/lib/ui/TagInput.test.tsx` (after the existing describe block; add new tests inside the same `describe("<TagInput>")` if you prefer):
+
+```tsx
+  test("clicking a chip enters edit mode with text pre-filled and selected", async () => {
+    render(<Harness initial={["fire"]} />);
+    await userEvent.click(screen.getByText("fire"));
+    const input = screen.getByRole("textbox", { name: /edit tag 'fire'/i });
+    expect(input).toHaveFocus();
+    expect(input).toHaveValue("fire");
+    // selection: simulate typing to verify selection-all replaces the value
+    await userEvent.keyboard("ice");
+    expect(input).toHaveValue("ice");
+  });
+```
+
+- [ ] **Step 2: Run and confirm failure**
+
+Run: `npm test -- src/lib/ui/TagInput.test.tsx -t "clicking a chip enters edit mode"`
+
+Expected: FAIL — chip click does nothing yet.
+
+- [ ] **Step 3: Wire chip click → edit mode in TagInput.tsx**
+
+Modify `src/lib/ui/TagInput.tsx`:
+
+Add a handler near `handleGapPointerDown`:
+
+```tsx
+  const handleChipPointerDown = (index: number) => (e: PointerEvent) => {
+    // Only intercept on the chip-view; if the user clicks the × button, that
+    // button's own onClick handles removal and we don't want to also open edit.
+    if ((e.target as HTMLElement).closest("button[aria-label^='Remove']")) return;
+    e.preventDefault();
+    commitTrailing();
+    dispatch({ type: "commitAndOpenEdit", index, value });
+  };
+```
+
+In the chip `<li>` JSX, replace the contents based on whether this chip is the one being edited. Replace the existing chip `<li>` block (the second element of `slotChildren`) with:
+
+```tsx
+            state.mode.kind === "editing" && state.mode.index === i ? (
+              <li key={`chip-${i}`} role="listitem" className={styles.tag}>
+                <input
+                  className={styles.chipEdit}
+                  // biome-ignore lint/a11y/noAutofocus: edit input must focus on open
+                  autoFocus
+                  value={state.mode.draft}
+                  onFocus={(e) => e.currentTarget.select()}
+                  onChange={(e) =>
+                    dispatch({ type: "updateDraft", draft: e.target.value })
+                  }
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      dispatch({ type: "commit" });
+                    } else if (e.key === "Escape") {
+                      e.stopPropagation();
+                      dispatch({ type: "cancel" });
+                    }
+                  }}
+                  onBlur={() => dispatch({ type: "commit" })}
+                  aria-label={`Edit tag '${state.mode.original}'`}
+                />
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  aria-label={`Remove ${state.mode.original}`}
+                  className={styles.remove}
+                  onPointerDown={(e) => {
+                    // × must win over commit: prevent blur-commit by handling on pointerdown.
+                    e.preventDefault();
+                    if (state.mode.kind === "editing") {
+                      dispatch({ type: "removeChip", index: state.mode.index });
+                    }
+                  }}
+                >
+                  ×
+                </button>
+              </li>
+            ) : (
+              <li
+                key={`chip-${i}`}
+                role="listitem"
+                className={styles.tag}
+                onPointerDown={handleChipPointerDown(i)}
+              >
+                <span className={styles.tagText}>{label}</span>
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  aria-label={`Remove ${label}`}
+                  className={styles.remove}
+                  onClick={handleRemoveClick(i)}
+                >
+                  ×
+                </button>
+              </li>
+            ),
+```
+
+(The exact placement is: in the `value.flatMap` callback, the second member of `slotChildren` becomes a ternary on `state.mode.kind === "editing" && state.mode.index === i`.)
+
+- [ ] **Step 4: Re-run and confirm pass**
+
+Run: `npm test -- src/lib/ui/TagInput.test.tsx -t "clicking a chip enters edit mode"`
+
+Expected: PASS.
+
+- [ ] **Step 5: Write test "Edit + Enter commits the new value at the same index"**
+
+```tsx
+  test("editing + Enter commits the new value at the same index", async () => {
+    const Watcher = () => {
+      const [v, setV] = useState<string[]>(["fire", "ice"]);
+      return (
+        <>
+          <TagInput aria-label="footer tags" value={v} onChange={setV} />
+          <output>{v.join("|")}</output>
+        </>
+      );
+    };
+    render(<Watcher />);
+    await userEvent.click(screen.getByText("fire"));
+    const input = screen.getByRole("textbox", { name: /edit tag 'fire'/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "lightning{Enter}");
+    expect(screen.getByRole("status")).toHaveTextContent("lightning|ice");
+  });
+```
+
+(Note: `<output>` exposes `role="status"`.)
+
+- [ ] **Step 6: Run and confirm pass (already wired in step 3)**
+
+Run: `npm test -- src/lib/ui/TagInput.test.tsx -t "Enter commits the new value at the same index"`
+
+Expected: PASS.
+
+- [ ] **Step 7: Write test "Edit + Escape reverts AND does not bubble"**
+
+```tsx
+  test("edit + Escape reverts and does not bubble", async () => {
+    const onOuterKey = vi.fn();
+    render(
+      <div onKeyDown={onOuterKey}>
+        <Harness initial={["fire"]} />
+      </div>,
+    );
+    await userEvent.click(screen.getByText("fire"));
+    const input = screen.getByRole("textbox", { name: /edit tag 'fire'/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "ice");
+    await userEvent.keyboard("{Escape}");
+    expect(screen.getByText("fire")).toBeInTheDocument();
+    expect(screen.queryByText("ice")).not.toBeInTheDocument();
+    // sanity: outer handler fires for a non-Escape key
+    onOuterKey.mockClear();
+    await userEvent.click(screen.getByText("fire"));
+    await userEvent.keyboard("a");
+    expect(onOuterKey).toHaveBeenCalled();
+    // and is NOT called for Escape
+    onOuterKey.mockClear();
+    await userEvent.keyboard("{Escape}");
+    expect(onOuterKey).not.toHaveBeenCalled();
+  });
+```
+
+Add `vi` to the imports at the top of `TagInput.test.tsx`: `import { describe, expect, test, vi } from "vitest";`.
+
+- [ ] **Step 8: Run and confirm pass**
+
+Run: `npm test -- src/lib/ui/TagInput.test.tsx -t "edit + Escape reverts and does not bubble"`
+
+Expected: PASS (Escape stopPropagation is already wired in step 3 inside the edit `onKeyDown`).
+
+- [ ] **Step 9: Write test "Empty edit commit removes the chip; focus on gap"**
+
+```tsx
+  test("empty edit commit removes the chip and focuses the gap at that index", async () => {
+    render(<Harness initial={["fire", "ice", "wind"]} />);
+    await userEvent.click(screen.getByText("ice"));
+    const input = screen.getByRole("textbox", { name: /edit tag 'ice'/i });
+    await userEvent.clear(input);
+    await userEvent.keyboard("{Enter}");
+    expect(screen.queryByText("ice")).not.toBeInTheDocument();
+    // The gap that hosted the removed chip is now "before wind".
+    expect(screen.getByRole("button", { name: /insert tag before wind/i })).toHaveFocus();
+  });
+```
+
+- [ ] **Step 10: Run and confirm fail, then wire focus management**
+
+Run the test. It will likely fail because focus management hasn't been wired yet. Add this `useLayoutEffect` to TagInput.tsx (imports add `useLayoutEffect`):
+
+```tsx
+  const isFirstRender = useRef(true);
+
+  useLayoutEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    const wrapper = wrapperRef.current;
+    if (!wrapper) return;
+    // Skip-restore: if the user has actively moved focus to a different element
+    // outside the wrapper, don't yank them back. `body` means the previously
+    // focused element was unmounted (e.g., the edit input we were editing was
+    // just removed), which IS a case where we want to restore focus to the
+    // computed active slot.
+    const active = document.activeElement;
+    if (active && active !== document.body && !wrapper.contains(active)) return;
+    const slots = wrapper.querySelectorAll<HTMLElement>("[data-slot]");
+    const target = Array.from(slots).find(
+      (el) => Number(el.dataset.slotIndex) === state.activeSlot,
+    );
+    target?.focus();
+    // biome-ignore lint/correctness/useExhaustiveDependencies: focus follows activeSlot + mode + value.length
+  }, [state.activeSlot, state.mode.kind, value.length]);
+```
+
+Add a `wrapperRef`:
+
+```tsx
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+```
+
+Attach `ref={wrapperRef}` to the root `<div>`. Tag every focusable slot element with `data-slot data-slot-index={...}`:
+
+- gap button: `data-slot data-slot-index={i * 2}`
+- chip `<li>` when not editing: `data-slot data-slot-index={i * 2 + 1}` (also give it `tabIndex={state.activeSlot === i * 2 + 1 ? 0 : -1}`)
+- chip-edit input: `data-slot data-slot-index={i * 2 + 1}` (real focus owned by the input)
+- gap-insert input: `data-slot data-slot-index={i * 2}` (real focus on the input)
+- trailing input: `data-slot data-slot-index={value.length * 2}` plus `tabIndex={state.activeSlot === value.length * 2 ? 0 : -1}`
+
+Re-run the test. Expected: PASS.
+
+- [ ] **Step 11: Write test "Whitespace-only edit commit also removes"**
+
+```tsx
+  test("whitespace-only edit commit removes the chip", async () => {
+    render(<Harness initial={["fire", "ice"]} />);
+    await userEvent.click(screen.getByText("fire"));
+    const input = screen.getByRole("textbox", { name: /edit tag 'fire'/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "   {Enter}");
+    expect(screen.queryByText("fire")).not.toBeInTheDocument();
+  });
+```
+
+Run: PASS (reducer already handles this).
+
+- [ ] **Step 12: Write test "Edit + outside-blur commits AND does not restore focus"**
+
+```tsx
+  test("edit + blur to outside the wrapper commits and does not restore focus", async () => {
+    render(
+      <>
+        <Harness initial={["fire"]} />
+        <button type="button">elsewhere</button>
+      </>,
+    );
+    await userEvent.click(screen.getByText("fire"));
+    const input = screen.getByRole("textbox", { name: /edit tag 'fire'/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "lightning");
+    const outsideBtn = screen.getByRole("button", { name: "elsewhere" });
+    await userEvent.click(outsideBtn);
+    expect(screen.getByText("lightning")).toBeInTheDocument();
+    expect(outsideBtn).toHaveFocus();
+  });
+```
+
+- [ ] **Step 13: Run the outside-blur test**
+
+The corrected `useLayoutEffect` from step 10 already gates on `active !== document.body && !wrapper.contains(active)`. When the user clicks the "elsewhere" button, `document.activeElement` becomes that button, which is outside the wrapper and not body → the effect returns early and focus stays put. Run: PASS.
+
+- [ ] **Step 14: Write test "× on edit-mode chip removes, focus on gap"**
+
+```tsx
+  test("× on a chip in edit mode removes without committing edit text and focuses the gap", async () => {
+    render(<Harness initial={["fire", "ice"]} />);
+    await userEvent.click(screen.getByText("fire"));
+    const input = screen.getByRole("textbox", { name: /edit tag 'fire'/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "lightning");
+    // The × inside the editing chip's <li> still has the original label.
+    await userEvent.click(screen.getByRole("button", { name: /remove fire/i }));
+    expect(screen.queryByText("fire")).not.toBeInTheDocument();
+    expect(screen.queryByText("lightning")).not.toBeInTheDocument();
+    // Focus lands on the gap slot at the deleted index (now "before ice").
+    expect(screen.getByRole("button", { name: /insert tag before ice/i })).toHaveFocus();
+  });
+```
+
+Run: PASS (× pointerdown short-circuits blur-commit; wired in step 3).
+
+- [ ] **Step 15: Write test "Chip→chip transition commits then opens"**
+
+```tsx
+  test("clicking another chip while editing commits then opens edit on the new chip", async () => {
+    render(<Harness initial={["fire", "ice"]} />);
+    await userEvent.click(screen.getByText("fire"));
+    const input = screen.getByRole("textbox", { name: /edit tag 'fire'/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "lightning");
+    await userEvent.click(screen.getByText("ice"));
+    expect(screen.getByText("lightning")).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: /edit tag 'ice'/i })).toHaveFocus();
+  });
+```
+
+Run: PASS (chip pointerdown dispatches `commitAndOpenEdit`).
+
+- [ ] **Step 16: Write test "Gap→edit-in-progress transition commits then opens insert"**
+
+```tsx
+  test("clicking a gap while editing commits the edit then opens insert at that gap", async () => {
+    render(<Harness initial={["fire", "ice"]} />);
+    await userEvent.click(screen.getByText("fire"));
+    const editInput = screen.getByRole("textbox", { name: /edit tag 'fire'/i });
+    await userEvent.clear(editInput);
+    await userEvent.type(editInput, "lightning");
+    await userEvent.click(screen.getByRole("button", { name: /insert tag before ice/i }));
+    expect(screen.getByText("lightning")).toBeInTheDocument();
+    // The insert input replaces the gap button at "Insert tag before ice".
+    expect(screen.getByRole("textbox", { name: /insert tag before ice/i })).toHaveFocus();
+  });
+```
+
+Run: should PASS. If failure is due to the gap input not appearing, check that the gap rendering branch in Task 2 step 1 still works when `inserting !== null`.
+
+- [ ] **Step 17: Write test "Paste 'a\\nb' collapses to one chip"**
+
+```tsx
+  test("pasting 'a\\nb' into an edit and committing yields a single chip 'a b'", async () => {
+    render(<Harness initial={["x"]} />);
+    await userEvent.click(screen.getByText("x"));
+    const input = screen.getByRole("textbox", { name: /edit tag 'x'/i });
+    await userEvent.clear(input);
+    input.focus();
+    await userEvent.paste("a\nb");
+    await userEvent.keyboard("{Enter}");
+    expect(screen.getByText("a b")).toBeInTheDocument();
+    expect(screen.queryByText("a\nb")).not.toBeInTheDocument();
+  });
+```
+
+Run: PASS (normalizeDraft collapses + trims).
+
+- [ ] **Step 18: Write test "Non-empty edit commit is trimmed"**
+
+```tsx
+  test("non-empty edit commit is trimmed", async () => {
+    render(<Harness initial={["x"]} />);
+    await userEvent.click(screen.getByText("x"));
+    const input = screen.getByRole("textbox", { name: /edit tag 'x'/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "   trimmed   {Enter}");
+    expect(screen.getByText("trimmed")).toBeInTheDocument();
+  });
+```
+
+Run: PASS.
+
+- [ ] **Step 19: Run all TagInput tests; confirm all 10 baseline + new tests pass**
+
+Run: `npm test -- src/lib/ui/TagInput.test.tsx`
+
+Expected: All tests pass (originally 10 + this task's additions).
+
+- [ ] **Step 20: Commit**
+
+```bash
+git add src/lib/ui/TagInput.tsx src/lib/ui/TagInput.test.tsx
+git commit -m "feat(TagInput): click-to-edit chips with Enter/Escape/blur semantics"
+```
+
+---
+
+## Task 4: Keyboard navigation + roving tabindex
+
+**Files:**
+- Modify: `src/lib/ui/TagInput.tsx`
+- Modify: `src/lib/ui/TagInput.test.tsx`
+
+Goal: Tab into the list lands on active slot; ←/→ navigate between slots with no wrap; Enter / F2 on focused chip enters edit; Delete / Backspace on focused chip removes; Enter or printable key on focused gap opens insert. Roving tabindex invariant: exactly one slot has `tabindex=0`. Adds tests 17–27.
+
+- [ ] **Step 1: Add the wrapper key handler**
+
+In `TagInput.tsx`, add a key-handler attached to the root `<div>`:
+
+```tsx
+  const totalSlots = value.length * 2 + 1; // gaps (value.length) + chips (value.length) + trailing
+
+  const handleWrapperKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    // Don't intercept when the focus is inside an edit / insert input.
+    if (state.mode.kind !== "idle") return;
+    const active = state.activeSlot;
+    if (e.key === "ArrowRight") {
+      if (active < totalSlots - 1) {
+        e.preventDefault();
+        dispatch({ type: "setActiveSlot", slot: active + 1 });
+      }
+    } else if (e.key === "ArrowLeft") {
+      if (active > 0) {
+        e.preventDefault();
+        dispatch({ type: "setActiveSlot", slot: active - 1 });
+      }
+    }
+  };
+```
+
+Attach `onKeyDown={handleWrapperKeyDown}` to the root `<div>`.
+
+- [ ] **Step 2: Write test "Arrow Left/Right traverses gap → chip → gap → trailing"**
+
+```tsx
+  test("arrow keys traverse slots in order: gap → chip → gap → trailing", async () => {
+    render(<Harness initial={["fire", "ice"]} />);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(screen.getByRole("button", { name: /insert tag at end|footer tags/i }))
+      .not.toHaveFocus(); // moved off trailing
+    // After 1 ArrowLeft from slot 4 (trailing): slot 3 = chip ice.
+    expect(screen.getAllByRole("listitem")[1]).toHaveFocus();
+    await userEvent.keyboard("{ArrowLeft}");
+    // slot 2 = gap before ice
+    expect(screen.getByRole("button", { name: /insert tag before ice/i })).toHaveFocus();
+    await userEvent.keyboard("{ArrowLeft}");
+    // slot 1 = chip fire
+    expect(screen.getAllByRole("listitem")[0]).toHaveFocus();
+    await userEvent.keyboard("{ArrowLeft}");
+    // slot 0 = gap at start
+    expect(screen.getByRole("button", { name: /insert tag at start/i })).toHaveFocus();
+    await userEvent.keyboard("{ArrowLeft}");
+    // edge: no wrap, still at slot 0
+    expect(screen.getByRole("button", { name: /insert tag at start/i })).toHaveFocus();
+  });
+```
+
+- [ ] **Step 3: Make chips focusable as `<li>` with managed tabIndex**
+
+Update the chip `<li>` (non-editing branch) in `TagInput.tsx`:
+
+```tsx
+              <li
+                key={`chip-${i}`}
+                role="listitem"
+                className={styles.tag}
+                data-slot
+                data-slot-index={i * 2 + 1}
+                tabIndex={state.activeSlot === i * 2 + 1 ? 0 : -1}
+                aria-label={`Tag: ${label}`}
+                aria-keyshortcuts="Enter Delete"
+                onPointerDown={handleChipPointerDown(i)}
+                onKeyDown={(e) => handleChipKeyDown(e, i, label)}
+              >
+                <span className={styles.tagText}>{label}</span>
+                <button ...>×</button>
+              </li>
+```
+
+(Keep the inner × button unchanged.)
+
+Add `handleChipKeyDown`:
+
+```tsx
+  const handleChipKeyDown = (
+    e: KeyboardEvent<HTMLLIElement>,
+    index: number,
+    _label: string,
+  ) => {
+    if (e.key === "Enter" || e.key === "F2") {
+      e.preventDefault();
+      dispatch({ type: "openEdit", index, value });
+    } else if (e.key === "Delete" || e.key === "Backspace") {
+      e.preventDefault();
+      dispatch({ type: "removeChip", index });
+    }
+  };
+```
+
+Run the arrow-key test: it should now PASS once chips are focusable.
+
+- [ ] **Step 4: Write test "Tab into list lands on trailing input"**
+
+```tsx
+  test("tabbing into the list lands on the trailing input by default", async () => {
+    render(
+      <>
+        <button type="button">before</button>
+        <Harness initial={["fire"]} />
+      </>,
+    );
+    screen.getByRole("button", { name: "before" }).focus();
+    await userEvent.tab();
+    expect(screen.getByRole("textbox", { name: /footer tags/i })).toHaveFocus();
+  });
+```
+
+Make the gap buttons and trailing input also use roving tabindex. Update the gap `<button>` (non-inserting branch):
+
+```tsx
+                <button
+                  type="button"
+                  className={styles.gapButton}
+                  data-slot
+                  data-slot-index={i * 2}
+                  tabIndex={state.activeSlot === i * 2 ? 0 : -1}
+                  aria-label={
+                    i === 0 ? "Insert tag at start" : `Insert tag before ${value[i]}`
+                  }
+                  onPointerDown={handleGapPointerDown(i)}
+                  onKeyDown={(e) => handleGapKeyDown(e, i)}
+                />
+```
+
+Update the trailing `<input>`:
+
+```tsx
+      <input
+        ref={trailingInputRef}
+        id={id}
+        type="text"
+        data-slot
+        data-slot-index={value.length * 2}
+        tabIndex={state.activeSlot === value.length * 2 ? 0 : -1}
+        ...
+      />
+```
+
+Add `handleGapKeyDown`:
+
+```tsx
+  const handleGapKeyDown = (e: KeyboardEvent<HTMLButtonElement>, at: number) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      dispatch({ type: "openInsert", at });
+      return;
+    }
+    if (
+      e.key.length === 1 &&
+      !e.ctrlKey &&
+      !e.metaKey &&
+      !e.altKey &&
+      !e.nativeEvent.isComposing
+    ) {
+      e.preventDefault();
+      dispatch({ type: "openInsert", at, initialDraft: e.key });
+    }
+  };
+```
+
+Run all keyboard tests: arrow nav + tab-lands-on-trailing should PASS.
+
+- [ ] **Step 5: Write test "Edge arrows stay put"**
+
+```tsx
+  test("Arrow Right from trailing goes nowhere; Arrow Left from leading gap goes nowhere", async () => {
+    render(<Harness initial={["a"]} />);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    await userEvent.keyboard("{ArrowRight}");
+    expect(trailing).toHaveFocus();
+    // Move all the way left
+    await userEvent.keyboard("{ArrowLeft}{ArrowLeft}{ArrowLeft}");
+    expect(screen.getByRole("button", { name: /insert tag at start/i })).toHaveFocus();
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(screen.getByRole("button", { name: /insert tag at start/i })).toHaveFocus();
+  });
+```
+
+Run: PASS (wrapper handler clamps to bounds).
+
+- [ ] **Step 6: Write test "Enter on focused chip enters edit"**
+
+```tsx
+  test("Enter on a focused chip enters edit mode", async () => {
+    render(<Harness initial={["fire"]} />);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    await userEvent.keyboard("{ArrowLeft}"); // to chip
+    await userEvent.keyboard("{Enter}");
+    expect(screen.getByRole("textbox", { name: /edit tag 'fire'/i })).toHaveFocus();
+  });
+```
+
+Run: PASS.
+
+- [ ] **Step 7: Write test "Enter on focused gap opens insert with empty draft"**
+
+```tsx
+  test("Enter on a focused gap opens insert with empty draft", async () => {
+    render(<Harness initial={["fire"]} />);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    await userEvent.keyboard("{ArrowLeft}{ArrowLeft}"); // chip then gap-at-start
+    await userEvent.keyboard("{Enter}");
+    const insertInput = screen.getByRole("textbox", { name: /insert tag at start/i });
+    expect(insertInput).toHaveFocus();
+    expect(insertInput).toHaveValue("");
+  });
+```
+
+Run: PASS.
+
+- [ ] **Step 8: Write test "Printable key on focused gap opens insert with that char"**
+
+```tsx
+  test("printable key on focused gap opens insert with that key as initial draft", async () => {
+    render(<Harness initial={["fire"]} />);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    await userEvent.keyboard("{ArrowLeft}{ArrowLeft}"); // gap at start
+    await userEvent.keyboard("x");
+    const insertInput = screen.getByRole("textbox", { name: /insert tag at start/i });
+    expect(insertInput).toHaveValue("x");
+    expect(insertInput).toHaveFocus();
+  });
+```
+
+Run: PASS.
+
+- [ ] **Step 9: Write test "Shift+letter produces capital"**
+
+```tsx
+  test("Shift+letter on focused gap opens insert with capital letter", async () => {
+    render(<Harness initial={["fire"]} />);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    await userEvent.keyboard("{ArrowLeft}{ArrowLeft}");
+    await userEvent.keyboard("X");
+    const insertInput = screen.getByRole("textbox", { name: /insert tag at start/i });
+    expect(insertInput).toHaveValue("X");
+  });
+```
+
+Run: PASS.
+
+- [ ] **Step 10: Write test "Delete + Backspace on focused chip both remove"**
+
+```tsx
+  test("Delete on focused chip removes it; Backspace also removes", async () => {
+    render(<Harness initial={["fire", "ice"]} />);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    await userEvent.keyboard("{ArrowLeft}"); // chip ice
+    await userEvent.keyboard("{Delete}");
+    expect(screen.queryByText("ice")).not.toBeInTheDocument();
+    expect(screen.getByText("fire")).toBeInTheDocument();
+    // Now Backspace from the focused fire chip
+    await userEvent.keyboard("{ArrowLeft}"); // gap before fire
+    await userEvent.keyboard("{ArrowRight}"); // chip fire
+    await userEvent.keyboard("{Backspace}");
+    expect(screen.queryByText("fire")).not.toBeInTheDocument();
+  });
+```
+
+Run: PASS.
+
+- [ ] **Step 11: Write test "After Delete, focus lands on gap at deleted index"**
+
+```tsx
+  test("after Delete removes a chip, focus lands on the gap at the deleted index", async () => {
+    render(<Harness initial={["fire", "ice", "wind"]} />);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    await userEvent.keyboard("{ArrowLeft}{ArrowLeft}{ArrowLeft}"); // chip ice
+    await userEvent.keyboard("{Delete}");
+    expect(screen.getByRole("button", { name: /insert tag before wind/i })).toHaveFocus();
+  });
+```
+
+Run: PASS.
+
+- [ ] **Step 12: Write test "Backspace on empty trailing input still removes last chip; focus stays on trailing"**
+
+```tsx
+  test("Backspace on empty trailing input removes last chip; focus stays on trailing", async () => {
+    render(<Harness initial={["fire", "ice"]} />);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    await userEvent.keyboard("{Backspace}");
+    expect(screen.queryByText("ice")).not.toBeInTheDocument();
+    expect(trailing).toHaveFocus();
+  });
+```
+
+The existing test "Backspace on an empty input removes the last chip" overlaps but doesn't assert focus stays. This new test makes the focus invariant explicit. Run: PASS.
+
+- [ ] **Step 13: Write test "Backspace inside non-empty edit edits text"**
+
+```tsx
+  test("Backspace inside non-empty edit input edits text, does not remove chip", async () => {
+    render(<Harness initial={["fire", "ice"]} />);
+    await userEvent.click(screen.getByText("fire"));
+    const input = screen.getByRole("textbox", { name: /edit tag 'fire'/i });
+    await userEvent.keyboard("{End}{Backspace}"); // delete trailing "e"
+    expect(input).toHaveValue("fir");
+    expect(screen.getByText("ice")).toBeInTheDocument();
+  });
+```
+
+Run: PASS.
+
+- [ ] **Step 14: Run full TagInput test file; confirm everything passes**
+
+Run: `npm test -- src/lib/ui/TagInput.test.tsx`
+
+Expected: all tests pass.
+
+- [ ] **Step 15: Commit**
+
+```bash
+git add src/lib/ui/TagInput.tsx src/lib/ui/TagInput.test.tsx
+git commit -m "feat(TagInput): keyboard navigation with roving tabindex"
+```
+
+---
+
+## Task 5: Gap insertion polish + behavioral active-slot test + remaining insert-mode tests
+
+**Files:**
+- Modify: `src/lib/ui/TagInput.test.tsx`
+- Modify: `src/lib/ui/TagInput.tsx` (small touch-ups only)
+
+Goal: cover the remaining insert-mode tests from the test plan that weren't already covered by chip-mode work (tests 12-16 from the spec). Most behavior is already wired; this task is mostly tests.
+
+- [ ] **Step 1: Write test "Click gap opens an input at that index; Enter inserts"**
+
+```tsx
+  test("clicking a gap opens an input at that index; typing + Enter inserts at that index", async () => {
+    const Watcher = () => {
+      const [v, setV] = useState<string[]>(["a", "c"]);
+      return (
+        <>
+          <TagInput aria-label="footer tags" value={v} onChange={setV} />
+          <output>{v.join("|")}</output>
+        </>
+      );
+    };
+    render(<Watcher />);
+    await userEvent.click(screen.getByRole("button", { name: /insert tag before c/i }));
+    const insertInput = screen.getByRole("textbox", { name: /insert tag before c/i });
+    await userEvent.type(insertInput, "b{Enter}");
+    expect(screen.getByRole("status")).toHaveTextContent("a|b|c");
+  });
+```
+
+Run: PASS.
+
+- [ ] **Step 2: Write tests "Empty insert is no-op" and "Whitespace-only insert is no-op"**
+
+```tsx
+  test("empty insert commit is a no-op", async () => {
+    const Watcher = () => {
+      const [v, setV] = useState<string[]>(["a", "c"]);
+      return (
+        <>
+          <TagInput aria-label="footer tags" value={v} onChange={setV} />
+          <output>{v.join("|")}</output>
+        </>
+      );
+    };
+    render(<Watcher />);
+    await userEvent.click(screen.getByRole("button", { name: /insert tag before c/i }));
+    await userEvent.keyboard("{Enter}");
+    expect(screen.getByRole("status")).toHaveTextContent("a|c");
+  });
+
+  test("whitespace-only insert commit is a no-op", async () => {
+    const Watcher = () => {
+      const [v, setV] = useState<string[]>(["a", "c"]);
+      return (
+        <>
+          <TagInput aria-label="footer tags" value={v} onChange={setV} />
+          <output>{v.join("|")}</output>
+        </>
+      );
+    };
+    render(<Watcher />);
+    await userEvent.click(screen.getByRole("button", { name: /insert tag before c/i }));
+    await userEvent.keyboard("   {Enter}");
+    expect(screen.getByRole("status")).toHaveTextContent("a|c");
+  });
+```
+
+Run: PASS.
+
+- [ ] **Step 3: Write test "After successful insert, next Enter inserts at index+1 (behavioral)"**
+
+```tsx
+  test("after a successful insert at gap N, the next insert lands at N+1", async () => {
+    const Watcher = () => {
+      const [v, setV] = useState<string[]>(["a", "d"]);
+      return (
+        <>
+          <TagInput aria-label="footer tags" value={v} onChange={setV} />
+          <output>{v.join("|")}</output>
+        </>
+      );
+    };
+    render(<Watcher />);
+    // Insert "b" between a and d
+    await userEvent.click(screen.getByRole("button", { name: /insert tag before d/i }));
+    await userEvent.type(
+      screen.getByRole("textbox", { name: /insert tag before d/i }),
+      "b{Enter}",
+    );
+    expect(screen.getByRole("status")).toHaveTextContent("a|b|d");
+    // Active slot should now be the gap after b (i.e., "before d"). Press Enter,
+    // type "c", Enter → value becomes a|b|c|d.
+    await userEvent.keyboard("{Enter}");
+    await userEvent.type(
+      screen.getByRole("textbox", { name: /insert tag before d/i }),
+      "c{Enter}",
+    );
+    expect(screen.getByRole("status")).toHaveTextContent("a|b|c|d");
+  });
+```
+
+Run: PASS.
+
+- [ ] **Step 4: Write test "Escape during insert discards draft (and stopPropagation in trailing too)"**
+
+```tsx
+  test("Escape during insert discards draft (mid-list and trailing, empty and non-empty)", async () => {
+    const onOuterKey = vi.fn();
+    render(
+      <div onKeyDown={onOuterKey}>
+        <Harness initial={["a", "b"]} />
+      </div>,
+    );
+    // mid-list insert with text
+    await userEvent.click(screen.getByRole("button", { name: /insert tag before b/i }));
+    await userEvent.type(
+      screen.getByRole("textbox", { name: /insert tag before b/i }),
+      "x",
+    );
+    onOuterKey.mockClear();
+    await userEvent.keyboard("{Escape}");
+    expect(screen.queryByText("x")).not.toBeInTheDocument();
+    expect(onOuterKey).not.toHaveBeenCalled();
+    // trailing input with empty draft → Escape should still stopPropagation
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    onOuterKey.mockClear();
+    await userEvent.keyboard("{Escape}");
+    expect(onOuterKey).not.toHaveBeenCalled();
+  });
+```
+
+This test will likely fail on the trailing-input branch because the trailing input doesn't yet have an Escape handler. Wire it in TagInput.tsx — replace `handleTrailingKeyDown`:
+
+```tsx
+  const handleTrailingKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      commitTrailing();
+    } else if (e.key === "Backspace" && trailingDraft === "" && value.length > 0) {
+      e.preventDefault();
+      dispatch({ type: "removeChip", index: value.length - 1 });
+    } else if (e.key === "Escape") {
+      e.stopPropagation();
+      setTrailingDraft("");
+    }
+  };
+```
+
+Re-run: PASS.
+
+- [ ] **Step 5: Run full file; commit**
+
+Run: `npm test -- src/lib/ui/TagInput.test.tsx`
+
+Expected: all pass.
+
+```bash
+git add src/lib/ui/TagInput.tsx src/lib/ui/TagInput.test.tsx
+git commit -m "test(TagInput): cover insert mode behavior + trailing-input Escape"
+```
+
+---
+
+## Task 6: Accessibility polish + assertions
+
+**Files:**
+- Modify: `src/lib/ui/TagInput.tsx`
+- Modify: `src/lib/ui/TagInput.module.css`
+- Modify: `src/lib/ui/TagInput.test.tsx`
+
+Goal: add the `aria-describedby` hint on the trailing input, ensure `role="list"` + `role="presentation"` + `aria-keyshortcuts` are correct, and add tests 28–31.
+
+- [ ] **Step 1: Add sr-only hint span and aria-describedby on the trailing input**
+
+In `TagInput.tsx`, after the `useId` import (add it if not present: `import { useId } from "react";`), generate a hint id and wire it:
+
+```tsx
+  const hintId = useId();
+```
+
+In the JSX before the trailing input:
+
+```tsx
+      <span id={hintId} className={styles.srOnly}>
+        Use the left arrow key to insert tags between existing tags.
+      </span>
+```
+
+Then on the trailing input, replace the `aria-describedby` line:
+
+```tsx
+        aria-describedby={
+          [ariaDescribedBy, hintId].filter(Boolean).join(" ") || undefined
+        }
+```
+
+- [ ] **Step 2: Confirm sr-only class exists**
+
+The `.srOnly` class was added in Task 2 step 2. Sanity check.
+
+- [ ] **Step 3: Write test "Wrapper exposes role=group with the consumer's aria-label"**
+
+```tsx
+  test("wrapper exposes role=group with the consumer's aria-label", () => {
+    render(<Harness initial={["a"]} />);
+    expect(screen.getByRole("group", { name: /footer tags/i })).toBeInTheDocument();
+  });
+```
+
+Run: PASS.
+
+- [ ] **Step 4: Write test "List has role=list; chip count matches value.length"**
+
+```tsx
+  test("inner list has role=list; chip count matches value.length", () => {
+    render(<Harness initial={["a", "b", "c"]} />);
+    expect(screen.getByRole("list")).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+  });
+```
+
+Run: should PASS because gaps use `role="presentation"`. If `getAllByRole("listitem")` returns 6 (gaps counted), confirm the gap `<li>` has `role="presentation"` (added in Task 2 step 1).
+
+- [ ] **Step 5: Write test "Gap slots have the correct aria-labels"**
+
+```tsx
+  test("gap slots have aria-labels: start / before <next>", () => {
+    render(<Harness initial={["fire", "ice"]} />);
+    expect(screen.getByRole("button", { name: /insert tag at start/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /insert tag before ice/i })).toBeInTheDocument();
+  });
+```
+
+Run: PASS.
+
+- [ ] **Step 6: Write test "Roving tabindex invariant"**
+
+```tsx
+  test("roving tabindex: exactly one slot has tabindex=0 at idle and after nav", () => {
+    const { container } = render(<Harness initial={["a", "b"]} />);
+    const tabbable = () => container.querySelectorAll('[tabindex="0"]');
+    expect(tabbable()).toHaveLength(1);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    expect(tabbable()).toHaveLength(1);
+    expect(trailing).toHaveAttribute("tabindex", "0");
+    // Move active to a chip
+    fireEvent.keyDown(screen.getByRole("group", { name: /footer tags/i }), {
+      key: "ArrowLeft",
+    });
+    expect(tabbable()).toHaveLength(1);
+  });
+```
+
+Add `fireEvent` to the imports: `import { fireEvent, render, screen } from "../../test/render";` (it's re-exported via `@testing-library/react`).
+
+Run: PASS.
+
+- [ ] **Step 7: Write test "chip slot has aria-keyshortcuts"**
+
+```tsx
+  test("chip slot exposes aria-keyshortcuts for Enter and Delete", () => {
+    render(<Harness initial={["a"]} />);
+    expect(screen.getAllByRole("listitem")[0]).toHaveAttribute(
+      "aria-keyshortcuts",
+      "Enter Delete",
+    );
+  });
+```
+
+Run: PASS.
+
+- [ ] **Step 8: Final TagInput test run, build, commit**
+
+```bash
+npm test -- src/lib/ui/TagInput.test.tsx
+npx tsc --noEmit
+```
+
+Expected: all pass, clean typecheck.
+
+```bash
+git add src/lib/ui/TagInput.tsx src/lib/ui/TagInput.module.css src/lib/ui/TagInput.test.tsx
+git commit -m "feat(TagInput): a11y polish — aria-describedby hint, list semantics, key shortcuts"
+```
+
+---
+
+## Task 7: Full project verification + manual UI check
+
+**Files:** none directly modified; this is verification only.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npm test`
+
+Expected: 0 failures across all test files. If anything in `CardEditor.test.tsx` regresses, the cause is most likely that TagInput's DOM changed in a way that affected an existing assertion — investigate before adjusting either side.
+
+- [ ] **Step 2: Run the production build**
+
+Run: `npm run build`
+
+Expected: clean build, no type errors.
+
+- [ ] **Step 3: Start dev server and test the UI manually**
+
+Run: `npm run dev` (pre-approved per CLAUDE.md).
+
+Open a card editor and walk through:
+1. Click on a chip in "Header tags" — chip becomes an input with text selected.
+2. Type to replace, press Enter — chip updates.
+3. Edit a chip, press Escape — chip reverts. The card editor dialog must NOT close.
+4. Edit a chip, clear it, press Enter — chip disappears.
+5. Click between two chips (you should see a faint caret on hover) — an empty insert input appears between them.
+6. Type a value and press Enter — new chip inserted at that position.
+7. Press Tab to focus the tag input; press ←/→ arrow keys to navigate chips and gaps.
+8. With a chip focused, press Enter — it enters edit mode. Press Escape to cancel.
+9. With a chip focused, press Delete — chip removed.
+10. With a gap focused, type a letter — insert opens with that letter.
+11. On mobile (or with DevTools "Responsive" coarse-pointer emulation), tap a chip and tap between chips — confirm the larger 12px touch target.
+
+If anything looks broken, file as a Step in this task and fix before continuing.
+
+- [ ] **Step 4: Stop the dev server**
+
+Done — no commit needed if no fixes were required. If fixes were needed, the engineer must add steps documenting the fix, run tests, and commit.
+
+- [ ] **Step 5: Final summary**
+
+Push or hand off for PR creation as the user directs. Do NOT push or open a PR without explicit user instruction.
+
+---
+
+## Notes for the engineer
+
+- The component has **no consumer-visible API change**. `CardEditor.tsx` doesn't change.
+- The 10 baseline tests in `TagInput.test.tsx` are the contract for trailing-input append + remove behaviors. Don't delete or modify them.
+- "Edit mode" and "insert mode" each render their own `<input>` element. `field-sizing: content` is the modern way to grow inputs; the `width: 8ch` fallback is intentional, not a bug.
+- The reducer is the source of truth for state transitions. If a behavior feels wrong, change the reducer (with a unit test) rather than the component's render logic.
+- `useLayoutEffect` for focus management: never call `.focus()` from an effect that doesn't gate on `wrapperRef.current?.contains(document.activeElement)`, or blur-to-outside will be hijacked back into the widget.
+- `onPointerDown` lives only on slot *wrappers* (chip `<li>`, gap button), never on the active `<input>` itself. Otherwise text selection inside the input breaks.
+- Escape `stopPropagation()` is unconditional inside every edit/insert input AND the trailing input.

--- a/docs/superpowers/specs/2026-05-12-tag-input-editing-design.md
+++ b/docs/superpowers/specs/2026-05-12-tag-input-editing-design.md
@@ -63,7 +63,7 @@ type ActiveSlot = number; // 0…(value.length * 2) — the slot index that owns
 
 `mode` is a discriminated union — illegal states (both `editing` and `inserting` set) are unrepresentable. `original` is captured at edit-open so `Escape` can revert without re-reading from `value`. `activeSlot` is decoupled from `mode` so a transient blur doesn't lose the roving-tabindex position.
 
-Slot indexing: even indices `0, 2, 4, …` are gap slots; odd indices `1, 3, 5, …` are chip slots. The trailing input is the final even index, `value.length * 2`.
+Slot indexing: even indices `0, 2, 4, …` are gap slots; odd indices `1, 3, 5, …` are chip slots. The trailing input is the final even index, `value.length * 2`. Edge case: when `value=[]`, the only slot is the trailing input at index 0 — there are no interior gaps and no chip slots.
 
 ## Edit-mode semantics
 
@@ -72,11 +72,12 @@ Slot indexing: even indices `0, 2, 4, …` are gap slots; odd indices `1, 3, 5, 
 - Empty / whitespace commit → the chip at `editing.index` is removed.
 - Non-empty commit → `value[editing.index]` is updated.
 - Duplicates are allowed — committing a value that already exists elsewhere is fine; consumers dedupe if they care.
-- `Escape` reverts to `original` and exits edit mode. **Escape's keydown event has `stopPropagation()` called** so it does not bubble to the parent `CardEditor` dialog and dismiss the card. After cancel, focus moves to the chip slot.
-- Blur to *outside the wrapper* (focusing another form field, etc.) → commits using the same rules as `Enter`.
-- Click/tap on another slot *inside the wrapper* while editing → handled via `onPointerDown` (covers mouse + touch + pen) on the new slot, which calls commit before opening the new editor. This sidesteps the `blur → click` race.
+- `Escape` reverts to `original` and exits edit mode. **Escape's keydown event has `stopPropagation()` called unconditionally inside any edit / insert input** (including the trailing input, even with an empty draft) so it never bubbles to the parent `CardEditor` dialog. After cancel, focus moves to the chip slot.
+- Blur to *outside the wrapper* (focusing another form field, etc.) → commits using the same rules as `Enter`, **but does NOT restore focus to the chip slot** — the user has intentionally moved on; we don't yank them back.
+- Click/tap on another slot *inside the wrapper* while editing → handled via `onPointerDown` on the new slot wrapper (covers mouse + touch + pen), which commits the current edit before opening the new editor. This sidesteps the `blur → click` race. **Important scope note:** the `onPointerDown` commit-before-open lives only on *other* slot wrappers (chip slots, gap slots, trailing input). The active `<input>` itself does **not** intercept its own pointer events, so text selection, double-click word selection, and caret placement keep working inside the edit input.
+- Transition order on cross-slot pointerdown while editing: resolve the click target by chip identity *before* applying commit. When commit is destructive (empty-commit-remove) and the new target's index sits to the *left* of the just-removed chip, the new target's index is unchanged; if it sits to the *right*, the index shifts down by one. The reducer applies commit then opens the new editor using the post-commit identity.
 - × on a chip in edit mode → removes the chip; the in-progress edit text is discarded. Same `onPointerDown` mechanism short-circuits the blur-commit so the removal wins.
-- Focus return after commit: the chip slot at `editing.index` (the just-edited chip's container). After empty-commit-remove: the gap slot at that same index, or trailing input if the list is now empty.
+- Focus return after commit via Enter or inside-wrapper pointerdown: the chip slot at `editing.index`. After empty-commit-remove: the gap slot at that same index, or trailing input if the list is now empty. After commit via outside-wrapper blur: focus stays on whatever the user moved to (no restore).
 
 ## Insert-mode semantics
 
@@ -84,9 +85,10 @@ Same as edit-mode (including newline collapse and trim) except:
 
 - Empty / whitespace commit → no-op (no chip created). Differs from edit-mode because there's no existing chip to delete.
 - After a successful commit, active slot moves to the gap *after* the newly inserted chip (i.e., slot index `at*2 + 2` in the new layout) so consecutive insertion keeps working.
-- `Escape` discards the draft and clears `mode`. Same `stopPropagation()` rule as edit-mode Escape.
-- Focus return after commit / discard: the gap slot that hosted the insert (or the gap after, per the rule above for successful commit).
-- Removing the trailing input is meaningless; in trailing-input insert mode, Escape just clears the draft and keeps focus there.
+- `Escape` discards the draft and clears `mode`. Same unconditional `stopPropagation()` rule as edit-mode Escape (must not bubble to parent dialog even when draft is empty).
+- Focus return after commit / discard via Enter or inside-wrapper pointerdown: the gap slot that hosted the insert (or the gap after the new chip, per the rule above for successful commit). After commit via outside-wrapper blur: focus stays where the user moved.
+- Cross-slot pointerdown during insert follows the same identity-before-commit rule as edit mode: if the click target is a chip to the *left* of the insert index, its index is unchanged; to the *right*, a successful (non-empty) insert shifts it up by one.
+- Trailing-input insert mode is the only insert position whose "host" gap *is* the input itself; Escape clears the draft and focus stays on the trailing input.
 
 ## Keyboard navigation
 
@@ -96,23 +98,23 @@ Same as edit-mode (including newline collapse and trim) except:
 - On a focused gap slot:
   - `Enter` opens insert with an empty draft.
   - Any *printable* key opens insert with that key as the initial draft, **only when** `event.key.length === 1`, no `Ctrl`/`Meta`/`Alt` modifier is held (Shift is allowed for capitals/punctuation), and `event.isComposing === false` (skip IME composition events).
-- `Backspace` on the *empty trailing input* still removes the last chip (preserved from today).
+- `Backspace` on the *empty trailing input* still removes the last chip (preserved from today). Active slot was the trailing input and stays the trailing input — no focus move.
 - `Backspace` inside a non-empty edit/insert input edits text normally — never deletes the chip.
-- Focus return after `Delete`/`Backspace`-removes-chip: the gap slot at the deleted index, or trailing input if the list is now empty.
+- Focus return after `Delete`/`Backspace` removes a chip via the chip slot's key handler: the gap slot at the deleted index, or trailing input if the list is now empty. (The trailing-input case in the bullet above doesn't go through this path because no chip is removed via the chip slot.)
 
 ## Accessibility
 
 - Wrapper: `role="group"`, `aria-label` / `aria-labelledby` from props (today's behavior).
-- Inside the wrapper, a `<ul role="list">` (CSS-reset to flex row) holds the chip + gap slots. Each chip slot is a `<li role="listitem">` so screen readers announce a list with the correct item count. Gap slots are also `<li>` but with `role="presentation"` so they don't pollute the item count — they're nav-relevant, not content-relevant.
-- Chip slot (the `<li>`): focusable container (`tabindex` managed by roving), `aria-label="Tag: <text>"`. Owns Enter/Delete/Backspace handling. The × button inside is focusable as `<button aria-label="Remove <text>">`.
-- Chip-edit: replaces chip-view in the same `<li>`. Real DOM focus on the `<input aria-label="Edit tag '<original>'">` — not `aria-activedescendant`, because the input needs real keystroke focus.
+- Inside the wrapper, a `<ul role="list">` (CSS-reset to flex row) holds the chip + gap slots. Each chip slot is a `<li role="listitem">` so screen readers announce a list with the correct item count. Gap slots are also `<li>` but with `role="presentation"` (ARIA 1.2 listitem-or-presentation pattern). Modern AT honors this and counts only the listitem children; if a target browser/AT pair turns out to count the presentational `<li>`s, the fallback is to drop `role="list"` entirely and rely on per-slot `aria-label` for context.
+- Chip slot (the `<li>`): focusable container (`tabindex` managed by roving), `aria-label="Tag: <text>"`, `aria-keyshortcuts="Enter Delete"` so SRs announce the interaction model. Owns Enter/Delete/Backspace handling. The × button inside is `tabindex=-1` (reachable via mouse/touch or via the chip's Delete shortcut, not via Tab).
+- Chip-edit: replaces chip-view in the same `<li>`. Real DOM focus on the `<input aria-label="Edit tag '<original>'">` — not `aria-activedescendant`, because the input needs real keystroke focus. While editing, the chip `<li>` itself goes `tabindex=-1` so Shift-Tab from the input exits the widget cleanly without an intermediate stop on the listitem.
 - Gap slot: focusable `<button>` styled as a 1–2px caret target. `aria-label`s:
   - `"Insert tag at start"` (index 0, before any chip)
   - `"Insert tag before <next>"` (middle, before chip `n`)
-  - The trailing input keeps the consumer's `aria-label` / `aria-labelledby` (today's behavior) — it is *both* the trailing input *and* the "insert at end" gap, so its single label needs to convey both. We rely on the consumer's "Header tags" / "Footer tags" label naming the whole field; the trailing input is the canonical entry point.
-- Gap slot caret rendering only appears on `:hover` or `[data-focused]` to keep idle UI quiet.
-- Roving tabindex: exactly one slot has `tabindex=0` at a time; all others `tabindex=-1`. Active slot is tracked in state. When the active slot is removed (chip deletion), focus moves per the rules above before the offending slot unmounts (use `flushSync` or move focus on the same render that prunes the slot).
-- Escape inside an edit/insert input calls `stopPropagation()` to prevent dismissing the parent dialog.
+  - The trailing input keeps the consumer's `aria-label` / `aria-labelledby` (today's behavior) — it is *both* the trailing input *and* the "insert at end" gap. It additionally carries `aria-describedby` pointing to a visually-hidden hint: *"Use ← to insert between existing tags."* This is the only entry-discovery cue for keyboard/SR users; consumes one line of sr-only CSS.
+- Gap slot caret rendering only appears on `:hover` or `[data-focused]` to keep idle UI quiet. Caret color uses a token meeting 3:1 non-text contrast (`--color-focus-ring` against the wrapper background).
+- Roving tabindex: exactly one slot has `tabindex=0` at a time; all others `tabindex=-1`. Active slot is tracked in state. Focus is moved via `useLayoutEffect` keyed on `activeSlot` (and on `mode` for edit/insert transitions) — synchronous-before-paint, no `flushSync` needed.
+- Escape inside an edit/insert input calls `stopPropagation()` *unconditionally* — even when the draft is empty — to prevent dismissing the parent dialog.
 
 ## Component contract (public API)
 
@@ -137,11 +139,11 @@ Drop `react-aria-components`' `TagGroup`/`TagList`/`Tag`. Build a focus-managed 
 
 - `<div role="group">` wrapper carries the consumer's aria-label and the `onKeyDown` for arrow nav.
 - Inside: a `<ul role="list">` of slot `<li>`s — chips and gaps interleaved — plus the trailing `<input>` (the final "gap" rendered as an actual input).
-- `mode` discriminated union and `activeSlot` index live in `useReducer` or a small `useState` pair; transitions (`openEdit`, `openInsert`, `commit`, `cancel`, `remove`) go through one reducer-style helper for predictability.
-- All slot pointer interactions use `onPointerDown` (mouse + touch + pen) for the commit-before-open mechanism; `onClick` handlers only run after commit has settled.
-- Width-growing edit / insert input: CSS `field-sizing: content` with a fixed `width: 8ch` (and `min-width: 8ch`) fallback. Modern Chromium + Safari 18.4+ + Firefox 144+ get content-fit growth; older browsers see a fixed-ish input — acceptable graceful degradation, no polyfill.
+- `mode` discriminated union and `activeSlot` index live in a single `useReducer` (not two `useState`s) so that coupled transitions — e.g., commit-and-move-active-to-the-gap-after — apply in one update. Transitions (`openEdit`, `openInsert`, `commit`, `cancel`, `remove`) are reducer actions.
+- All slot *wrapper* pointer interactions use `onPointerDown` (mouse + touch + pen) for the commit-before-open mechanism; `onClick` handlers only run after commit has settled. The active edit/insert `<input>` does NOT install its own `onPointerDown` handler — text selection, double-click word-select, and caret placement keep their default behavior.
+- Width-growing edit / insert input: CSS `field-sizing: content` with a fixed `width: 8ch` (and `min-width: 8ch`) fallback. Modern browsers get content-fit growth; older browsers see a fixed-width input — acceptable graceful degradation, no polyfill.
 
-Why drop `TagGroup`: it's designed for read-only-or-removable chip rows. Editable chips interleaved with insertion slots don't fit its collection model, and its built-in keyboard handlers fight ours. The custom focus-management code is well-known but non-trivial — estimate 250–350 lines including the slot dispatch, the reducer, and the keyboard handler.
+Why drop `TagGroup`: it's designed for read-only-or-removable chip rows. Editable chips interleaved with insertion slots don't fit its collection model, and its built-in keyboard handlers fight ours. The custom focus-management code is non-trivial — slot dispatch, the reducer, and the keyboard handler — but well-bounded.
 
 ## Styling
 
@@ -157,42 +159,43 @@ Keep using `TagInput.module.css`. New additions:
 Tests live in `src/lib/ui/TagInput.test.tsx`. All 10 existing tests stay (they describe the still-valid public contract: append, blur-commit, comma-not-committing, trim, etc.). New tests:
 
 **Edit mode**
-1. Click chip enters edit mode with text pre-filled and selected.
+1. Click chip enters edit mode with text pre-filled and selected. Assert the edit input is queryable by its `aria-label` ("Edit tag '<original>'").
 2. Edit + `Enter` commits the new value at the same index.
-3. Edit + `Escape` reverts and does not bubble (assert outer key handler is *not* called).
-4. Empty edit commit removes the chip at that index.
+3. Edit + `Escape` reverts AND does not bubble. Test pattern: wrap `<Harness>` in a `<div onKeyDown={spy}>`. Assert `spy` is called for a non-Escape key (sanity) and NOT called when Escape is pressed inside the edit input.
+4. Empty edit commit removes the chip at that index; focus lands on the gap slot at that index.
 5. Whitespace-only edit commit also removes (e.g., `"   "` → remove).
-6. Edit + blur to outside the wrapper commits.
-7. × on a chip currently being edited removes the chip without committing the in-progress edit text.
-8. Clicking another chip while editing commits the current edit then opens edit on the new chip.
-9. Pasting `"a\nb"` into an edit and committing yields a single chip `"a b"` (newline collapsed + trimmed).
-10. Non-empty edit commit is trimmed.
+6. Edit + blur to outside the wrapper commits, AND does NOT restore focus to the chip slot (focus stays on the outside element).
+7. × on a chip currently being edited removes the chip without committing the in-progress edit text; focus lands on the gap slot at that index.
+8. Clicking another chip while editing commits the current edit then opens edit on the new chip (chip→chip transition).
+9. Clicking a gap while editing commits the current edit then opens insert at that gap (gap→edit-in-progress transition).
+10. Pasting `"a\nb"` into an edit and committing yields a single chip `"a b"` (newline collapsed + trimmed).
+11. Non-empty edit commit is trimmed.
 
 **Insert mode**
-11. Click gap opens an input at that index; type + `Enter` inserts at that index.
-12. Empty insert commit is a no-op.
-13. Whitespace-only insert commit is a no-op.
-14. After a successful insert, active slot is the gap *after* the new chip (assert next `Enter` opens insert at index+1).
-15. `Escape` during insert discards the draft.
+12. Click gap opens an input at that index; type + `Enter` inserts at that index.
+13. Empty insert commit is a no-op.
+14. Whitespace-only insert commit is a no-op.
+15. After a successful insert at gap N, the next commit (Enter, type, Enter) inserts at index N+1. Asserted *behaviorally* via the resulting `value` order rather than by reading internal state.
+16. `Escape` during insert discards the draft (covers both mid-list and trailing-input insert with empty/non-empty drafts; verifies stopPropagation in both).
 
 **Keyboard navigation**
-16. Tab into list lands on the trailing input by default.
-17. Arrow Right from trailing input goes nowhere (no wrap). Arrow Left from leading gap goes nowhere.
-18. Arrow Left/Right traverses gap → chip → gap → trailing.
-19. `Enter` on focused chip enters edit mode.
-20. `Enter` on focused gap opens insert with empty draft.
-21. Printable key on focused gap opens insert with that character as the draft.
-22. Shift+letter on focused gap opens insert with capital letter (assert Shift permitted).
-23. `Delete` on focused chip removes it; `Backspace` on focused chip also removes (both shortcuts).
-24. After `Delete`, focus lands on the gap at the deleted index.
-25. `Backspace` on empty trailing input still removes last chip (preserve current behavior).
-26. `Backspace` inside a non-empty edit input edits text, does NOT remove the chip.
+17. Tab into list lands on the trailing input by default.
+18. Arrow Right from trailing input goes nowhere (no wrap). Arrow Left from leading gap goes nowhere.
+19. Arrow Left/Right traverses gap → chip → gap → trailing.
+20. `Enter` on focused chip enters edit mode.
+21. `Enter` on focused gap opens insert with empty draft.
+22. Printable key on focused gap opens insert with that character as the draft.
+23. Shift+letter on focused gap opens insert with capital letter (RTL pattern: `userEvent.keyboard("A")` produces `"A"`; Shift modifier doesn't need explicit press).
+24. `Delete` on focused chip removes it; `Backspace` on focused chip also removes (both shortcuts).
+25. After `Delete` removes a chip, focus lands on the gap at the deleted index.
+26. `Backspace` on empty trailing input still removes last chip (preserve current behavior); focus stays on the trailing input.
+27. `Backspace` inside a non-empty edit input edits text, does NOT remove the chip.
 
 **Accessibility**
-27. Wrapper exposes `role="group"` with the consumer's aria-label.
-28. List inside has `role="list"`; chip count matches `value.length` via `getAllByRole("listitem")`.
-29. Gap slots have aria-labels: `"Insert tag at start"`, `"Insert tag before <next>"`. Targeted by these labels throughout the insert tests.
-30. Roving tabindex: at idle, exactly one slot has `tabindex=0`; after arrow nav, the new slot is `tabindex=0` and the previous is `tabindex=-1`.
+28. Wrapper exposes `role="group"` with the consumer's aria-label.
+29. List inside has `role="list"`; chip count matches `value.length` via `getAllByRole("listitem")` (gaps as `role="presentation"` are excluded).
+30. Gap slots have aria-labels: `"Insert tag at start"`, `"Insert tag before <next>"`. Targeted by these labels throughout the insert tests.
+31. Roving tabindex: at idle, exactly one slot has `tabindex=0`; after arrow nav, the new slot is `tabindex=0` and the previous is `tabindex=-1`. Uses `document.querySelectorAll('[tabindex="0"]')` — a documented deviation from getByRole, justified because the assertion is about the roving invariant itself.
 
 Use `getByRole` selectors throughout. Factories not needed (chip text is just `string`).
 

--- a/docs/superpowers/specs/2026-05-12-tag-input-editing-design.md
+++ b/docs/superpowers/specs/2026-05-12-tag-input-editing-design.md
@@ -37,61 +37,82 @@ Why mouse/touch have no "focused but not editing" state: there's no useful actio
 
 ## Slot model
 
-The wrapper renders a flat sequence of *slots*. For `value = [A, B, C]`:
+The wrapper renders a flat sequence of *slots*. For `value = [A, B, C]` there are `value.length + 1 = 4` insertion positions; the last one is the trailing input itself:
 
 ```
-[gap 0] [chip A] [gap 1] [chip B] [gap 2] [chip C] [trailing-input]
+[gap 0] [chip A] [gap 1] [chip B] [gap 2] [chip C] [trailing-input = gap 3]
 ```
 
-- **Gap slot** — 1–2px visual, 8px hit target on fine pointers, 12px on coarse pointers (`@media (pointer: coarse)`). Cursor: `text`. On hover/focus, a thin caret line renders to confirm the target. Clicking sets `inserting = { at: i, draft: "" }`. Focusable for keyboard nav.
-- **Chip slot** — renders either *chip-view* (default) or *chip-edit* (when `editing.index === i`).
+- **Gap slot (interior)** — 1–2px visual, 8px hit target on fine pointers, 12px on coarse pointers (`@media (pointer: coarse)`). Cursor: `text`. On hover/focus, a thin caret line renders to confirm the target. Clicking opens insert mode at index `i`. Focusable for keyboard nav.
+- **Chip slot** — a focusable container (`role="listitem"`, `tabindex` managed by roving rules) that renders either *chip-view* (default) or *chip-edit* (in edit mode for this index).
   - Chip-view: a span with the label and the × remove button (today's design).
   - Chip-edit: an `<input>` pre-filled with the chip text, selection-all on focus, plus the same × that removes the chip outright (× wins over commit).
-- **Trailing input** — visible only when no chip is being edited and no mid-list insert is active. Functions as an always-empty entry point for appending. Clicking it (or typing into it) appends to the end via the same commit rules as insertion. When the user is editing a chip or mid-list-inserting, the trailing input is hidden so the "one input at a time" rule holds; the edit/insert input replaces it visually.
+- **Trailing input** — the last insertion slot, distinguished only by being a real `<input>` element instead of a 1–2px caret target. Always mounted; while edit-mode or mid-list insert is active, it stays in the DOM (kept `visibility: hidden`, `tabindex=-1`, `aria-hidden`) so the wrapper doesn't reflow. When idle it's the default landing slot and the only slot showing the `placeholder`.
 
 ## Internal state
 
 ```ts
-type Editing = { index: number; draft: string } | null;
-type Inserting = { at: number; draft: string } | null;
+type Mode =
+  | { kind: "idle" }
+  | { kind: "editing"; index: number; draft: string; original: string }
+  | { kind: "inserting"; at: number; draft: string };
+
+// Plus:
+type ActiveSlot = number; // 0…(value.length * 2) — the slot index that owns tabindex=0
 ```
 
-`editing` and `inserting` are mutually exclusive. Opening one commits or cancels the other first. We never render two inputs at the same time.
+`mode` is a discriminated union — illegal states (both `editing` and `inserting` set) are unrepresentable. `original` is captured at edit-open so `Escape` can revert without re-reading from `value`. `activeSlot` is decoupled from `mode` so a transient blur doesn't lose the roving-tabindex position.
+
+Slot indexing: even indices `0, 2, 4, …` are gap slots; odd indices `1, 3, 5, …` are chip slots. The trailing input is the final even index, `value.length * 2`.
 
 ## Edit-mode semantics
 
-- `Enter` commits the whole input string as the new chip value at `editing.index`. No splitting on Enter — this is the question the user flagged in 2A; the answer is "save whole".
+- `Enter` commits. The whole input string becomes the chip value (no splitting on Enter — the 2A question; "save whole").
+- Pre-commit normalization: any `\n` / `\r` in the draft (e.g., from paste) is replaced with a space, then the string is `trim()`-ed. Matches today's append path.
 - Empty / whitespace commit → the chip at `editing.index` is removed.
 - Non-empty commit → `value[editing.index]` is updated.
-- `Escape` reverts and exits edit mode; focus returns to the chip-view.
-- Blur (click/tap elsewhere, `Tab`) → commits using the same rules as `Enter`.
-- × on a chip in edit mode → removes the chip; the in-progress edit text is discarded. Implemented by handling `mousedown` on × to short-circuit the blur-commit.
-- Clicking another chip or another gap while editing → commits the current edit, then opens the new editor.
+- Duplicates are allowed — committing a value that already exists elsewhere is fine; consumers dedupe if they care.
+- `Escape` reverts to `original` and exits edit mode. **Escape's keydown event has `stopPropagation()` called** so it does not bubble to the parent `CardEditor` dialog and dismiss the card. After cancel, focus moves to the chip slot.
+- Blur to *outside the wrapper* (focusing another form field, etc.) → commits using the same rules as `Enter`.
+- Click/tap on another slot *inside the wrapper* while editing → handled via `onPointerDown` (covers mouse + touch + pen) on the new slot, which calls commit before opening the new editor. This sidesteps the `blur → click` race.
+- × on a chip in edit mode → removes the chip; the in-progress edit text is discarded. Same `onPointerDown` mechanism short-circuits the blur-commit so the removal wins.
+- Focus return after commit: the chip slot at `editing.index` (the just-edited chip's container). After empty-commit-remove: the gap slot at that same index, or trailing input if the list is now empty.
 
 ## Insert-mode semantics
 
-Same as edit-mode except:
+Same as edit-mode (including newline collapse and trim) except:
 
-- Empty / whitespace commit → no-op (no chip created). This differs from edit-mode because there's no existing chip to delete.
-- After a successful commit, active slot moves to the gap *after* the newly inserted chip so the user can keep inserting at adjacent positions.
-- `Escape` discards the draft.
+- Empty / whitespace commit → no-op (no chip created). Differs from edit-mode because there's no existing chip to delete.
+- After a successful commit, active slot moves to the gap *after* the newly inserted chip (i.e., slot index `at*2 + 2` in the new layout) so consecutive insertion keeps working.
+- `Escape` discards the draft and clears `mode`. Same `stopPropagation()` rule as edit-mode Escape.
+- Focus return after commit / discard: the gap slot that hosted the insert (or the gap after, per the rule above for successful commit).
+- Removing the trailing input is meaningless; in trailing-input insert mode, Escape just clears the draft and keeps focus there.
 
 ## Keyboard navigation
 
 - Tab into the component lands on the active slot. Default active slot on mount is the trailing input (matches today).
-- ←/→ arrows move active among slots in order: gap → chip → gap → ... → trailing-input. **No wrap.** Edges stop.
-- On a focused gap slot, `Enter` opens an insert with an empty draft. Any printable key (single character, no `Ctrl`/`Meta`/`Alt` modifier) also opens an insert with that character as the initial draft (this matches the "I-beam cursor" mental model — typing at a focused cursor position inserts).
-- On a focused chip slot, `Enter` (or `F2`) opens edit; `Delete`/`Backspace` removes.
-- `Backspace` on the *empty trailing input* still removes the last chip (preserved from today's behavior).
+- ←/→ arrows move active among slots in order: gap → chip → gap → … → trailing-input. **No wrap.** Edges stop.
+- On a focused chip slot, `Enter` (or `F2`) opens edit; `Delete` removes (primary); `Backspace` also removes (secondary shortcut, retained because users currently use Backspace).
+- On a focused gap slot:
+  - `Enter` opens insert with an empty draft.
+  - Any *printable* key opens insert with that key as the initial draft, **only when** `event.key.length === 1`, no `Ctrl`/`Meta`/`Alt` modifier is held (Shift is allowed for capitals/punctuation), and `event.isComposing === false` (skip IME composition events).
+- `Backspace` on the *empty trailing input* still removes the last chip (preserved from today).
 - `Backspace` inside a non-empty edit/insert input edits text normally — never deletes the chip.
+- Focus return after `Delete`/`Backspace`-removes-chip: the gap slot at the deleted index, or trailing input if the list is now empty.
 
 ## Accessibility
 
 - Wrapper: `role="group"`, `aria-label` / `aria-labelledby` from props (today's behavior).
-- Chip-view: a non-focusable visual span. The × button inside is focusable as `<button aria-label="Remove <text>">`.
-- Chip-edit: `<input aria-label="Edit tag '<original>'">`.
-- Gap slot: focusable `<button aria-label="Insert tag at start">` (index 0), `"Insert tag before <next>"` (middle), or `"Insert tag at end"` (which is the trailing input; can keep its existing aria-label). A thin caret line renders on hover/focus.
-- Roving tabindex: exactly one slot in the list has `tabindex=0` at a time. All others are `tabindex=-1`. Active slot is tracked in state and follows arrow-key nav.
+- Inside the wrapper, a `<ul role="list">` (CSS-reset to flex row) holds the chip + gap slots. Each chip slot is a `<li role="listitem">` so screen readers announce a list with the correct item count. Gap slots are also `<li>` but with `role="presentation"` so they don't pollute the item count — they're nav-relevant, not content-relevant.
+- Chip slot (the `<li>`): focusable container (`tabindex` managed by roving), `aria-label="Tag: <text>"`. Owns Enter/Delete/Backspace handling. The × button inside is focusable as `<button aria-label="Remove <text>">`.
+- Chip-edit: replaces chip-view in the same `<li>`. Real DOM focus on the `<input aria-label="Edit tag '<original>'">` — not `aria-activedescendant`, because the input needs real keystroke focus.
+- Gap slot: focusable `<button>` styled as a 1–2px caret target. `aria-label`s:
+  - `"Insert tag at start"` (index 0, before any chip)
+  - `"Insert tag before <next>"` (middle, before chip `n`)
+  - The trailing input keeps the consumer's `aria-label` / `aria-labelledby` (today's behavior) — it is *both* the trailing input *and* the "insert at end" gap, so its single label needs to convey both. We rely on the consumer's "Header tags" / "Footer tags" label naming the whole field; the trailing input is the canonical entry point.
+- Gap slot caret rendering only appears on `:hover` or `[data-focused]` to keep idle UI quiet.
+- Roving tabindex: exactly one slot has `tabindex=0` at a time; all others `tabindex=-1`. Active slot is tracked in state. When the active slot is removed (chip deletion), focus moves per the rules above before the offending slot unmounts (use `flushSync` or move focus on the same render that prunes the slot).
+- Escape inside an edit/insert input calls `stopPropagation()` to prevent dismissing the parent dialog.
 
 ## Component contract (public API)
 
@@ -114,37 +135,64 @@ type TagInputProps = {
 
 Drop `react-aria-components`' `TagGroup`/`TagList`/`Tag`. Build a focus-managed list inside `TagInput.tsx`:
 
-- One `<div role="group">` wrapper with `onKeyDown` for arrow nav.
-- Children are a flat sequence of slot components: `<GapSlot>`, `<ChipView>` (or `<ChipEdit>` when editing that index), and the trailing `<input>` (same component as `<ChipEdit>` parameterized for insert mode).
-- One `activeSlot` state value tracks which slot has `tabindex=0`. `editing` and `inserting` are separate state values as defined above.
-- Width-growing input: CSS `field-sizing: content` with a `min-width: 8ch` fallback. Already widely supported in modern browsers; we ship without a polyfill.
+- `<div role="group">` wrapper carries the consumer's aria-label and the `onKeyDown` for arrow nav.
+- Inside: a `<ul role="list">` of slot `<li>`s — chips and gaps interleaved — plus the trailing `<input>` (the final "gap" rendered as an actual input).
+- `mode` discriminated union and `activeSlot` index live in `useReducer` or a small `useState` pair; transitions (`openEdit`, `openInsert`, `commit`, `cancel`, `remove`) go through one reducer-style helper for predictability.
+- All slot pointer interactions use `onPointerDown` (mouse + touch + pen) for the commit-before-open mechanism; `onClick` handlers only run after commit has settled.
+- Width-growing edit / insert input: CSS `field-sizing: content` with a fixed `width: 8ch` (and `min-width: 8ch`) fallback. Modern Chromium + Safari 18.4+ + Firefox 144+ get content-fit growth; older browsers see a fixed-ish input — acceptable graceful degradation, no polyfill.
 
-Why drop `TagGroup`: it's designed for read-only-or-removable chip rows. Editable chips interleaved with insertion slots don't fit its collection model, and its built-in keyboard handlers fight ours. The custom focus-management code is well-known and small (~150–200 lines of well-bounded logic).
+Why drop `TagGroup`: it's designed for read-only-or-removable chip rows. Editable chips interleaved with insertion slots don't fit its collection model, and its built-in keyboard handlers fight ours. The custom focus-management code is well-known but non-trivial — estimate 250–350 lines including the slot dispatch, the reducer, and the keyboard handler.
 
 ## Styling
 
 Keep using `TagInput.module.css`. New additions:
 
-- `.gap` — flex item with width 8px (12px on coarse pointers via `@media (pointer: coarse)`), cursor `text`. Caret renders via `::before` on `:hover` or `[data-focused]`.
-- `.chipEdit` — input styled to match `.tag` chrome so the chip doesn't visually jump when entering edit mode.
+- `.gap` — flex item with width 8px (12px on coarse pointers via `@media (pointer: coarse)`), cursor `text`. Caret renders via `::before` on `:hover` or `[data-focused]`. Button reset (no border, no background).
+- `.chipEdit` — input styled to match `.tag` chrome so the chip doesn't visually jump when entering edit mode. `field-sizing: content; min-width: 8ch;`. Long values: the wrapper is already `flex-wrap: wrap`, so an overgrowing edit input wraps to a new row rather than overflowing horizontally.
+- `.trailingHidden` — applied to the trailing input while edit/insert mode is active: `visibility: hidden; pointer-events: none;`. Preserves its space so the wrapper doesn't reflow.
 - All new colors/sizes use existing `--color-*` / `--space-*` / `--radius-*` tokens.
 
 ## Testing plan
 
 Tests live in `src/lib/ui/TagInput.test.tsx`. All 10 existing tests stay (they describe the still-valid public contract: append, blur-commit, comma-not-committing, trim, etc.). New tests:
 
+**Edit mode**
 1. Click chip enters edit mode with text pre-filled and selected.
 2. Edit + `Enter` commits the new value at the same index.
-3. Edit + `Escape` reverts.
+3. Edit + `Escape` reverts and does not bubble (assert outer key handler is *not* called).
 4. Empty edit commit removes the chip at that index.
-5. Edit + blur (clicking elsewhere) commits.
-6. × on a chip currently being edited removes the chip without committing the in-progress edit text.
-7. Click gap opens an input at that index; type + `Enter` inserts at that index.
-8. Empty insert commit is a no-op.
-9. Keyboard: Tab into list, arrow Right traverses gap → chip → gap, `Enter` on focused chip enters edit mode.
-10. Keyboard: `Delete` on focused chip removes it.
-11. Keyboard: printable key on focused gap opens insert with that character as the draft.
-12. Keyboard: `Backspace` on empty trailing input still removes last chip (preserve current behavior).
+5. Whitespace-only edit commit also removes (e.g., `"   "` → remove).
+6. Edit + blur to outside the wrapper commits.
+7. × on a chip currently being edited removes the chip without committing the in-progress edit text.
+8. Clicking another chip while editing commits the current edit then opens edit on the new chip.
+9. Pasting `"a\nb"` into an edit and committing yields a single chip `"a b"` (newline collapsed + trimmed).
+10. Non-empty edit commit is trimmed.
+
+**Insert mode**
+11. Click gap opens an input at that index; type + `Enter` inserts at that index.
+12. Empty insert commit is a no-op.
+13. Whitespace-only insert commit is a no-op.
+14. After a successful insert, active slot is the gap *after* the new chip (assert next `Enter` opens insert at index+1).
+15. `Escape` during insert discards the draft.
+
+**Keyboard navigation**
+16. Tab into list lands on the trailing input by default.
+17. Arrow Right from trailing input goes nowhere (no wrap). Arrow Left from leading gap goes nowhere.
+18. Arrow Left/Right traverses gap → chip → gap → trailing.
+19. `Enter` on focused chip enters edit mode.
+20. `Enter` on focused gap opens insert with empty draft.
+21. Printable key on focused gap opens insert with that character as the draft.
+22. Shift+letter on focused gap opens insert with capital letter (assert Shift permitted).
+23. `Delete` on focused chip removes it; `Backspace` on focused chip also removes (both shortcuts).
+24. After `Delete`, focus lands on the gap at the deleted index.
+25. `Backspace` on empty trailing input still removes last chip (preserve current behavior).
+26. `Backspace` inside a non-empty edit input edits text, does NOT remove the chip.
+
+**Accessibility**
+27. Wrapper exposes `role="group"` with the consumer's aria-label.
+28. List inside has `role="list"`; chip count matches `value.length` via `getAllByRole("listitem")`.
+29. Gap slots have aria-labels: `"Insert tag at start"`, `"Insert tag before <next>"`. Targeted by these labels throughout the insert tests.
+30. Roving tabindex: at idle, exactly one slot has `tabindex=0`; after arrow nav, the new slot is `tabindex=0` and the previous is `tabindex=-1`.
 
 Use `getByRole` selectors throughout. Factories not needed (chip text is just `string`).
 

--- a/docs/superpowers/specs/2026-05-12-tag-input-editing-design.md
+++ b/docs/superpowers/specs/2026-05-12-tag-input-editing-design.md
@@ -1,0 +1,154 @@
+# TagInput — inline editing & mid-list insertion
+
+## Problem
+
+`TagInput` in `src/lib/ui/TagInput.tsx` is a chip-input field used for header and footer tags on cards. Two pain points:
+
+1. **No editing.** To change a tag, the user must delete it and retype it whole. Worse: because the only delete shortcut from the keyboard is `Backspace` on an empty trailing input, editing the first of four chips means deleting the last three first.
+2. **No mid-list insertion.** New chips can only be appended at the end. There's no way to place the cursor between two existing chips.
+
+## Goals
+
+- Allow editing an existing chip in place.
+- Allow inserting a new chip at an arbitrary position in the list.
+- Preserve current accessibility (keyboard reachable, screen-reader friendly).
+- Keep `TagInput`'s public API unchanged — consumers (`CardEditor`) don't change.
+- Keep the component inside the design system (`src/lib/ui/`); continue using design-system tokens.
+
+## Non-goals
+
+- Drag-and-drop reordering of chips.
+- Multi-select / bulk operations on chips.
+- Suggestions, autocomplete, or chip validation.
+
+## Interaction matrix
+
+| | Mouse | Touch | Keyboard |
+|---|---|---|---|
+| Focus a chip | (hover only) | (tap on label enters edit; no "focus-only" state) | Tab into list, ←/→ between slots |
+| Edit a chip | Click on chip label | Tap on chip label | Active chip + `Enter` (or `F2`) |
+| Remove a chip | Click × | Tap × | Active chip + `Delete` or `Backspace` |
+| Insert between chips | Click in gap | Tap in gap (12px target) | Active gap slot + `Enter` or any printable key |
+| Append at end | Click trailing area | Tap trailing area | Active trailing input (default landing slot) |
+| Commit edit / insert | Click elsewhere (blur) | Tap elsewhere | `Enter` or `Tab` |
+| Cancel edit / insert | (none — blur commits) | (none — blur commits) | `Escape` |
+
+Why mouse/touch have no "focused but not editing" state: there's no useful action available in that state, and adding a two-step click-then-act feels heavier than necessary. Keyboard users need the intermediate state because navigation precedes activation.
+
+## Slot model
+
+The wrapper renders a flat sequence of *slots*. For `value = [A, B, C]`:
+
+```
+[gap 0] [chip A] [gap 1] [chip B] [gap 2] [chip C] [trailing-input]
+```
+
+- **Gap slot** — 1–2px visual, 8px hit target on fine pointers, 12px on coarse pointers (`@media (pointer: coarse)`). Cursor: `text`. On hover/focus, a thin caret line renders to confirm the target. Clicking sets `inserting = { at: i, draft: "" }`. Focusable for keyboard nav.
+- **Chip slot** — renders either *chip-view* (default) or *chip-edit* (when `editing.index === i`).
+  - Chip-view: a span with the label and the × remove button (today's design).
+  - Chip-edit: an `<input>` pre-filled with the chip text, selection-all on focus, plus the same × that removes the chip outright (× wins over commit).
+- **Trailing input** — visible only when no chip is being edited and no mid-list insert is active. Functions as an always-empty entry point for appending. Clicking it (or typing into it) appends to the end via the same commit rules as insertion. When the user is editing a chip or mid-list-inserting, the trailing input is hidden so the "one input at a time" rule holds; the edit/insert input replaces it visually.
+
+## Internal state
+
+```ts
+type Editing = { index: number; draft: string } | null;
+type Inserting = { at: number; draft: string } | null;
+```
+
+`editing` and `inserting` are mutually exclusive. Opening one commits or cancels the other first. We never render two inputs at the same time.
+
+## Edit-mode semantics
+
+- `Enter` commits the whole input string as the new chip value at `editing.index`. No splitting on Enter — this is the question the user flagged in 2A; the answer is "save whole".
+- Empty / whitespace commit → the chip at `editing.index` is removed.
+- Non-empty commit → `value[editing.index]` is updated.
+- `Escape` reverts and exits edit mode; focus returns to the chip-view.
+- Blur (click/tap elsewhere, `Tab`) → commits using the same rules as `Enter`.
+- × on a chip in edit mode → removes the chip; the in-progress edit text is discarded. Implemented by handling `mousedown` on × to short-circuit the blur-commit.
+- Clicking another chip or another gap while editing → commits the current edit, then opens the new editor.
+
+## Insert-mode semantics
+
+Same as edit-mode except:
+
+- Empty / whitespace commit → no-op (no chip created). This differs from edit-mode because there's no existing chip to delete.
+- After a successful commit, active slot moves to the gap *after* the newly inserted chip so the user can keep inserting at adjacent positions.
+- `Escape` discards the draft.
+
+## Keyboard navigation
+
+- Tab into the component lands on the active slot. Default active slot on mount is the trailing input (matches today).
+- ←/→ arrows move active among slots in order: gap → chip → gap → ... → trailing-input. **No wrap.** Edges stop.
+- On a focused gap slot, `Enter` opens an insert with an empty draft. Any printable key (single character, no `Ctrl`/`Meta`/`Alt` modifier) also opens an insert with that character as the initial draft (this matches the "I-beam cursor" mental model — typing at a focused cursor position inserts).
+- On a focused chip slot, `Enter` (or `F2`) opens edit; `Delete`/`Backspace` removes.
+- `Backspace` on the *empty trailing input* still removes the last chip (preserved from today's behavior).
+- `Backspace` inside a non-empty edit/insert input edits text normally — never deletes the chip.
+
+## Accessibility
+
+- Wrapper: `role="group"`, `aria-label` / `aria-labelledby` from props (today's behavior).
+- Chip-view: a non-focusable visual span. The × button inside is focusable as `<button aria-label="Remove <text>">`.
+- Chip-edit: `<input aria-label="Edit tag '<original>'">`.
+- Gap slot: focusable `<button aria-label="Insert tag at start">` (index 0), `"Insert tag before <next>"` (middle), or `"Insert tag at end"` (which is the trailing input; can keep its existing aria-label). A thin caret line renders on hover/focus.
+- Roving tabindex: exactly one slot in the list has `tabindex=0` at a time. All others are `tabindex=-1`. Active slot is tracked in state and follows arrow-key nav.
+
+## Component contract (public API)
+
+Unchanged:
+
+```ts
+type TagInputProps = {
+  id?: string;
+  className?: string;
+  value: string[];
+  onChange: (next: string[]) => void;
+  placeholder?: string;
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
+  "aria-describedby"?: string;
+};
+```
+
+## Implementation approach
+
+Drop `react-aria-components`' `TagGroup`/`TagList`/`Tag`. Build a focus-managed list inside `TagInput.tsx`:
+
+- One `<div role="group">` wrapper with `onKeyDown` for arrow nav.
+- Children are a flat sequence of slot components: `<GapSlot>`, `<ChipView>` (or `<ChipEdit>` when editing that index), and the trailing `<input>` (same component as `<ChipEdit>` parameterized for insert mode).
+- One `activeSlot` state value tracks which slot has `tabindex=0`. `editing` and `inserting` are separate state values as defined above.
+- Width-growing input: CSS `field-sizing: content` with a `min-width: 8ch` fallback. Already widely supported in modern browsers; we ship without a polyfill.
+
+Why drop `TagGroup`: it's designed for read-only-or-removable chip rows. Editable chips interleaved with insertion slots don't fit its collection model, and its built-in keyboard handlers fight ours. The custom focus-management code is well-known and small (~150–200 lines of well-bounded logic).
+
+## Styling
+
+Keep using `TagInput.module.css`. New additions:
+
+- `.gap` — flex item with width 8px (12px on coarse pointers via `@media (pointer: coarse)`), cursor `text`. Caret renders via `::before` on `:hover` or `[data-focused]`.
+- `.chipEdit` — input styled to match `.tag` chrome so the chip doesn't visually jump when entering edit mode.
+- All new colors/sizes use existing `--color-*` / `--space-*` / `--radius-*` tokens.
+
+## Testing plan
+
+Tests live in `src/lib/ui/TagInput.test.tsx`. All 10 existing tests stay (they describe the still-valid public contract: append, blur-commit, comma-not-committing, trim, etc.). New tests:
+
+1. Click chip enters edit mode with text pre-filled and selected.
+2. Edit + `Enter` commits the new value at the same index.
+3. Edit + `Escape` reverts.
+4. Empty edit commit removes the chip at that index.
+5. Edit + blur (clicking elsewhere) commits.
+6. × on a chip currently being edited removes the chip without committing the in-progress edit text.
+7. Click gap opens an input at that index; type + `Enter` inserts at that index.
+8. Empty insert commit is a no-op.
+9. Keyboard: Tab into list, arrow Right traverses gap → chip → gap, `Enter` on focused chip enters edit mode.
+10. Keyboard: `Delete` on focused chip removes it.
+11. Keyboard: printable key on focused gap opens insert with that character as the draft.
+12. Keyboard: `Backspace` on empty trailing input still removes last chip (preserve current behavior).
+
+Use `getByRole` selectors throughout. Factories not needed (chip text is just `string`).
+
+## Out-of-scope follow-ups
+
+- Drag-and-drop reorder. If desired later, the slot model already gives us slot indices; reorder is a state mutation, not a structural change.
+- Touch long-press to reveal a remove confirmation for nervous mobile users. Today's × tap target is sufficient.

--- a/src/lib/ui/README.md
+++ b/src/lib/ui/README.md
@@ -12,7 +12,7 @@ Thin wrappers around `react-aria-components` (and a couple of native elements) t
 | `Input` | A single-line text field. |
 | `Link` | An `<a>` styled with the accent color and an underline. Use for inline external links; in-app navigation goes through TanStack Router's `<Link>`. |
 | `Textarea` | A multi-line text field. |
-| `TagInput` | A controlled chip-input field. Users type freeform text + Enter to commit chips; `×` per chip removes them. |
+| `TagInput` | A controlled chip-input field. Click a chip to edit in place; click between chips to insert; `×` removes. Full keyboard nav via ←/→ and Enter/Delete. |
 | `Switch` | An on/off toggle with a track + thumb. Children are the label. |
 | `ToggleButton` | A toggleable button (alone or inside a `ToggleButtonGroup`). |
 | `ToggleButtonGroup` | A segmented selector — wraps `ToggleButton` children. |

--- a/src/lib/ui/TagInput.module.css
+++ b/src/lib/ui/TagInput.module.css
@@ -16,15 +16,11 @@
   outline-offset: 2px;
 }
 
-.group {
-  display: contents;
-}
-
 .list {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--space-2);
+  display: contents;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 .tag {
@@ -39,6 +35,7 @@
   font-size: var(--fs-sm);
   line-height: 1.6;
   outline: none;
+  cursor: text;
 }
 
 .tag[data-focused] {
@@ -75,7 +72,48 @@
   outline-offset: 1px;
 }
 
-.input {
+.gap {
+  display: inline-flex;
+  align-items: stretch;
+  position: relative;
+  width: 0;
+}
+
+.gapButton {
+  position: absolute;
+  inset-block: -2px;
+  inset-inline: -4px;
+  width: 8px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: text;
+}
+
+@media (pointer: coarse) {
+  .gapButton {
+    inset-inline: -6px;
+    width: 12px;
+  }
+}
+
+.gapButton:hover::before,
+.gapButton:focus-visible::before {
+  content: "";
+  position: absolute;
+  inset-block: 0;
+  left: 50%;
+  width: 1px;
+  background: var(--color-focus-ring);
+  transform: translateX(-0.5px);
+}
+
+.gapButton:focus-visible {
+  outline: none;
+}
+
+.input,
+.chipEdit {
   flex: 1;
   min-width: 8ch;
   border: 0;
@@ -86,4 +124,33 @@
   font: inherit;
   font-family: var(--font-body);
   font-size: var(--fs-md);
+}
+
+.chipEdit {
+  width: 8ch;
+  flex: 0 0 auto;
+  field-sizing: content;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-2);
+  font-size: var(--fs-sm);
+  line-height: 1.6;
+}
+
+.trailingHidden {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }

--- a/src/lib/ui/TagInput.module.css
+++ b/src/lib/ui/TagInput.module.css
@@ -157,13 +157,16 @@
 
 /* When the edit input lives inside a chip <li>, the <li> already provides
    the chip chrome — strip the input's own border/background/padding so the
-   element heights match the chip-view span and no layout shift occurs. */
+   element heights match the chip-view span and no layout shift occurs. Also
+   drop the min-width so the input matches the chip's text width instead of
+   widening the chip to 8ch on edit. */
 .tag > .chipEdit,
 .tag > .chipEdit:focus-visible {
   border: 0;
   background: transparent;
   padding: 0;
   outline: 0;
+  min-width: 0;
 }
 
 @supports not (field-sizing: content) {

--- a/src/lib/ui/TagInput.module.css
+++ b/src/lib/ui/TagInput.module.css
@@ -38,7 +38,8 @@
   cursor: text;
 }
 
-.tag:focus-visible {
+.tag:focus-visible,
+.tag:has(.chipEdit:focus-visible) {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 1px;
 }
@@ -159,9 +160,9 @@
    the chip chrome — strip the input's own border/background/padding so the
    element heights match the chip-view span and no layout shift occurs. Also
    drop the min-width so the input matches the chip's text width instead of
-   widening the chip to 8ch on edit. */
-.tag > .chipEdit,
-.tag > .chipEdit:focus-visible {
+   widening the chip to 8ch on edit. The focused chip ring is provided by
+   .tag:has(.chipEdit:focus-visible) above. */
+.tag > .chipEdit {
   border: 0;
   background: transparent;
   padding: 0;
@@ -174,6 +175,21 @@
     width: auto;
     min-width: 12ch;
     max-width: 100%;
+  }
+  /* In-chip edit input must NOT re-introduce the floor that the modern path
+     dropped, otherwise editing "fire" widens the chip to 12ch on Firefox <144. */
+  .tag > .chipEdit {
+    min-width: 0;
+    max-width: 100%;
+  }
+}
+
+/* In Windows High Contrast Mode, the stripped-chrome edit input has no
+   visible cue. Re-introduce an outline so the editing chip is identifiable. */
+@media (forced-colors: active) {
+  .tag > .chipEdit:focus-visible {
+    outline: 2px solid CanvasText;
+    outline-offset: 1px;
   }
 }
 

--- a/src/lib/ui/TagInput.module.css
+++ b/src/lib/ui/TagInput.module.css
@@ -140,7 +140,6 @@
 }
 
 .chipEdit {
-  width: 8ch;
   flex: 0 0 auto;
   field-sizing: content;
   padding: 0 var(--space-2);

--- a/src/lib/ui/TagInput.module.css
+++ b/src/lib/ui/TagInput.module.css
@@ -92,8 +92,8 @@
 
 @media (pointer: coarse) {
   .gapButton {
-    inset-inline: -6px;
-    width: 12px;
+    inset-inline: -12px;
+    width: 24px;
   }
 }
 
@@ -110,6 +110,13 @@
 
 .gapButton:focus-visible {
   outline: none;
+}
+
+@media (forced-colors: active) {
+  .gapButton:hover::before,
+  .gapButton:focus-visible::before {
+    background: CanvasText;
+  }
 }
 
 .input,
@@ -136,6 +143,19 @@
   background: var(--color-surface-2);
   font-size: var(--fs-sm);
   line-height: 1.6;
+}
+
+.chipEdit:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 1px;
+}
+
+@supports not (field-sizing: content) {
+  .chipEdit {
+    width: auto;
+    min-width: 12ch;
+    max-width: 100%;
+  }
 }
 
 .trailingHidden {

--- a/src/lib/ui/TagInput.module.css
+++ b/src/lib/ui/TagInput.module.css
@@ -76,14 +76,19 @@
   display: inline-flex;
   align-items: stretch;
   position: relative;
+}
+
+.gap:has(.gapButton) {
   width: 0;
 }
 
 .gapButton {
   position: absolute;
-  inset-block: -2px;
+  top: 50%;
   inset-inline: -4px;
   width: 8px;
+  height: calc(var(--fs-sm) * 1.6 + 2px);
+  transform: translateY(-50%);
   padding: 0;
   border: 0;
   background: transparent;
@@ -101,11 +106,12 @@
 .gapButton:focus-visible::before {
   content: "";
   position: absolute;
-  inset-block: 0;
+  inset-block: 2px;
   left: 50%;
-  width: 1px;
+  width: 2px;
   background: var(--color-focus-ring);
-  transform: translateX(-0.5px);
+  border-radius: 1px;
+  transform: translateX(-1px);
 }
 
 .gapButton:focus-visible {

--- a/src/lib/ui/TagInput.module.css
+++ b/src/lib/ui/TagInput.module.css
@@ -155,6 +155,17 @@
   outline-offset: 1px;
 }
 
+/* When the edit input lives inside a chip <li>, the <li> already provides
+   the chip chrome — strip the input's own border/background/padding so the
+   element heights match the chip-view span and no layout shift occurs. */
+.tag > .chipEdit,
+.tag > .chipEdit:focus-visible {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  outline: 0;
+}
+
 @supports not (field-sizing: content) {
   .chipEdit {
     width: auto;

--- a/src/lib/ui/TagInput.module.css
+++ b/src/lib/ui/TagInput.module.css
@@ -38,7 +38,7 @@
   cursor: text;
 }
 
-.tag[data-focused] {
+.tag:focus-visible {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 1px;
 }

--- a/src/lib/ui/TagInput.reducer.test.ts
+++ b/src/lib/ui/TagInput.reducer.test.ts
@@ -309,4 +309,90 @@ describe("tagInputReducer", () => {
     expect(moved.state.mode).toEqual(open.state.mode);
     expect(moved.state.activeSlot).toBe(0);
   });
+
+  test("commitAndOpenEdit out-of-bounds target falls back to idle", () => {
+    // edit chip 2, clear, click chip 2 (no longer exists post-removal)
+    const open = tagInputReducer(
+      initialState(VALUE),
+      {
+        type: "openEdit",
+        index: 2,
+        value: VALUE,
+      },
+      VALUE,
+    );
+    const typed = tagInputReducer(open.state, { type: "updateDraft", draft: "" }, VALUE);
+    const trans = tagInputReducer(
+      typed.state,
+      {
+        type: "commitAndOpenEdit",
+        index: 5,
+        value: VALUE,
+      },
+      VALUE,
+    );
+    expect(trans.state.mode).toEqual({ kind: "idle" });
+    expect(trans.nextValue).toEqual(["a", "b"]);
+  });
+
+  test("commitAndOpenEdit after update-outcome preserves target index", () => {
+    // edit chip 0, change to "A", click chip 2 — chip 2 unchanged
+    const open = tagInputReducer(
+      initialState(VALUE),
+      {
+        type: "openEdit",
+        index: 0,
+        value: VALUE,
+      },
+      VALUE,
+    );
+    const typed = tagInputReducer(open.state, { type: "updateDraft", draft: "A" }, VALUE);
+    const trans = tagInputReducer(
+      typed.state,
+      {
+        type: "commitAndOpenEdit",
+        index: 2,
+        value: VALUE,
+      },
+      VALUE,
+    );
+    expect(trans.nextValue).toEqual(["A", "b", "c"]);
+    expect(trans.state.mode).toEqual({
+      kind: "editing",
+      index: 2,
+      draft: "c",
+      original: "c",
+    });
+  });
+
+  test("commitAndOpenInsert after remove-outcome shifts target left", () => {
+    // edit chip 0, clear (remove), click gap 2 — should shift to gap 1
+    const open = tagInputReducer(
+      initialState(VALUE),
+      {
+        type: "openEdit",
+        index: 0,
+        value: VALUE,
+      },
+      VALUE,
+    );
+    const typed = tagInputReducer(open.state, { type: "updateDraft", draft: "" }, VALUE);
+    const trans = tagInputReducer(
+      typed.state,
+      {
+        type: "commitAndOpenInsert",
+        at: 2,
+      },
+      VALUE,
+    );
+    expect(trans.nextValue).toEqual(["b", "c"]);
+    expect(trans.state.mode).toEqual({ kind: "inserting", at: 1, draft: "" });
+  });
+
+  test("updateDraft while idle is a no-op", () => {
+    const initial = initialState(VALUE);
+    const result = tagInputReducer(initial, { type: "updateDraft", draft: "x" }, VALUE);
+    expect(result.state).toEqual(initial);
+    expect(result.nextValue).toBeUndefined();
+  });
 });

--- a/src/lib/ui/TagInput.reducer.test.ts
+++ b/src/lib/ui/TagInput.reducer.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, test } from "vitest";
+import { initialState, normalizeDraft, type State, tagInputReducer } from "./TagInput.reducer";
+
+const VALUE = ["a", "b", "c"];
+
+function idle(activeSlot = VALUE.length * 2): State {
+  return { mode: { kind: "idle" }, activeSlot };
+}
+
+describe("normalizeDraft", () => {
+  test("collapses newlines to spaces then trims", () => {
+    expect(normalizeDraft("  foo\nbar\r baz  ")).toBe("foo bar  baz");
+  });
+  test("trims pure whitespace to empty", () => {
+    expect(normalizeDraft("   ")).toBe("");
+  });
+});
+
+describe("tagInputReducer", () => {
+  test("openEdit captures original and moves activeSlot to chip", () => {
+    const { state } = tagInputReducer(
+      initialState(VALUE),
+      {
+        type: "openEdit",
+        index: 1,
+        value: VALUE,
+      },
+      VALUE,
+    );
+    expect(state.mode).toEqual({
+      kind: "editing",
+      index: 1,
+      draft: "b",
+      original: "b",
+    });
+    expect(state.activeSlot).toBe(3);
+  });
+
+  test("openInsert enters inserting at the gap with initialDraft", () => {
+    const { state } = tagInputReducer(
+      initialState(VALUE),
+      {
+        type: "openInsert",
+        at: 2,
+        initialDraft: "x",
+      },
+      VALUE,
+    );
+    expect(state.mode).toEqual({ kind: "inserting", at: 2, draft: "x" });
+    expect(state.activeSlot).toBe(4);
+  });
+
+  test("updateDraft mutates editing.draft", () => {
+    let result = tagInputReducer(
+      initialState(VALUE),
+      {
+        type: "openEdit",
+        index: 0,
+        value: VALUE,
+      },
+      VALUE,
+    );
+    result = tagInputReducer(result.state, { type: "updateDraft", draft: "A" }, VALUE);
+    expect(result.state.mode).toEqual({
+      kind: "editing",
+      index: 0,
+      draft: "A",
+      original: "a",
+    });
+  });
+
+  test("commit on non-empty edit updates value", () => {
+    const open = tagInputReducer(
+      initialState(VALUE),
+      {
+        type: "openEdit",
+        index: 1,
+        value: VALUE,
+      },
+      VALUE,
+    );
+    const typed = tagInputReducer(open.state, { type: "updateDraft", draft: "B" }, VALUE);
+    const committed = tagInputReducer(typed.state, { type: "commit" }, VALUE);
+    expect(committed.nextValue).toEqual(["a", "B", "c"]);
+    expect(committed.state).toEqual(idle(3));
+  });
+
+  test("commit on empty edit removes the chip and points active to the gap", () => {
+    const open = tagInputReducer(
+      initialState(VALUE),
+      {
+        type: "openEdit",
+        index: 1,
+        value: VALUE,
+      },
+      VALUE,
+    );
+    const typed = tagInputReducer(open.state, { type: "updateDraft", draft: "" }, VALUE);
+    const committed = tagInputReducer(typed.state, { type: "commit" }, VALUE);
+    expect(committed.nextValue).toEqual(["a", "c"]);
+    expect(committed.state).toEqual({ mode: { kind: "idle" }, activeSlot: 2 });
+  });
+
+  test("commit on whitespace-only edit removes the chip", () => {
+    const open = tagInputReducer(
+      initialState(VALUE),
+      {
+        type: "openEdit",
+        index: 0,
+        value: VALUE,
+      },
+      VALUE,
+    );
+    const typed = tagInputReducer(open.state, { type: "updateDraft", draft: "   " }, VALUE);
+    const committed = tagInputReducer(typed.state, { type: "commit" }, VALUE);
+    expect(committed.nextValue).toEqual(["b", "c"]);
+  });
+
+  test("commit on no-change edit is a noop with nextValue undefined", () => {
+    const open = tagInputReducer(
+      initialState(VALUE),
+      {
+        type: "openEdit",
+        index: 0,
+        value: VALUE,
+      },
+      VALUE,
+    );
+    const committed = tagInputReducer(open.state, { type: "commit" }, VALUE);
+    expect(committed.nextValue).toBeUndefined();
+    expect(committed.state).toEqual(idle(1));
+  });
+
+  test("commit on non-empty insert places value at index and advances active", () => {
+    const open = tagInputReducer(
+      initialState(VALUE),
+      {
+        type: "openInsert",
+        at: 1,
+        initialDraft: "X",
+      },
+      VALUE,
+    );
+    const committed = tagInputReducer(open.state, { type: "commit" }, VALUE);
+    expect(committed.nextValue).toEqual(["a", "X", "b", "c"]);
+    expect(committed.state).toEqual({ mode: { kind: "idle" }, activeSlot: 4 });
+  });
+
+  test("commit on empty insert is a noop", () => {
+    const open = tagInputReducer(
+      initialState(VALUE),
+      {
+        type: "openInsert",
+        at: 1,
+      },
+      VALUE,
+    );
+    const committed = tagInputReducer(open.state, { type: "commit" }, VALUE);
+    expect(committed.nextValue).toBeUndefined();
+    expect(committed.state).toEqual({ mode: { kind: "idle" }, activeSlot: 2 });
+  });
+
+  test("commitAndOpenEdit on empty-edit-removal adjusts target index left of removed", () => {
+    const open = tagInputReducer(
+      initialState(VALUE),
+      {
+        type: "openEdit",
+        index: 2,
+        value: VALUE,
+      },
+      VALUE,
+    );
+    const typed = tagInputReducer(open.state, { type: "updateDraft", draft: "" }, VALUE);
+    const trans = tagInputReducer(
+      typed.state,
+      {
+        type: "commitAndOpenEdit",
+        index: 0,
+        value: VALUE,
+      },
+      VALUE,
+    );
+    expect(trans.nextValue).toEqual(["a", "b"]);
+    expect(trans.state.mode).toEqual({
+      kind: "editing",
+      index: 0,
+      draft: "a",
+      original: "a",
+    });
+  });
+
+  test("commitAndOpenEdit on empty-edit-removal adjusts target index right of removed (shift -1)", () => {
+    const open = tagInputReducer(
+      initialState(VALUE),
+      {
+        type: "openEdit",
+        index: 0,
+        value: VALUE,
+      },
+      VALUE,
+    );
+    const typed = tagInputReducer(open.state, { type: "updateDraft", draft: "" }, VALUE);
+    const trans = tagInputReducer(
+      typed.state,
+      {
+        type: "commitAndOpenEdit",
+        index: 2,
+        value: VALUE,
+      },
+      VALUE,
+    );
+    expect(trans.nextValue).toEqual(["b", "c"]);
+    expect(trans.state.mode).toEqual({
+      kind: "editing",
+      index: 1,
+      draft: "c",
+      original: "c",
+    });
+  });
+
+  test("commitAndOpenInsert after successful insert shifts insert position right (+1)", () => {
+    const open = tagInputReducer(
+      initialState(VALUE),
+      {
+        type: "openInsert",
+        at: 1,
+        initialDraft: "X",
+      },
+      VALUE,
+    );
+    const trans = tagInputReducer(
+      open.state,
+      {
+        type: "commitAndOpenInsert",
+        at: 2,
+      },
+      VALUE,
+    );
+    expect(trans.nextValue).toEqual(["a", "X", "b", "c"]);
+    expect(trans.state.mode).toEqual({ kind: "inserting", at: 3, draft: "" });
+    expect(trans.state.activeSlot).toBe(6);
+  });
+
+  test("cancel from editing returns to idle with active on the chip slot", () => {
+    const open = tagInputReducer(
+      initialState(VALUE),
+      {
+        type: "openEdit",
+        index: 1,
+        value: VALUE,
+      },
+      VALUE,
+    );
+    const cancelled = tagInputReducer(open.state, { type: "cancel" }, VALUE);
+    expect(cancelled.nextValue).toBeUndefined();
+    expect(cancelled.state).toEqual(idle(3));
+  });
+
+  test("cancel from inserting returns to idle with active on the gap", () => {
+    const open = tagInputReducer(
+      initialState(VALUE),
+      {
+        type: "openInsert",
+        at: 1,
+      },
+      VALUE,
+    );
+    const cancelled = tagInputReducer(open.state, { type: "cancel" }, VALUE);
+    expect(cancelled.state).toEqual(idle(2));
+  });
+
+  test("removeChip removes index, moves active to gap at that index", () => {
+    const removed = tagInputReducer(
+      initialState(VALUE),
+      {
+        type: "removeChip",
+        index: 1,
+      },
+      VALUE,
+    );
+    expect(removed.nextValue).toEqual(["a", "c"]);
+    expect(removed.state).toEqual({ mode: { kind: "idle" }, activeSlot: 2 });
+  });
+
+  test("removeChip from a single-element value lands active on trailing input (slot 0)", () => {
+    const removed = tagInputReducer(
+      initialState(["a"]),
+      {
+        type: "removeChip",
+        index: 0,
+      },
+      ["a"],
+    );
+    expect(removed.nextValue).toEqual([]);
+    expect(removed.state).toEqual({ mode: { kind: "idle" }, activeSlot: 0 });
+  });
+
+  test("setActiveSlot only changes activeSlot, leaves mode untouched", () => {
+    const open = tagInputReducer(
+      initialState(VALUE),
+      {
+        type: "openEdit",
+        index: 1,
+        value: VALUE,
+      },
+      VALUE,
+    );
+    const moved = tagInputReducer(open.state, { type: "setActiveSlot", slot: 0 }, VALUE);
+    expect(moved.state.mode).toEqual(open.state.mode);
+    expect(moved.state.activeSlot).toBe(0);
+  });
+});

--- a/src/lib/ui/TagInput.reducer.ts
+++ b/src/lib/ui/TagInput.reducer.ts
@@ -1,0 +1,219 @@
+export type Mode =
+  | { readonly kind: "idle" }
+  | {
+      readonly kind: "editing";
+      readonly index: number;
+      readonly draft: string;
+      readonly original: string;
+    }
+  | { readonly kind: "inserting"; readonly at: number; readonly draft: string };
+
+export type State = {
+  readonly mode: Mode;
+  readonly activeSlot: number;
+};
+
+export type Action =
+  | { readonly type: "openEdit"; readonly index: number; readonly value: readonly string[] }
+  | { readonly type: "openInsert"; readonly at: number; readonly initialDraft?: string }
+  | { readonly type: "updateDraft"; readonly draft: string }
+  | { readonly type: "commit" }
+  | {
+      readonly type: "commitAndOpenEdit";
+      readonly index: number;
+      readonly value: readonly string[];
+    }
+  | {
+      readonly type: "commitAndOpenInsert";
+      readonly at: number;
+      readonly initialDraft?: string;
+    }
+  | { readonly type: "cancel" }
+  | { readonly type: "removeChip"; readonly index: number }
+  | { readonly type: "setActiveSlot"; readonly slot: number };
+
+export type Result = {
+  readonly state: State;
+  readonly nextValue?: string[];
+};
+
+export function initialState(value: readonly string[]): State {
+  return { mode: { kind: "idle" }, activeSlot: value.length * 2 };
+}
+
+export function normalizeDraft(draft: string): string {
+  return draft.replace(/[\n\r]/g, " ").trim();
+}
+
+type CommitOutcome =
+  | { kind: "noop"; activeSlot: number }
+  | { kind: "update"; value: string[]; activeSlot: number }
+  | { kind: "remove"; value: string[]; removedIndex: number; activeSlot: number }
+  | { kind: "insert"; value: string[]; insertedAt: number; activeSlot: number };
+
+function applyCommit(mode: Mode, value: readonly string[]): CommitOutcome {
+  if (mode.kind === "idle") {
+    return { kind: "noop", activeSlot: value.length * 2 };
+  }
+  const normalized = normalizeDraft(mode.draft);
+  if (mode.kind === "editing") {
+    if (normalized === "") {
+      const next = [...value.slice(0, mode.index), ...value.slice(mode.index + 1)];
+      return {
+        kind: "remove",
+        value: next,
+        removedIndex: mode.index,
+        activeSlot: next.length === 0 ? 0 : mode.index * 2,
+      };
+    }
+    if (normalized === value[mode.index]) {
+      return { kind: "noop", activeSlot: mode.index * 2 + 1 };
+    }
+    const next = [...value];
+    next[mode.index] = normalized;
+    return { kind: "update", value: next, activeSlot: mode.index * 2 + 1 };
+  }
+  if (normalized === "") {
+    return { kind: "noop", activeSlot: mode.at * 2 };
+  }
+  const next = [...value.slice(0, mode.at), normalized, ...value.slice(mode.at)];
+  return {
+    kind: "insert",
+    value: next,
+    insertedAt: mode.at,
+    activeSlot: mode.at * 2 + 2,
+  };
+}
+
+function adjustIndex(target: number, outcome: CommitOutcome): number {
+  if (outcome.kind === "remove") {
+    return target > outcome.removedIndex ? target - 1 : target;
+  }
+  if (outcome.kind === "insert") {
+    return target >= outcome.insertedAt ? target + 1 : target;
+  }
+  return target;
+}
+
+export function tagInputReducer(state: State, action: Action, value: readonly string[]): Result {
+  switch (action.type) {
+    case "openEdit": {
+      const v = action.value;
+      const original = v[action.index] ?? "";
+      return {
+        state: {
+          mode: {
+            kind: "editing",
+            index: action.index,
+            draft: original,
+            original,
+          },
+          activeSlot: action.index * 2 + 1,
+        },
+      };
+    }
+    case "openInsert": {
+      const draft = action.initialDraft ?? "";
+      return {
+        state: {
+          mode: { kind: "inserting", at: action.at, draft },
+          activeSlot: action.at * 2,
+        },
+      };
+    }
+    case "updateDraft": {
+      if (state.mode.kind === "editing") {
+        return {
+          state: { ...state, mode: { ...state.mode, draft: action.draft } },
+        };
+      }
+      if (state.mode.kind === "inserting") {
+        return {
+          state: { ...state, mode: { ...state.mode, draft: action.draft } },
+        };
+      }
+      return { state };
+    }
+    case "commit": {
+      const outcome = applyCommit(state.mode, value);
+      const nextState: State = {
+        mode: { kind: "idle" },
+        activeSlot: outcome.activeSlot,
+      };
+      return outcome.kind === "noop"
+        ? { state: nextState }
+        : { state: nextState, nextValue: outcome.value };
+    }
+    case "commitAndOpenEdit": {
+      const outcome = applyCommit(state.mode, value);
+      const postValue = outcome.kind === "noop" ? action.value : outcome.value;
+      const targetIndex = adjustIndex(action.index, outcome);
+      if (targetIndex < 0 || targetIndex >= postValue.length) {
+        const nextState: State = {
+          mode: { kind: "idle" },
+          activeSlot: outcome.activeSlot,
+        };
+        return outcome.kind === "noop"
+          ? { state: nextState }
+          : { state: nextState, nextValue: outcome.value };
+      }
+      const original = postValue[targetIndex] ?? "";
+      const nextState: State = {
+        mode: {
+          kind: "editing",
+          index: targetIndex,
+          draft: original,
+          original,
+        },
+        activeSlot: targetIndex * 2 + 1,
+      };
+      return outcome.kind === "noop"
+        ? { state: nextState }
+        : { state: nextState, nextValue: outcome.value };
+    }
+    case "commitAndOpenInsert": {
+      const outcome = applyCommit(state.mode, value);
+      const targetAt = adjustIndex(action.at, outcome);
+      const draft = action.initialDraft ?? "";
+      const nextState: State = {
+        mode: { kind: "inserting", at: targetAt, draft },
+        activeSlot: targetAt * 2,
+      };
+      return outcome.kind === "noop"
+        ? { state: nextState }
+        : { state: nextState, nextValue: outcome.value };
+    }
+    case "cancel": {
+      if (state.mode.kind === "editing") {
+        return {
+          state: {
+            mode: { kind: "idle" },
+            activeSlot: state.mode.index * 2 + 1,
+          },
+        };
+      }
+      if (state.mode.kind === "inserting") {
+        return {
+          state: {
+            mode: { kind: "idle" },
+            activeSlot: state.mode.at * 2,
+          },
+        };
+      }
+      return { state };
+    }
+    case "removeChip": {
+      const v = [...value.slice(0, action.index), ...value.slice(action.index + 1)];
+      return {
+        state: {
+          mode: { kind: "idle" },
+          activeSlot: v.length === 0 ? 0 : action.index * 2,
+        },
+        nextValue: v,
+      };
+    }
+    case "setActiveSlot": {
+      return { state: { ...state, activeSlot: action.slot } };
+    }
+  }
+}

--- a/src/lib/ui/TagInput.test.tsx
+++ b/src/lib/ui/TagInput.test.tsx
@@ -1,7 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { describe, expect, test, vi } from "vitest";
-import { render, screen } from "../../test/render";
+import { fireEvent, render, screen } from "../../test/render";
 import { TagInput } from "./TagInput";
 
 function Harness({ initial = [] as string[] }) {
@@ -470,5 +470,41 @@ describe("<TagInput>", () => {
     await userEvent.keyboard("{Escape}");
     expect(onOuterKey).not.toHaveBeenCalled();
     expect(trailing).toHaveValue("");
+  });
+
+  test("wrapper exposes role=group with the consumer's aria-label", () => {
+    render(<Harness initial={["a"]} />);
+    expect(screen.getByRole("group", { name: /footer tags/i })).toBeInTheDocument();
+  });
+
+  test("inner list has role=list; chip count matches value.length", () => {
+    render(<Harness initial={["a", "b", "c"]} />);
+    expect(screen.getByRole("list")).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+  });
+
+  test("gap slots have aria-labels: start / before <next>", () => {
+    render(<Harness initial={["fire", "ice"]} />);
+    expect(screen.getByRole("button", { name: /insert tag at start/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /insert tag before ice/i })).toBeInTheDocument();
+  });
+
+  test("roving tabindex: exactly one slot has tabindex=0 at idle and after nav", () => {
+    const { container } = render(<Harness initial={["a", "b"]} />);
+    const tabbable = () => container.querySelectorAll('[tabindex="0"]');
+    expect(tabbable()).toHaveLength(1);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    expect(tabbable()).toHaveLength(1);
+    expect(trailing).toHaveAttribute("tabindex", "0");
+    fireEvent.keyDown(screen.getByRole("group", { name: /footer tags/i }), {
+      key: "ArrowLeft",
+    });
+    expect(tabbable()).toHaveLength(1);
+  });
+
+  test("chip slot exposes aria-keyshortcuts for Enter and Delete", () => {
+    render(<Harness initial={["a"]} />);
+    expect(screen.getAllByRole("listitem")[0]).toHaveAttribute("aria-keyshortcuts", "Enter Delete");
   });
 });

--- a/src/lib/ui/TagInput.test.tsx
+++ b/src/lib/ui/TagInput.test.tsx
@@ -260,6 +260,17 @@ describe("<TagInput>", () => {
     expect(screen.getByRole("button", { name: /insert tag at start/i })).toHaveFocus();
   });
 
+  test("ArrowLeft inside non-empty trailing input moves the caret, does not navigate or commit", async () => {
+    render(<Harness initial={["fire"]} />);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i }) as HTMLInputElement;
+    trailing.focus();
+    await userEvent.type(trailing, "rare");
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(trailing).toHaveValue("rare");
+    expect(trailing).toHaveFocus();
+    expect(trailing.selectionStart).toBe(3);
+  });
+
   test("tabbing into the list lands on the trailing input by default", async () => {
     render(
       <>

--- a/src/lib/ui/TagInput.test.tsx
+++ b/src/lib/ui/TagInput.test.tsx
@@ -512,8 +512,11 @@ describe("<TagInput>", () => {
     expect(tabbable()).toHaveLength(1);
   });
 
-  test("chip slot exposes aria-keyshortcuts for Enter and Delete", () => {
+  test("chip slot exposes aria-keyshortcuts for Enter, F2, Delete, and Backspace", () => {
     render(<Harness initial={["a"]} />);
-    expect(screen.getAllByRole("listitem")[0]).toHaveAttribute("aria-keyshortcuts", "Enter Delete");
+    expect(screen.getAllByRole("listitem")[0]).toHaveAttribute(
+      "aria-keyshortcuts",
+      "Enter F2 Delete Backspace",
+    );
   });
 });

--- a/src/lib/ui/TagInput.test.tsx
+++ b/src/lib/ui/TagInput.test.tsx
@@ -519,4 +519,14 @@ describe("<TagInput>", () => {
       "Enter F2 Delete Backspace",
     );
   });
+
+  test("value=[] renders only the trailing input as the active slot", () => {
+    render(<Harness />);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    expect(trailing).toBeInTheDocument();
+    expect(trailing).toHaveAttribute("tabindex", "0");
+    // No chips, no gap buttons.
+    expect(screen.queryAllByRole("listitem")).toHaveLength(0);
+    expect(screen.queryAllByRole("button", { name: /insert tag/i })).toHaveLength(0);
+  });
 });

--- a/src/lib/ui/TagInput.test.tsx
+++ b/src/lib/ui/TagInput.test.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { render, screen } from "../../test/render";
 import { TagInput } from "./TagInput";
 
@@ -99,5 +99,148 @@ describe("<TagInput>", () => {
     await userEvent.type(input, "foo,");
     await userEvent.click(screen.getByRole("button", { name: "elsewhere" }));
     expect(screen.getByText("foo,")).toBeInTheDocument();
+  });
+
+  test("clicking a chip enters edit mode with text pre-filled and selected", async () => {
+    render(<Harness initial={["fire"]} />);
+    await userEvent.click(screen.getByText("fire"));
+    const input = screen.getByRole("textbox", { name: /edit tag 'fire'/i });
+    expect(input).toHaveFocus();
+    expect(input).toHaveValue("fire");
+    await userEvent.keyboard("ice");
+    expect(input).toHaveValue("ice");
+  });
+
+  test("editing + Enter commits the new value at the same index", async () => {
+    const Watcher = () => {
+      const [v, setV] = useState<string[]>(["fire", "ice"]);
+      return (
+        <>
+          <TagInput aria-label="footer tags" value={v} onChange={setV} />
+          <output>{v.join("|")}</output>
+        </>
+      );
+    };
+    render(<Watcher />);
+    await userEvent.click(screen.getByText("fire"));
+    const input = screen.getByRole("textbox", { name: /edit tag 'fire'/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "lightning{Enter}");
+    expect(screen.getByRole("status")).toHaveTextContent("lightning|ice");
+  });
+
+  test("edit + Escape reverts and does not bubble", async () => {
+    const onOuterKey = vi.fn();
+    render(
+      // biome-ignore lint/a11y/noStaticElementInteractions: test-only outer listener verifying event propagation
+      <div onKeyDown={onOuterKey}>
+        <Harness initial={["fire"]} />
+      </div>,
+    );
+    await userEvent.click(screen.getByText("fire"));
+    const input = screen.getByRole("textbox", { name: /edit tag 'fire'/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "ice");
+    await userEvent.keyboard("{Escape}");
+    expect(screen.getByText("fire")).toBeInTheDocument();
+    expect(screen.queryByText("ice")).not.toBeInTheDocument();
+    onOuterKey.mockClear();
+    await userEvent.click(screen.getByText("fire"));
+    await userEvent.keyboard("a");
+    expect(onOuterKey).toHaveBeenCalled();
+    onOuterKey.mockClear();
+    await userEvent.keyboard("{Escape}");
+    expect(onOuterKey).not.toHaveBeenCalled();
+  });
+
+  test("empty edit commit removes the chip and focuses the gap at that index", async () => {
+    render(<Harness initial={["fire", "ice", "wind"]} />);
+    await userEvent.click(screen.getByText("ice"));
+    const input = screen.getByRole("textbox", { name: /edit tag 'ice'/i });
+    await userEvent.clear(input);
+    await userEvent.keyboard("{Enter}");
+    expect(screen.queryByText("ice")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /insert tag before wind/i })).toHaveFocus();
+  });
+
+  test("whitespace-only edit commit removes the chip", async () => {
+    render(<Harness initial={["fire", "ice"]} />);
+    await userEvent.click(screen.getByText("fire"));
+    const input = screen.getByRole("textbox", { name: /edit tag 'fire'/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "   {Enter}");
+    expect(screen.queryByText("fire")).not.toBeInTheDocument();
+  });
+
+  test("edit + blur to outside the wrapper commits and does not restore focus", async () => {
+    render(
+      <>
+        <Harness initial={["fire"]} />
+        <button type="button">elsewhere</button>
+      </>,
+    );
+    await userEvent.click(screen.getByText("fire"));
+    const input = screen.getByRole("textbox", { name: /edit tag 'fire'/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "lightning");
+    const outsideBtn = screen.getByRole("button", { name: "elsewhere" });
+    await userEvent.click(outsideBtn);
+    expect(screen.getByText("lightning")).toBeInTheDocument();
+    expect(outsideBtn).toHaveFocus();
+  });
+
+  test("× on a chip in edit mode removes without committing edit text and focuses the gap", async () => {
+    render(<Harness initial={["fire", "ice"]} />);
+    await userEvent.click(screen.getByText("fire"));
+    const input = screen.getByRole("textbox", { name: /edit tag 'fire'/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "lightning");
+    await userEvent.click(screen.getByRole("button", { name: /remove fire/i }));
+    expect(screen.queryByText("fire")).not.toBeInTheDocument();
+    expect(screen.queryByText("lightning")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /insert tag at start/i })).toHaveFocus();
+  });
+
+  test("clicking another chip while editing commits then opens edit on the new chip", async () => {
+    render(<Harness initial={["fire", "ice"]} />);
+    await userEvent.click(screen.getByText("fire"));
+    const input = screen.getByRole("textbox", { name: /edit tag 'fire'/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "lightning");
+    await userEvent.click(screen.getByText("ice"));
+    expect(screen.getByText("lightning")).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: /edit tag 'ice'/i })).toHaveFocus();
+  });
+
+  test("clicking a gap while editing commits the edit then opens insert at that gap", async () => {
+    render(<Harness initial={["fire", "ice"]} />);
+    await userEvent.click(screen.getByText("fire"));
+    const editInput = screen.getByRole("textbox", { name: /edit tag 'fire'/i });
+    await userEvent.clear(editInput);
+    await userEvent.type(editInput, "lightning");
+    await userEvent.click(screen.getByRole("button", { name: /insert tag before ice/i }));
+    expect(screen.getByText("lightning")).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: /insert tag before ice/i })).toHaveFocus();
+  });
+
+  test("pasting 'a\\nb' into an edit and committing yields a single chip 'a b'", async () => {
+    render(<Harness initial={["x"]} />);
+    await userEvent.click(screen.getByText("x"));
+    const input = screen.getByRole("textbox", { name: /edit tag 'x'/i });
+    await userEvent.clear(input);
+    input.focus();
+    await userEvent.paste("a\nb");
+    await userEvent.keyboard("{Enter}");
+    expect(screen.getByText("a b")).toBeInTheDocument();
+    expect(screen.queryByText("a\nb")).not.toBeInTheDocument();
+  });
+
+  test("non-empty edit commit is trimmed", async () => {
+    render(<Harness initial={["x"]} />);
+    await userEvent.click(screen.getByText("x"));
+    const input = screen.getByRole("textbox", { name: /edit tag 'x'/i });
+    await userEvent.clear(input);
+    await userEvent.type(input, "   trimmed   {Enter}");
+    expect(screen.getByText("trimmed")).toBeInTheDocument();
   });
 });

--- a/src/lib/ui/TagInput.test.tsx
+++ b/src/lib/ui/TagInput.test.tsx
@@ -243,4 +243,126 @@ describe("<TagInput>", () => {
     await userEvent.type(input, "   trimmed   {Enter}");
     expect(screen.getByText("trimmed")).toBeInTheDocument();
   });
+
+  test("arrow keys traverse slots in order: gap → chip → gap → trailing", async () => {
+    render(<Harness initial={["fire", "ice"]} />);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(screen.getAllByRole("listitem")[1]).toHaveFocus();
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(screen.getByRole("button", { name: /insert tag before ice/i })).toHaveFocus();
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(screen.getAllByRole("listitem")[0]).toHaveFocus();
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(screen.getByRole("button", { name: /insert tag at start/i })).toHaveFocus();
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(screen.getByRole("button", { name: /insert tag at start/i })).toHaveFocus();
+  });
+
+  test("tabbing into the list lands on the trailing input by default", async () => {
+    render(
+      <>
+        <button type="button">before</button>
+        <Harness initial={["fire"]} />
+      </>,
+    );
+    screen.getByRole("button", { name: "before" }).focus();
+    await userEvent.tab();
+    expect(screen.getByRole("textbox", { name: /footer tags/i })).toHaveFocus();
+  });
+
+  test("Arrow Right from trailing goes nowhere; Arrow Left from leading gap goes nowhere", async () => {
+    render(<Harness initial={["a"]} />);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    await userEvent.keyboard("{ArrowRight}");
+    expect(trailing).toHaveFocus();
+    await userEvent.keyboard("{ArrowLeft}{ArrowLeft}{ArrowLeft}");
+    expect(screen.getByRole("button", { name: /insert tag at start/i })).toHaveFocus();
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(screen.getByRole("button", { name: /insert tag at start/i })).toHaveFocus();
+  });
+
+  test("Enter on a focused chip enters edit mode", async () => {
+    render(<Harness initial={["fire"]} />);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    await userEvent.keyboard("{ArrowLeft}");
+    await userEvent.keyboard("{Enter}");
+    expect(screen.getByRole("textbox", { name: /edit tag 'fire'/i })).toHaveFocus();
+  });
+
+  test("Enter on a focused gap opens insert with empty draft", async () => {
+    render(<Harness initial={["fire"]} />);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    await userEvent.keyboard("{ArrowLeft}{ArrowLeft}");
+    await userEvent.keyboard("{Enter}");
+    const insertInput = screen.getByRole("textbox", { name: /insert tag at start/i });
+    expect(insertInput).toHaveFocus();
+    expect(insertInput).toHaveValue("");
+  });
+
+  test("printable key on focused gap opens insert with that key as initial draft", async () => {
+    render(<Harness initial={["fire"]} />);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    await userEvent.keyboard("{ArrowLeft}{ArrowLeft}");
+    await userEvent.keyboard("x");
+    const insertInput = screen.getByRole("textbox", { name: /insert tag at start/i });
+    expect(insertInput).toHaveValue("x");
+    expect(insertInput).toHaveFocus();
+  });
+
+  test("Shift+letter on focused gap opens insert with capital letter", async () => {
+    render(<Harness initial={["fire"]} />);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    await userEvent.keyboard("{ArrowLeft}{ArrowLeft}");
+    await userEvent.keyboard("X");
+    const insertInput = screen.getByRole("textbox", { name: /insert tag at start/i });
+    expect(insertInput).toHaveValue("X");
+  });
+
+  test("Delete on focused chip removes it; Backspace also removes", async () => {
+    render(<Harness initial={["fire", "ice"]} />);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    await userEvent.keyboard("{ArrowLeft}");
+    await userEvent.keyboard("{Delete}");
+    expect(screen.queryByText("ice")).not.toBeInTheDocument();
+    expect(screen.getByText("fire")).toBeInTheDocument();
+    await userEvent.keyboard("{ArrowLeft}");
+    await userEvent.keyboard("{ArrowRight}");
+    await userEvent.keyboard("{Backspace}");
+    expect(screen.queryByText("fire")).not.toBeInTheDocument();
+  });
+
+  test("after Delete removes a chip, focus lands on the gap at the deleted index", async () => {
+    render(<Harness initial={["fire", "ice", "wind"]} />);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    await userEvent.keyboard("{ArrowLeft}{ArrowLeft}{ArrowLeft}");
+    await userEvent.keyboard("{Delete}");
+    expect(screen.getByRole("button", { name: /insert tag before wind/i })).toHaveFocus();
+  });
+
+  test("Backspace on empty trailing input removes last chip; focus stays on trailing", async () => {
+    render(<Harness initial={["fire", "ice"]} />);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    await userEvent.keyboard("{Backspace}");
+    expect(screen.queryByText("ice")).not.toBeInTheDocument();
+    expect(trailing).toHaveFocus();
+  });
+
+  test("Backspace inside non-empty edit input edits text, does not remove chip", async () => {
+    render(<Harness initial={["fire", "ice"]} />);
+    await userEvent.click(screen.getByText("fire"));
+    const input = screen.getByRole("textbox", { name: /edit tag 'fire'/i });
+    await userEvent.keyboard("{End}{Backspace}");
+    expect(input).toHaveValue("fir");
+    expect(screen.getByText("ice")).toBeInTheDocument();
+  });
 });

--- a/src/lib/ui/TagInput.test.tsx
+++ b/src/lib/ui/TagInput.test.tsx
@@ -376,4 +376,93 @@ describe("<TagInput>", () => {
     expect(input).toHaveValue("fir");
     expect(screen.getByText("ice")).toBeInTheDocument();
   });
+
+  test("clicking a gap opens an input at that index; typing + Enter inserts at that index", async () => {
+    const Watcher = () => {
+      const [v, setV] = useState<string[]>(["a", "c"]);
+      return (
+        <>
+          <TagInput aria-label="footer tags" value={v} onChange={setV} />
+          <output>{v.join("|")}</output>
+        </>
+      );
+    };
+    render(<Watcher />);
+    await userEvent.click(screen.getByRole("button", { name: /insert tag before c/i }));
+    const insertInput = screen.getByRole("textbox", { name: /insert tag before c/i });
+    await userEvent.type(insertInput, "b{Enter}");
+    expect(screen.getByRole("status")).toHaveTextContent("a|b|c");
+  });
+
+  test("empty insert commit is a no-op", async () => {
+    const Watcher = () => {
+      const [v, setV] = useState<string[]>(["a", "c"]);
+      return (
+        <>
+          <TagInput aria-label="footer tags" value={v} onChange={setV} />
+          <output>{v.join("|")}</output>
+        </>
+      );
+    };
+    render(<Watcher />);
+    await userEvent.click(screen.getByRole("button", { name: /insert tag before c/i }));
+    await userEvent.keyboard("{Enter}");
+    expect(screen.getByRole("status")).toHaveTextContent("a|c");
+  });
+
+  test("whitespace-only insert commit is a no-op", async () => {
+    const Watcher = () => {
+      const [v, setV] = useState<string[]>(["a", "c"]);
+      return (
+        <>
+          <TagInput aria-label="footer tags" value={v} onChange={setV} />
+          <output>{v.join("|")}</output>
+        </>
+      );
+    };
+    render(<Watcher />);
+    await userEvent.click(screen.getByRole("button", { name: /insert tag before c/i }));
+    await userEvent.keyboard("   {Enter}");
+    expect(screen.getByRole("status")).toHaveTextContent("a|c");
+  });
+
+  test("after a successful insert at gap N, the next insert lands at N+1", async () => {
+    const Watcher = () => {
+      const [v, setV] = useState<string[]>(["a", "d"]);
+      return (
+        <>
+          <TagInput aria-label="footer tags" value={v} onChange={setV} />
+          <output>{v.join("|")}</output>
+        </>
+      );
+    };
+    render(<Watcher />);
+    await userEvent.click(screen.getByRole("button", { name: /insert tag before d/i }));
+    await userEvent.type(screen.getByRole("textbox", { name: /insert tag before d/i }), "b{Enter}");
+    expect(screen.getByRole("status")).toHaveTextContent("a|b|d");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.type(screen.getByRole("textbox", { name: /insert tag before d/i }), "c{Enter}");
+    expect(screen.getByRole("status")).toHaveTextContent("a|b|c|d");
+  });
+
+  test("Escape during insert discards draft (mid-list and trailing, empty and non-empty)", async () => {
+    const onOuterKey = vi.fn();
+    render(
+      // biome-ignore lint/a11y/noStaticElementInteractions: test-only outer listener verifying event propagation
+      <div onKeyDown={onOuterKey}>
+        <Harness initial={["a", "b"]} />
+      </div>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /insert tag before b/i }));
+    await userEvent.type(screen.getByRole("textbox", { name: /insert tag before b/i }), "x");
+    onOuterKey.mockClear();
+    await userEvent.keyboard("{Escape}");
+    expect(screen.queryByText("x")).not.toBeInTheDocument();
+    expect(onOuterKey).not.toHaveBeenCalled();
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    onOuterKey.mockClear();
+    await userEvent.keyboard("{Escape}");
+    expect(onOuterKey).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/ui/TagInput.test.tsx
+++ b/src/lib/ui/TagInput.test.tsx
@@ -304,6 +304,15 @@ describe("<TagInput>", () => {
     expect(screen.getByRole("textbox", { name: /edit tag 'fire'/i })).toHaveFocus();
   });
 
+  test("F2 on a focused chip enters edit mode", async () => {
+    render(<Harness initial={["fire"]} />);
+    const trailing = screen.getByRole("textbox", { name: /footer tags/i });
+    trailing.focus();
+    await userEvent.keyboard("{ArrowLeft}");
+    await userEvent.keyboard("{F2}");
+    expect(screen.getByRole("textbox", { name: /edit tag 'fire'/i })).toHaveFocus();
+  });
+
   test("Enter on a focused gap opens insert with empty draft", async () => {
     render(<Harness initial={["fire"]} />);
     const trailing = screen.getByRole("textbox", { name: /footer tags/i });

--- a/src/lib/ui/TagInput.test.tsx
+++ b/src/lib/ui/TagInput.test.tsx
@@ -464,5 +464,11 @@ describe("<TagInput>", () => {
     onOuterKey.mockClear();
     await userEvent.keyboard("{Escape}");
     expect(onOuterKey).not.toHaveBeenCalled();
+    // Non-empty trailing-input Escape: typed text is discarded.
+    await userEvent.type(trailing, "y");
+    onOuterKey.mockClear();
+    await userEvent.keyboard("{Escape}");
+    expect(onOuterKey).not.toHaveBeenCalled();
+    expect(trailing).toHaveValue("");
   });
 });

--- a/src/lib/ui/TagInput.tsx
+++ b/src/lib/ui/TagInput.tsx
@@ -89,6 +89,9 @@ export function TagInput({
     } else if (e.key === "Backspace" && trailingDraft === "" && value.length > 0) {
       e.preventDefault();
       dispatch({ type: "removeChip", index: value.length - 1 });
+    } else if (e.key === "Escape") {
+      e.stopPropagation();
+      setTrailingDraft("");
     }
   };
 

--- a/src/lib/ui/TagInput.tsx
+++ b/src/lib/ui/TagInput.tsx
@@ -1,6 +1,14 @@
-import { type KeyboardEvent, useState } from "react";
-import { Button, Tag, TagGroup, TagList } from "react-aria-components";
+import {
+  type ChangeEvent,
+  type KeyboardEvent,
+  type PointerEvent,
+  useCallback,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
 import styles from "./TagInput.module.css";
+import { type Action, initialState, type State, tagInputReducer } from "./TagInput.reducer";
 
 export type TagInputProps = {
   id?: string;
@@ -23,59 +31,153 @@ export function TagInput({
   "aria-labelledby": ariaLabelledBy,
   "aria-describedby": ariaDescribedBy,
 }: TagInputProps) {
-  const [draft, setDraft] = useState("");
+  const [state, dispatchRaw] = useReducer(
+    (s: State, a: Action) => tagInputReducer(s, a, value).state,
+    value,
+    initialState,
+  );
 
-  const commit = () => {
-    const trimmed = draft.trim();
+  const trailingInputRef = useRef<HTMLInputElement | null>(null);
+  const [trailingDraft, setTrailingDraft] = useState("");
+
+  const dispatch = useCallback(
+    (action: Action) => {
+      const result = tagInputReducer(state, action, value);
+      if (result.nextValue !== undefined) {
+        onChange(result.nextValue);
+      }
+      dispatchRaw(action);
+    },
+    [state, value, onChange],
+  );
+
+  const commitTrailing = useCallback(() => {
+    const trimmed = trailingDraft.replace(/[\n\r]/g, " ").trim();
     if (trimmed === "") return;
     onChange([...value, trimmed]);
-    setDraft("");
+    setTrailingDraft("");
+  }, [trailingDraft, value, onChange]);
+
+  const inserting = state.mode.kind === "inserting" ? state.mode : null;
+
+  const handleInsertChange = (e: ChangeEvent<HTMLInputElement>) => {
+    dispatch({ type: "updateDraft", draft: e.target.value });
   };
 
-  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+  const handleInsertKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
       e.preventDefault();
-      commit();
-    } else if (e.key === "Backspace" && draft === "" && value.length > 0) {
-      e.preventDefault();
-      onChange(value.slice(0, -1));
+      dispatch({ type: "commit" });
+    } else if (e.key === "Escape") {
+      e.stopPropagation();
+      dispatch({ type: "cancel" });
     }
   };
 
-  const items = value.map((v, i) => ({ id: `${i}-${v}`, value: v }));
+  const handleInsertBlur = () => {
+    dispatch({ type: "commit" });
+  };
+
+  const handleTrailingKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      commitTrailing();
+    } else if (e.key === "Backspace" && trailingDraft === "" && value.length > 0) {
+      e.preventDefault();
+      dispatch({ type: "removeChip", index: value.length - 1 });
+    }
+  };
+
+  const handleTrailingBlur = () => {
+    commitTrailing();
+  };
+
+  const handleGapPointerDown = (at: number) => (e: PointerEvent) => {
+    e.preventDefault();
+    commitTrailing();
+    dispatch({ type: "commitAndOpenInsert", at });
+  };
+
+  const handleRemoveClick = (index: number) => () => {
+    dispatch({ type: "removeChip", index });
+  };
+
+  const isInsertingAt = (at: number): boolean => inserting !== null && inserting.at === at;
 
   return (
-    <div className={[styles.wrapper, className].filter(Boolean).join(" ")}>
-      <TagGroup
-        aria-label="Tags"
-        onRemove={(keys) => {
-          const next = value.filter((_, i) => !keys.has(`${i}-${value[i]}`));
-          onChange(next);
-        }}
-        className={styles.group}
-      >
-        <TagList items={items} className={styles.list}>
-          {(item) => (
-            <Tag textValue={item.value} className={styles.tag}>
-              <span className={styles.tagText}>{item.value}</span>
-              <Button slot="remove" aria-label={`Remove ${item.value}`} className={styles.remove}>
+    // biome-ignore lint/a11y/useSemanticElements: <fieldset> would impose default form styling; the widget is not a form group
+    <div
+      className={[styles.wrapper, className].filter(Boolean).join(" ")}
+      role="group"
+      aria-label={ariaLabelledBy ? undefined : (ariaLabel ?? "Tags")}
+      aria-labelledby={ariaLabelledBy}
+      aria-describedby={ariaDescribedBy}
+    >
+      {/* biome-ignore lint/a11y/noRedundantRoles: explicit role="list" is required because display:contents strips ul semantics in WebKit */}
+      <ul role="list" className={styles.list}>
+        {value.flatMap((label, i) => {
+          const gapKey = `gap-${i}-${label}`;
+          const chipKey = `chip-${i}-${label}`;
+          const slotChildren = [
+            <li
+              key={gapKey}
+              role="presentation"
+              className={styles.gap}
+              aria-hidden={!isInsertingAt(i)}
+            >
+              {isInsertingAt(i) ? (
+                <input
+                  className={styles.chipEdit}
+                  // biome-ignore lint/a11y/noAutofocus: explicit focus is required when the gap input mounts
+                  autoFocus
+                  value={inserting?.draft ?? ""}
+                  onChange={handleInsertChange}
+                  onKeyDown={handleInsertKeyDown}
+                  onBlur={handleInsertBlur}
+                  aria-label={i === 0 ? "Insert tag at start" : `Insert tag before ${value[i]}`}
+                />
+              ) : (
+                <button
+                  type="button"
+                  className={styles.gapButton}
+                  tabIndex={-1}
+                  aria-label={i === 0 ? "Insert tag at start" : `Insert tag before ${value[i]}`}
+                  onPointerDown={handleGapPointerDown(i)}
+                />
+              )}
+            </li>,
+            // biome-ignore lint/a11y/noRedundantRoles: explicit role="listitem" pairs with the explicit ul role="list" above
+            <li key={chipKey} role="listitem" className={styles.tag}>
+              <span className={styles.tagText}>{label}</span>
+              <button
+                type="button"
+                slot="remove"
+                tabIndex={-1}
+                aria-label={`Remove ${label}`}
+                className={styles.remove}
+                onClick={handleRemoveClick(i)}
+              >
                 ×
-              </Button>
-            </Tag>
-          )}
-        </TagList>
-      </TagGroup>
+              </button>
+            </li>,
+          ];
+          return slotChildren;
+        })}
+      </ul>
       <input
+        ref={trailingInputRef}
         id={id}
         type="text"
         aria-label={ariaLabelledBy ? undefined : (ariaLabel ?? "Tags")}
         aria-labelledby={ariaLabelledBy}
         aria-describedby={ariaDescribedBy}
-        className={styles.input}
-        value={draft}
-        onChange={(e) => setDraft(e.target.value)}
-        onKeyDown={onKeyDown}
-        onBlur={commit}
+        className={[styles.input, inserting !== null ? styles.trailingHidden : ""]
+          .filter(Boolean)
+          .join(" ")}
+        value={trailingDraft}
+        onChange={(e) => setTrailingDraft(e.target.value)}
+        onKeyDown={handleTrailingKeyDown}
+        onBlur={handleTrailingBlur}
         placeholder={value.length === 0 ? placeholder : undefined}
       />
     </div>

--- a/src/lib/ui/TagInput.tsx
+++ b/src/lib/ui/TagInput.tsx
@@ -284,7 +284,7 @@ export function TagInput({
                 data-slot-index={i * 2 + 1}
                 tabIndex={state.activeSlot === i * 2 + 1 ? 0 : -1}
                 aria-label={`Tag: ${label}`}
-                aria-keyshortcuts="Enter Delete"
+                aria-keyshortcuts="Enter F2 Delete Backspace"
                 onPointerDown={handleChipPointerDown(i)}
                 onKeyDown={(e) => handleChipKeyDown(e, i)}
               >
@@ -319,6 +319,7 @@ export function TagInput({
         className={[styles.input, inserting !== null ? styles.trailingHidden : ""]
           .filter(Boolean)
           .join(" ")}
+        aria-hidden={inserting !== null}
         value={trailingDraft}
         onChange={(e) => setTrailingDraft(e.target.value)}
         onKeyDown={handleTrailingKeyDown}

--- a/src/lib/ui/TagInput.tsx
+++ b/src/lib/ui/TagInput.tsx
@@ -140,6 +140,8 @@ export function TagInput({
 
   const handleWrapperKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
     if (state.mode.kind !== "idle") return;
+    // Don't hijack caret navigation inside the trailing input when there's text to navigate.
+    if (e.target instanceof HTMLInputElement && e.target.value !== "") return;
     const active = state.activeSlot;
     if (e.key === "ArrowRight") {
       if (active < totalSlots - 1) {

--- a/src/lib/ui/TagInput.tsx
+++ b/src/lib/ui/TagInput.tsx
@@ -101,7 +101,8 @@ export function TagInput({
   };
 
   const handleChipPointerDown = (index: number) => (e: PointerEvent) => {
-    if ((e.target as HTMLElement).closest("button[aria-label^='Remove']")) return;
+    const t = e.target;
+    if (t instanceof Element && t.closest(`.${styles.remove}`)) return;
     e.preventDefault();
     if (state.mode.kind === "idle") commitTrailing();
     dispatch({ type: "commitAndOpenEdit", index, value });

--- a/src/lib/ui/TagInput.tsx
+++ b/src/lib/ui/TagInput.tsx
@@ -324,7 +324,11 @@ export function TagInput({
         aria-label={ariaLabelledBy ? undefined : (ariaLabel ?? "Tags")}
         aria-labelledby={ariaLabelledBy}
         aria-describedby={[ariaDescribedBy, hintId].filter(Boolean).join(" ") || undefined}
-        className={[styles.input, inserting !== null ? styles.trailingHidden : ""]
+        className={[
+          styles.input,
+          trailingDraft !== "" ? styles.chipEdit : "",
+          inserting !== null ? styles.trailingHidden : "",
+        ]
           .filter(Boolean)
           .join(" ")}
         aria-hidden={inserting !== null}

--- a/src/lib/ui/TagInput.tsx
+++ b/src/lib/ui/TagInput.tsx
@@ -3,6 +3,7 @@ import {
   type KeyboardEvent,
   type PointerEvent,
   useCallback,
+  useId,
   useLayoutEffect,
   useReducer,
   useRef,
@@ -41,6 +42,7 @@ export function TagInput({
   const [trailingDraft, setTrailingDraft] = useState("");
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const isFirstRender = useRef(true);
+  const hintId = useId();
 
   const dispatch = useCallback(
     (action: Action) => {
@@ -302,6 +304,9 @@ export function TagInput({
           return slotChildren;
         })}
       </ul>
+      <span id={hintId} className={styles.srOnly}>
+        Use the left arrow key to insert tags between existing tags.
+      </span>
       <input
         id={id}
         type="text"
@@ -310,7 +315,7 @@ export function TagInput({
         tabIndex={state.activeSlot === value.length * 2 ? 0 : -1}
         aria-label={ariaLabelledBy ? undefined : (ariaLabel ?? "Tags")}
         aria-labelledby={ariaLabelledBy}
-        aria-describedby={ariaDescribedBy}
+        aria-describedby={[ariaDescribedBy, hintId].filter(Boolean).join(" ") || undefined}
         className={[styles.input, inserting !== null ? styles.trailingHidden : ""]
           .filter(Boolean)
           .join(" ")}

--- a/src/lib/ui/TagInput.tsx
+++ b/src/lib/ui/TagInput.tsx
@@ -3,7 +3,9 @@ import {
   type KeyboardEvent,
   type PointerEvent,
   useCallback,
+  useLayoutEffect,
   useReducer,
+  useRef,
   useState,
 } from "react";
 import styles from "./TagInput.module.css";
@@ -37,6 +39,8 @@ export function TagInput({
   );
 
   const [trailingDraft, setTrailingDraft] = useState("");
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const isFirstRender = useRef(true);
 
   const dispatch = useCallback(
     (action: Action) => {
@@ -92,8 +96,15 @@ export function TagInput({
 
   const handleGapPointerDown = (at: number) => (e: PointerEvent) => {
     e.preventDefault();
-    commitTrailing();
+    if (state.mode.kind === "idle") commitTrailing();
     dispatch({ type: "commitAndOpenInsert", at });
+  };
+
+  const handleChipPointerDown = (index: number) => (e: PointerEvent) => {
+    if ((e.target as HTMLElement).closest("button[aria-label^='Remove']")) return;
+    e.preventDefault();
+    if (state.mode.kind === "idle") commitTrailing();
+    dispatch({ type: "commitAndOpenEdit", index, value });
   };
 
   const handleRemoveClick = (index: number) => () => {
@@ -102,9 +113,27 @@ export function TagInput({
 
   const isInsertingAt = (at: number): boolean => inserting !== null && inserting.at === at;
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: focus restore must also re-fire on mode/value.length transitions (e.g., cancel) where activeSlot may be unchanged
+  useLayoutEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    const wrapper = wrapperRef.current;
+    if (!wrapper) return;
+    const active = document.activeElement;
+    if (active && active !== document.body) return;
+    const slots = wrapper.querySelectorAll<HTMLElement>("[data-slot]");
+    const target = Array.from(slots).find(
+      (el) => Number(el.dataset.slotIndex) === state.activeSlot,
+    );
+    target?.focus();
+  }, [state.activeSlot, state.mode.kind, value.length]);
+
   return (
     // biome-ignore lint/a11y/useSemanticElements: <fieldset> would impose default form styling; the widget is not a form group
     <div
+      ref={wrapperRef}
       className={[styles.wrapper, className].filter(Boolean).join(" ")}
       role="group"
       aria-label={ariaLabelledBy ? undefined : (ariaLabel ?? "Tags")}
@@ -117,14 +146,11 @@ export function TagInput({
           const gapKey = `gap-${i}-${label}`;
           const chipKey = `chip-${i}-${label}`;
           const slotChildren = [
-            <li
-              key={gapKey}
-              role="presentation"
-              className={styles.gap}
-              aria-hidden={!isInsertingAt(i)}
-            >
+            <li key={gapKey} role="presentation" className={styles.gap}>
               {isInsertingAt(i) ? (
                 <input
+                  data-slot
+                  data-slot-index={i * 2}
                   className={styles.chipEdit}
                   // biome-ignore lint/a11y/noAutofocus: explicit focus is required when the gap input mounts
                   autoFocus
@@ -137,6 +163,8 @@ export function TagInput({
               ) : (
                 <button
                   type="button"
+                  data-slot
+                  data-slot-index={i * 2}
                   className={styles.gapButton}
                   tabIndex={-1}
                   aria-label={i === 0 ? "Insert tag at start" : `Insert tag before ${value[i]}`}
@@ -144,19 +172,79 @@ export function TagInput({
                 />
               )}
             </li>,
-            // biome-ignore lint/a11y/noRedundantRoles: explicit role="listitem" pairs with the explicit ul role="list" above
-            <li key={chipKey} role="listitem" className={styles.tag}>
-              <span className={styles.tagText}>{label}</span>
-              <button
-                type="button"
-                tabIndex={-1}
-                aria-label={`Remove ${label}`}
-                className={styles.remove}
-                onClick={handleRemoveClick(i)}
+            state.mode.kind === "editing" && state.mode.index === i ? (
+              // biome-ignore lint/a11y/noRedundantRoles: explicit role="listitem" pairs with the explicit ul role="list" above
+              <li key={chipKey} role="listitem" className={styles.tag}>
+                <input
+                  data-slot
+                  data-slot-index={i * 2 + 1}
+                  className={styles.chipEdit}
+                  // biome-ignore lint/a11y/noAutofocus: edit input must focus on open
+                  autoFocus
+                  value={state.mode.draft}
+                  onFocus={(e) => e.currentTarget.select()}
+                  onChange={(e) => dispatch({ type: "updateDraft", draft: e.target.value })}
+                  onPaste={(e) => {
+                    const text = e.clipboardData.getData("text");
+                    if (!/[\n\r]/.test(text)) return;
+                    e.preventDefault();
+                    const target = e.currentTarget;
+                    const start = target.selectionStart ?? target.value.length;
+                    const end = target.selectionEnd ?? target.value.length;
+                    const collapsed = text.replace(/[\n\r]+/g, " ");
+                    const next = target.value.slice(0, start) + collapsed + target.value.slice(end);
+                    dispatch({ type: "updateDraft", draft: next });
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      dispatch({ type: "commit" });
+                    } else if (e.key === "Escape") {
+                      e.stopPropagation();
+                      dispatch({ type: "cancel" });
+                    }
+                  }}
+                  onBlur={() => dispatch({ type: "commit" })}
+                  aria-label={`Edit tag '${state.mode.original}'`}
+                />
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  aria-label={`Remove ${state.mode.original}`}
+                  className={styles.remove}
+                  onPointerDown={(e) => {
+                    e.preventDefault();
+                    if (state.mode.kind === "editing") {
+                      dispatch({ type: "removeChip", index: state.mode.index });
+                    }
+                  }}
+                >
+                  ×
+                </button>
+              </li>
+            ) : (
+              <li
+                key={chipKey}
+                // biome-ignore lint/a11y/noRedundantRoles: explicit role="listitem" pairs with the explicit ul role="list" above
+                role="listitem"
+                className={styles.tag}
+                data-slot
+                data-slot-index={i * 2 + 1}
+                tabIndex={state.activeSlot === i * 2 + 1 ? 0 : -1}
+                onPointerDown={handleChipPointerDown(i)}
               >
-                ×
-              </button>
-            </li>,
+                <span className={styles.tagText}>{label}</span>
+                <button
+                  type="button"
+                  tabIndex={-1}
+                  aria-label={`Remove ${label}`}
+                  className={styles.remove}
+                  onClick={handleRemoveClick(i)}
+                >
+                  ×
+                </button>
+              </li>
+            ),
           ];
           return slotChildren;
         })}
@@ -164,6 +252,9 @@ export function TagInput({
       <input
         id={id}
         type="text"
+        data-slot
+        data-slot-index={value.length * 2}
+        tabIndex={state.activeSlot === value.length * 2 ? 0 : -1}
         aria-label={ariaLabelledBy ? undefined : (ariaLabel ?? "Tags")}
         aria-labelledby={ariaLabelledBy}
         aria-describedby={ariaDescribedBy}

--- a/src/lib/ui/TagInput.tsx
+++ b/src/lib/ui/TagInput.tsx
@@ -4,7 +4,6 @@ import {
   type PointerEvent,
   useCallback,
   useReducer,
-  useRef,
   useState,
 } from "react";
 import styles from "./TagInput.module.css";
@@ -37,7 +36,6 @@ export function TagInput({
     initialState,
   );
 
-  const trailingInputRef = useRef<HTMLInputElement | null>(null);
   const [trailingDraft, setTrailingDraft] = useState("");
 
   const dispatch = useCallback(
@@ -151,7 +149,6 @@ export function TagInput({
               <span className={styles.tagText}>{label}</span>
               <button
                 type="button"
-                slot="remove"
                 tabIndex={-1}
                 aria-label={`Remove ${label}`}
                 className={styles.remove}
@@ -165,7 +162,6 @@ export function TagInput({
         })}
       </ul>
       <input
-        ref={trailingInputRef}
         id={id}
         type="text"
         aria-label={ariaLabelledBy ? undefined : (ariaLabel ?? "Tags")}

--- a/src/lib/ui/TagInput.tsx
+++ b/src/lib/ui/TagInput.tsx
@@ -56,8 +56,10 @@ export function TagInput({
   const commitTrailing = useCallback(() => {
     const trimmed = trailingDraft.replace(/[\n\r]/g, " ").trim();
     if (trimmed === "") return;
-    onChange([...value, trimmed]);
+    const newValue = [...value, trimmed];
+    onChange(newValue);
     setTrailingDraft("");
+    dispatchRaw({ type: "setActiveSlot", slot: newValue.length * 2 });
   }, [trailingDraft, value, onChange]);
 
   const inserting = state.mode.kind === "inserting" ? state.mode : null;
@@ -112,6 +114,46 @@ export function TagInput({
     dispatch({ type: "removeChip", index });
   };
 
+  const handleChipKeyDown = (e: KeyboardEvent<HTMLLIElement>, index: number) => {
+    if (e.key === "Enter" || e.key === "F2") {
+      e.preventDefault();
+      dispatch({ type: "openEdit", index, value });
+    } else if (e.key === "Delete" || e.key === "Backspace") {
+      e.preventDefault();
+      dispatch({ type: "removeChip", index });
+    }
+  };
+
+  const handleGapKeyDown = (e: KeyboardEvent<HTMLButtonElement>, at: number) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      dispatch({ type: "openInsert", at });
+      return;
+    }
+    if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey && !e.nativeEvent.isComposing) {
+      e.preventDefault();
+      dispatch({ type: "openInsert", at, initialDraft: e.key });
+    }
+  };
+
+  const totalSlots = value.length * 2 + 1;
+
+  const handleWrapperKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (state.mode.kind !== "idle") return;
+    const active = state.activeSlot;
+    if (e.key === "ArrowRight") {
+      if (active < totalSlots - 1) {
+        e.preventDefault();
+        dispatch({ type: "setActiveSlot", slot: active + 1 });
+      }
+    } else if (e.key === "ArrowLeft") {
+      if (active > 0) {
+        e.preventDefault();
+        dispatch({ type: "setActiveSlot", slot: active - 1 });
+      }
+    }
+  };
+
   const isInsertingAt = (at: number): boolean => inserting !== null && inserting.at === at;
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: focus restore must also re-fire on mode/value.length transitions (e.g., cancel) where activeSlot may be unchanged
@@ -123,7 +165,7 @@ export function TagInput({
     const wrapper = wrapperRef.current;
     if (!wrapper) return;
     const active = document.activeElement;
-    if (active && active !== document.body) return;
+    if (active && active !== document.body && !wrapper.contains(active)) return;
     const slots = wrapper.querySelectorAll<HTMLElement>("[data-slot]");
     const target = Array.from(slots).find(
       (el) => Number(el.dataset.slotIndex) === state.activeSlot,
@@ -140,6 +182,7 @@ export function TagInput({
       aria-label={ariaLabelledBy ? undefined : (ariaLabel ?? "Tags")}
       aria-labelledby={ariaLabelledBy}
       aria-describedby={ariaDescribedBy}
+      onKeyDown={handleWrapperKeyDown}
     >
       {/* biome-ignore lint/a11y/noRedundantRoles: explicit role="list" is required because display:contents strips ul semantics in WebKit */}
       <ul role="list" className={styles.list}>
@@ -167,9 +210,10 @@ export function TagInput({
                   data-slot
                   data-slot-index={i * 2}
                   className={styles.gapButton}
-                  tabIndex={-1}
+                  tabIndex={state.activeSlot === i * 2 ? 0 : -1}
                   aria-label={i === 0 ? "Insert tag at start" : `Insert tag before ${value[i]}`}
                   onPointerDown={handleGapPointerDown(i)}
+                  onKeyDown={(e) => handleGapKeyDown(e, i)}
                 />
               )}
             </li>,
@@ -232,7 +276,10 @@ export function TagInput({
                 data-slot
                 data-slot-index={i * 2 + 1}
                 tabIndex={state.activeSlot === i * 2 + 1 ? 0 : -1}
+                aria-label={`Tag: ${label}`}
+                aria-keyshortcuts="Enter Delete"
                 onPointerDown={handleChipPointerDown(i)}
+                onKeyDown={(e) => handleChipKeyDown(e, i)}
               >
                 <span className={styles.tagText}>{label}</span>
                 <button

--- a/src/lib/ui/TagInput.tsx
+++ b/src/lib/ui/TagInput.tsx
@@ -39,11 +39,17 @@ export function TagInput({
     initialState,
   );
 
+  // Edit / insert drafts live in the reducer's mode (so commit transitions
+  // can read them). The trailing input's draft is local-only — keeping it
+  // outside the reducer means typing doesn't notify the parent via onChange.
   const [trailingDraft, setTrailingDraft] = useState("");
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const isFirstRender = useRef(true);
   const hintId = useId();
 
+  // We run the reducer twice per action: once here to extract nextValue (so
+  // we can call onChange immediately), once via dispatchRaw so React owns the
+  // state transition. The reducer is pure, so both runs produce the same state.
   const dispatch = useCallback(
     (action: Action) => {
       const result = tagInputReducer(state, action, value);
@@ -61,6 +67,8 @@ export function TagInput({
     const newValue = [...value, trimmed];
     onChange(newValue);
     setTrailingDraft("");
+    // setActiveSlot never produces nextValue, so we use dispatchRaw directly
+    // instead of dispatch — onChange was already fired above for the appended chip.
     dispatchRaw({ type: "setActiveSlot", slot: newValue.length * 2 });
   }, [trailingDraft, value, onChange]);
 


### PR DESCRIPTION
### Description

Rewrites `src/lib/ui/TagInput.tsx` to support two long-standing pain points:

1. **Inline editing.** Click any chip to edit it in place. `Enter` commits, `Escape` reverts, `×` removes. Empty/whitespace commit also removes. Previously you had to delete a chip and retype it whole — and if the chip wasn't last in the list, you had to delete everything after it first.
2. **Mid-list insertion.** Click between any two chips (a thin caret appears on hover) to insert a tag at that position. Previously you could only append at the end.

Public API (`TagInputProps`) is unchanged — `CardEditor` is not modified.

### Implementation

- Drops `react-aria-components`' `TagGroup` / `TagList` / `Tag` for this primitive — the editable + insertable surface didn't fit its collection model. The component is now a custom focus-managed list (~340 lines).
- Pure reducer in `TagInput.reducer.ts` owns `mode` (idle / editing / inserting) + `activeSlot`. 23 reducer unit tests cover state transitions and the index-adjustment math for cross-slot commits.
- Roving tabindex over a slot model: even indices are gap slots, odd indices are chips, the trailing input is the final slot. Tab into the widget lands on the trailing input by default; ←/→ navigates between slots; `Enter`/`F2` on a chip enters edit; `Delete`/`Backspace` on a chip removes; `Enter` or any printable key on a gap opens insert.
- `useLayoutEffect` for focus restoration after destructive transitions (chip removal, transition between editor and chip-view). Outside-blur commits but does not steal focus back.
- `onPointerDown` for cross-slot commit-before-open (touch-safe; sidesteps `blur → click` race).
- Spec covers `aria-describedby` hint for SR users (\"Use the left arrow key to insert tags between existing tags\"), `aria-keyshortcuts` on chips, `role=\"list\"` + `role=\"listitem\"` semantics, and unconditional Escape `stopPropagation()` so the parent `CardEditor` dialog never gets dismissed mid-edit.

Spec and plan committed alongside the code (`docs/superpowers/specs/2026-05-12-tag-input-editing-design.md`, `docs/superpowers/plans/2026-05-12-tag-input-editing.md`).

### Screenshots

- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?

Open a card and try the **Header tags** or **Footer tags** field. Worth verifying:

- Click a chip → it becomes editable with text selected. Enter commits, Escape reverts.
- While editing, press Escape → the chip reverts but **the card editor dialog does NOT close** (the original motivation for the unconditional `stopPropagation` rule).
- Edit a chip, clear it, press Enter → chip is removed.
- Hover between two chips → a thin caret appears. Click → an empty insert input opens at that position.
- Tab into the field; use ←/→ to move across chips and gaps. Press `Enter` on a chip (edit), `Delete` (remove), `F2` (also edit), printable key on a gap (insert with that character).
- Type something in the trailing input, then press ← → the caret moves *inside the input*; it does NOT navigate or commit (regression-tested).
- Resize to mobile width — gap hit target is 24px on coarse pointers.
- Try editing a chip whose value starts with \"Remove \" (regression-tested — the × detection no longer matches by aria-label prefix).

**Test coverage** (44 component tests + 23 reducer tests):
- All 10 original tests preserved (append, blur-commit, comma-not-committing, trim, etc.)
- Edit mode: click→edit, Enter/Escape/blur/×, chip→chip and gap→chip transitions, paste-newline collapse, trim, focus-return rules.
- Insert mode: click-gap-opens-input, empty/whitespace no-op, post-insert active slot, trailing-input Escape.
- Keyboard nav: arrow traversal with no-wrap, Tab landing, Enter/F2/Delete/Backspace on chip, printable key + Shift on gap, Backspace-on-empty-trailing.
- A11y: `role=\"group\"` + `role=\"list\"` + `role=\"listitem\"`, gap aria-labels, roving tabindex invariant, `aria-keyshortcuts`.
- Edge cases: `value=[]`, reducer no-op branches (out-of-bounds, update outcomes, idle updates).

### Additional Context

- **The component grew from ~85 lines to ~340.** Plan estimated 250–350; spec lays out the rationale for dropping `TagGroup`. The reducer (a separate file) is ~220 lines and has its own unit-test surface.
- **Two sources of truth for in-progress text.** Edit / insert drafts live in the reducer's `mode`; the trailing input has its own `useState` for `trailingDraft`. This is intentional and commented inline — keeping the trailing draft outside the reducer means typing doesn't notify the parent via `onChange` until commit.
- **The `dispatch` wrapper runs the reducer twice per action** (once to extract `nextValue` for `onChange`, once via React's `dispatchRaw` for state). Commented inline; both runs produce the same state because the reducer is pure.
- **CSS uses `field-sizing: content`** with a `width: auto; min-width: 12ch` fallback under `@supports not`. Firefox <144 / Safari <18.4 get the fallback. The in-chip edit case has its own `min-width: 0` carve-out in both paths so editing \"fire\" doesn't widen the chip.
- **Forced-colors mode** (Windows High Contrast) has explicit fallbacks for the gap caret and the in-chip edit input outline (`CanvasText`).
- **Two rounds of parallel review** were run on the spec, and two rounds on the implementation (a11y, architecture, test coverage, real-browser readiness). All real-issue feedback was incorporated; the corresponding commits are titled `fix(TagInput): ...` for traceability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)