### PR TITLE
feat(deck): kind filter and sort on deck view

### DIFF
--- a/docs/superpowers/plans/2026-05-13-deck-tabs-sort.md
+++ b/docs/superpowers/plans/2026-05-13-deck-tabs-sort.md
@@ -1,0 +1,1079 @@
+# Deck view kind filter & sort — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a kind filter (All / Items / Spells) and a sort dropdown (Last updated / Name) to the deck list at `/deck/$deckId`, with state in URL search params.
+
+**Architecture:** Two pure functions — `deckListing(cards, opts)` (filter + sort + counts) and `validateDeckSearch(raw)` (URL param coercion). `DeckView` reads search params via `useSearch`, runs cards through `deckListing`, and renders a toolbar with `ToggleButtonGroup` (filter) + `MenuTrigger` (sort). Selection writes back to URL via `navigate({ search: prev => ... })`.
+
+**Tech Stack:** React 18, TypeScript (strict, `noUncheckedIndexedAccess`), TanStack Router, react-aria-components, Vitest + RTL + `@testing-library/user-event`, MSW.
+
+**Spec:** [`docs/superpowers/specs/2026-05-13-deck-tabs-sort-design.md`](../specs/2026-05-13-deck-tabs-sort-design.md)
+
+**Conventions used in every task:**
+- TDD: write failing test → confirm red → minimal impl → confirm green → commit.
+- Tests live next to the module they cover (`foo.ts` + `foo.test.ts`).
+- Factories pass only fields the test asserts on (CLAUDE.md rule).
+- `getByRole` over text/class selectors.
+- Every commit ends with `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`.
+- After each task: `npm test -- --run` (full suite) **and** `npm run build` (typecheck) before committing — vitest doesn't enforce `noUncheckedIndexedAccess` (memory note).
+
+---
+
+## Task 1: `deckListing` helper — types, filter, sort, counts
+
+**Files:**
+- Create: `src/decks/deckListing.ts`
+- Create: `src/decks/deckListing.test.ts`
+
+- [ ] **Step 1: Write failing tests for the helper**
+
+Create `src/decks/deckListing.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { Card } from "../cards/types";
+import { deckListing } from "./deckListing";
+
+function card(overrides: Partial<Card> & Pick<Card, "id" | "kind" | "name" | "updatedAt">): Card {
+  return {
+    body: "",
+    source: "custom",
+    headerTags: [],
+    footerTags: [],
+    createdAt: overrides.updatedAt,
+    ...overrides,
+  } as Card;
+}
+
+describe("deckListing", () => {
+  it("returns counts for items, spells, and total across all kinds", () => {
+    const cards = [
+      card({ id: "1", kind: "item", name: "A", updatedAt: "2026-01-01T00:00:00.000Z" }),
+      card({ id: "2", kind: "item", name: "B", updatedAt: "2026-01-02T00:00:00.000Z" }),
+      card({ id: "3", kind: "spell", name: "C", updatedAt: "2026-01-03T00:00:00.000Z" }),
+      card({ id: "4", kind: "ability", name: "D", updatedAt: "2026-01-04T00:00:00.000Z" }),
+    ];
+    const { counts } = deckListing(cards, { kind: "all", sort: "updated" });
+    expect(counts).toEqual({ all: 4, item: 2, spell: 1 });
+  });
+
+  it("kind=all includes ability cards", () => {
+    const cards = [
+      card({ id: "1", kind: "item", name: "A", updatedAt: "2026-01-01T00:00:00.000Z" }),
+      card({ id: "2", kind: "ability", name: "B", updatedAt: "2026-01-02T00:00:00.000Z" }),
+    ];
+    const { cards: out } = deckListing(cards, { kind: "all", sort: "name" });
+    expect(out.map((c) => c.id)).toEqual(["1", "2"]);
+  });
+
+  it("kind=item excludes spells and abilities", () => {
+    const cards = [
+      card({ id: "1", kind: "item", name: "A", updatedAt: "2026-01-01T00:00:00.000Z" }),
+      card({ id: "2", kind: "spell", name: "B", updatedAt: "2026-01-02T00:00:00.000Z" }),
+      card({ id: "3", kind: "ability", name: "C", updatedAt: "2026-01-03T00:00:00.000Z" }),
+    ];
+    const { cards: out } = deckListing(cards, { kind: "item", sort: "name" });
+    expect(out.map((c) => c.id)).toEqual(["1"]);
+  });
+
+  it("kind=spell excludes items and abilities", () => {
+    const cards = [
+      card({ id: "1", kind: "item", name: "A", updatedAt: "2026-01-01T00:00:00.000Z" }),
+      card({ id: "2", kind: "spell", name: "B", updatedAt: "2026-01-02T00:00:00.000Z" }),
+      card({ id: "3", kind: "ability", name: "C", updatedAt: "2026-01-03T00:00:00.000Z" }),
+    ];
+    const { cards: out } = deckListing(cards, { kind: "spell", sort: "name" });
+    expect(out.map((c) => c.id)).toEqual(["2"]);
+  });
+
+  it("sort=updated orders newest first by updatedAt", () => {
+    const cards = [
+      card({ id: "1", kind: "item", name: "A", updatedAt: "2026-01-01T00:00:00.000Z" }),
+      card({ id: "2", kind: "item", name: "B", updatedAt: "2026-03-01T00:00:00.000Z" }),
+      card({ id: "3", kind: "item", name: "C", updatedAt: "2026-02-01T00:00:00.000Z" }),
+    ];
+    const { cards: out } = deckListing(cards, { kind: "all", sort: "updated" });
+    expect(out.map((c) => c.id)).toEqual(["2", "3", "1"]);
+  });
+
+  it("sort=name orders A->Z with locale-aware comparison", () => {
+    const cards = [
+      card({ id: "1", kind: "item", name: "banana", updatedAt: "2026-01-01T00:00:00.000Z" }),
+      card({ id: "2", kind: "item", name: "Apple", updatedAt: "2026-01-02T00:00:00.000Z" }),
+      card({ id: "3", kind: "item", name: "Éclair", updatedAt: "2026-01-03T00:00:00.000Z" }),
+    ];
+    const { cards: out } = deckListing(cards, { kind: "all", sort: "name" });
+    // localeCompare with sensitivity: "base" treats É as E, A < B < É < ... but
+    // case-insensitive: Apple, banana, Éclair.
+    expect(out.map((c) => c.id)).toEqual(["2", "1", "3"]);
+  });
+
+  it("sort=updated tie-break falls through to name ascending", () => {
+    const t = "2026-01-01T00:00:00.000Z";
+    const cards = [
+      card({ id: "1", kind: "item", name: "Bravo", updatedAt: t }),
+      card({ id: "2", kind: "item", name: "Alpha", updatedAt: t }),
+    ];
+    const { cards: out } = deckListing(cards, { kind: "all", sort: "updated" });
+    expect(out.map((c) => c.id)).toEqual(["2", "1"]);
+  });
+
+  it("sort=updated tie-break falls through to id when name also ties", () => {
+    const t = "2026-01-01T00:00:00.000Z";
+    const cards = [
+      card({ id: "b", kind: "item", name: "Same", updatedAt: t }),
+      card({ id: "a", kind: "item", name: "Same", updatedAt: t }),
+    ];
+    const { cards: out } = deckListing(cards, { kind: "all", sort: "updated" });
+    expect(out.map((c) => c.id)).toEqual(["a", "b"]);
+  });
+
+  it("sort=name tie-break falls through to id", () => {
+    const cards = [
+      card({ id: "b", kind: "item", name: "Same", updatedAt: "2026-01-01T00:00:00.000Z" }),
+      card({ id: "a", kind: "item", name: "Same", updatedAt: "2026-01-02T00:00:00.000Z" }),
+    ];
+    const { cards: out } = deckListing(cards, { kind: "all", sort: "name" });
+    expect(out.map((c) => c.id)).toEqual(["a", "b"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const cards = [
+      card({ id: "1", kind: "item", name: "B", updatedAt: "2026-01-01T00:00:00.000Z" }),
+      card({ id: "2", kind: "item", name: "A", updatedAt: "2026-01-02T00:00:00.000Z" }),
+    ];
+    const snapshot = cards.map((c) => c.id);
+    deckListing(cards, { kind: "all", sort: "name" });
+    expect(cards.map((c) => c.id)).toEqual(snapshot);
+  });
+
+  it("returns empty cards with zero counts for empty input", () => {
+    const result = deckListing([], { kind: "all", sort: "updated" });
+    expect(result).toEqual({ cards: [], counts: { all: 0, item: 0, spell: 0 } });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify red**
+
+```bash
+npm test -- --run src/decks/deckListing.test.ts
+```
+
+Expected: All tests fail — `deckListing` doesn't exist yet.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `src/decks/deckListing.ts`:
+
+```ts
+import type { Card } from "../cards/types";
+
+export const DECK_KIND_FILTERS = ["all", "item", "spell"] as const;
+export const DECK_SORTS = ["updated", "name"] as const;
+
+export type DeckKindFilter = (typeof DECK_KIND_FILTERS)[number];
+export type DeckSort = (typeof DECK_SORTS)[number];
+
+export type DeckListing = {
+  cards: Card[];
+  counts: { all: number; item: number; spell: number };
+};
+
+const nameCollator = new Intl.Collator(undefined, { sensitivity: "base" });
+
+function compareByName(a: Card, b: Card): number {
+  return nameCollator.compare(a.name, b.name);
+}
+
+function compareById(a: Card, b: Card): number {
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+function compareByUpdated(a: Card, b: Card): number {
+  if (a.updatedAt === b.updatedAt) return 0;
+  return a.updatedAt < b.updatedAt ? 1 : -1;
+}
+
+export function deckListing(
+  cards: Card[],
+  opts: { kind: DeckKindFilter; sort: DeckSort },
+): DeckListing {
+  let item = 0;
+  let spell = 0;
+  for (const c of cards) {
+    if (c.kind === "item") item++;
+    else if (c.kind === "spell") spell++;
+  }
+
+  const filtered =
+    opts.kind === "all" ? cards.slice() : cards.filter((c) => c.kind === opts.kind);
+
+  if (opts.sort === "updated") {
+    filtered.sort((a, b) => compareByUpdated(a, b) || compareByName(a, b) || compareById(a, b));
+  } else {
+    filtered.sort((a, b) => compareByName(a, b) || compareById(a, b));
+  }
+
+  return { cards: filtered, counts: { all: cards.length, item, spell } };
+}
+```
+
+- [ ] **Step 4: Run tests to verify green**
+
+```bash
+npm test -- --run src/decks/deckListing.test.ts
+```
+
+Expected: All 11 tests pass.
+
+- [ ] **Step 5: Run full suite + typecheck**
+
+```bash
+npm test -- --run
+npm run build
+```
+
+Expected: 604+ tests pass; build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/decks/deckListing.ts src/decks/deckListing.test.ts
+git commit -m "$(cat <<'EOF'
+feat(decks): add deckListing helper (filter + sort + counts)
+
+Pure function over Card[]. Supports kind filter (all/item/spell),
+sort (updated desc / name asc with locale-aware comparison), and
+returns counts for the toolbar. Ability cards are visible only
+under "all".
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `validateDeckSearch` — URL param validator
+
+**Files:**
+- Modify: `src/app/router.tsx` (add validator + types, do NOT wire yet)
+- Create: `src/app/router.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/app/router.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { validateDeckSearch } from "./router";
+
+describe("validateDeckSearch", () => {
+  it("returns defaults for empty input", () => {
+    expect(validateDeckSearch({})).toEqual({ kind: "all", sort: "updated" });
+  });
+
+  it("passes valid values through", () => {
+    expect(validateDeckSearch({ kind: "spell", sort: "name" })).toEqual({
+      kind: "spell",
+      sort: "name",
+    });
+    expect(validateDeckSearch({ kind: "item", sort: "updated" })).toEqual({
+      kind: "item",
+      sort: "updated",
+    });
+  });
+
+  it("coerces unknown kind to 'all'", () => {
+    expect(validateDeckSearch({ kind: "weapons" }).kind).toBe("all");
+  });
+
+  it("coerces unknown sort to 'updated'", () => {
+    expect(validateDeckSearch({ sort: "rarity" }).sort).toBe("updated");
+  });
+
+  it("coerces non-string values to defaults", () => {
+    expect(validateDeckSearch({ kind: 42, sort: null })).toEqual({
+      kind: "all",
+      sort: "updated",
+    });
+  });
+
+  it("ignores unknown keys in the input", () => {
+    expect(validateDeckSearch({ kind: "spell", sort: "name", extra: "x" })).toEqual({
+      kind: "spell",
+      sort: "name",
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify red**
+
+```bash
+npm test -- --run src/app/router.test.ts
+```
+
+Expected: All tests fail — `validateDeckSearch` not exported.
+
+- [ ] **Step 3: Add validator + types to `src/app/router.tsx`**
+
+Add these imports near the top (after the existing imports):
+
+```ts
+import { DECK_KIND_FILTERS, DECK_SORTS, type DeckKindFilter, type DeckSort } from "../decks/deckListing";
+```
+
+Add these exports above the route declarations (e.g., right after `const rootRoute = createRootRoute({ component: Root });`):
+
+```ts
+export type DeckSearch = { kind: DeckKindFilter; sort: DeckSort };
+
+export function validateDeckSearch(raw: Record<string, unknown>): DeckSearch {
+  const rawKind = raw.kind;
+  const rawSort = raw.sort;
+  const kind = (DECK_KIND_FILTERS as readonly string[]).includes(rawKind as string)
+    ? (rawKind as DeckKindFilter)
+    : "all";
+  const sort = (DECK_SORTS as readonly string[]).includes(rawSort as string)
+    ? (rawSort as DeckSort)
+    : "updated";
+  return { kind, sort };
+}
+```
+
+Do NOT wire `validateSearch` into `deckViewRoute` yet — that's Task 3.
+
+- [ ] **Step 4: Run tests to verify green**
+
+```bash
+npm test -- --run src/app/router.test.ts
+```
+
+Expected: All 6 tests pass.
+
+- [ ] **Step 5: Run full suite + typecheck**
+
+```bash
+npm test -- --run
+npm run build
+```
+
+Expected: All tests pass; build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app/router.tsx src/app/router.test.ts
+git commit -m "$(cat <<'EOF'
+feat(router): add validateDeckSearch for kind+sort URL params
+
+Pure validator that coerces unknown values to defaults. Not yet
+wired into deckViewRoute. Unit-tested independently because view
+tests mock useNavigate and don't render the real router.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Wire `validateSearch` into `deckViewRoute`
+
+**Files:**
+- Modify: `src/app/router.tsx`
+
+This task is structural — no new tests; the validator's own tests already cover behavior. The wire-up is verified by `npm run build` (TS catches a misuse) and by the existing/upcoming `DeckView` tests still passing.
+
+- [ ] **Step 1: Update `deckViewRoute` to call `validateSearch`**
+
+In `src/app/router.tsx`, change the `deckViewRoute` definition to:
+
+```ts
+const deckViewRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/deck/$deckId",
+  validateSearch: validateDeckSearch,
+  component: function DeckViewRoute() {
+    const { deckId } = deckViewRoute.useParams();
+    return <DeckView deckId={deckId} />;
+  },
+});
+```
+
+- [ ] **Step 2: Typecheck + full suite**
+
+```bash
+npm run build
+npm test -- --run
+```
+
+Expected: build succeeds, all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/router.tsx
+git commit -m "$(cat <<'EOF'
+feat(router): wire validateDeckSearch onto deckViewRoute
+
+URL search params kind+sort are now coerced to valid values
+before reaching DeckView.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: DeckView toolbar — render filter buttons, sort dropdown, and apply listing
+
+**Files:**
+- Modify: `src/views/DeckView.tsx`
+- Modify: `src/views/DeckView.module.css`
+- Modify: `src/views/DeckView.test.tsx` (update existing mock, add new tests)
+
+This is the largest task. The toolbar reads search params, runs cards through `deckListing`, renders filter buttons + sort dropdown, and replaces the list with the filtered+sorted output. Selecting a filter or sort writes back via `navigate({ search })`.
+
+- [ ] **Step 1: Update the router mock at the top of `DeckView.test.tsx`**
+
+Replace lines 16–37 of `src/views/DeckView.test.tsx` with:
+
+```tsx
+const navigate = vi.fn();
+const useSearchMock = vi.fn<() => { kind: "all" | "item" | "spell"; sort: "updated" | "name" }>(
+  () => ({ kind: "all", sort: "updated" }),
+);
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual =
+    await vi.importActual<typeof import("@tanstack/react-router")>("@tanstack/react-router");
+  return {
+    ...actual,
+    Link: ({
+      children,
+      to,
+      params: _params,
+      ...rest
+    }: {
+      children: ReactNode;
+      to?: string;
+      params?: Record<string, string>;
+    } & Record<string, unknown>) => (
+      <a href={to} {...rest}>
+        {children}
+      </a>
+    ),
+    useNavigate: () => navigate,
+    useSearch: () => useSearchMock(),
+  };
+});
+```
+
+Add to `beforeEach` blocks (both `describe`s):
+
+```tsx
+beforeEach(async () => {
+  navigate.mockClear();
+  useSearchMock.mockReturnValue({ kind: "all", sort: "updated" });
+  await supabase.auth.signOut();
+});
+```
+
+- [ ] **Step 2: Write failing tests for toolbar rendering, filtering, and sorting**
+
+Add a new `describe` block to `src/views/DeckView.test.tsx`:
+
+```tsx
+import { makeSpellPayload, makeItemPayload } from "../test/factories";
+
+describe("DeckView toolbar", () => {
+  beforeEach(async () => {
+    navigate.mockClear();
+    useSearchMock.mockReturnValue({ kind: "all", sort: "updated" });
+    await supabase.auth.signOut();
+  });
+
+  function setupDeck(opts: { is_owner?: boolean } = {}) {
+    const deck = makePublicDeck.build({ is_owner: opts.is_owner ?? true });
+    const item1 = makeCardRow.build({
+      deck_id: deck.id,
+      payload: makeItemPayload.build({
+        name: "Alpha Item",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      }),
+    });
+    const item2 = makeCardRow.build({
+      deck_id: deck.id,
+      payload: makeItemPayload.build({
+        name: "Bravo Item",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      }),
+    });
+    const spell1 = makeCardRow.build({
+      deck_id: deck.id,
+      payload: makeSpellPayload.build({
+        name: "Cantrip",
+        updatedAt: "2026-02-01T00:00:00.000Z",
+      }),
+    });
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(deck)),
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () =>
+        HttpResponse.json([item1, item2, spell1]),
+      ),
+    );
+    return { deck, item1, item2, spell1 };
+  }
+
+  it("renders All/Items/Spells filter buttons with counts", async () => {
+    setupDeck();
+    render(wrap(<DeckView deckId="d" />));
+    expect(await screen.findByRole("radio", { name: "All (3)" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Items (2)" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Spells (1)" })).toBeInTheDocument();
+  });
+
+  it("All is selected by default; default sort is Last updated", async () => {
+    setupDeck();
+    render(wrap(<DeckView deckId="d" />));
+    expect(await screen.findByRole("radio", { name: "All (3)" })).toBeChecked();
+    expect(screen.getByRole("button", { name: /sort.*last updated/i })).toBeInTheDocument();
+  });
+
+  it("default render sorts by updatedAt descending", async () => {
+    const { item1, item2, spell1 } = setupDeck();
+    render(wrap(<DeckView deckId="d" />));
+    const rows = await screen.findAllByRole("listitem");
+    const names = rows.map((li) => li.querySelector("strong")?.textContent);
+    expect(names).toEqual([item2.payload.name, spell1.payload.name, item1.payload.name]);
+  });
+
+  it("mounting at kind=spell shows only spells with the Spells filter checked", async () => {
+    const { spell1 } = setupDeck();
+    useSearchMock.mockReturnValue({ kind: "spell", sort: "updated" });
+    render(wrap(<DeckView deckId="d" />));
+    expect(await screen.findByRole("radio", { name: "Spells (1)" })).toBeChecked();
+    const rows = screen.getAllByRole("listitem");
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.textContent).toContain(spell1.payload.name);
+  });
+
+  it("mounting at sort=name reorders by name", async () => {
+    setupDeck();
+    useSearchMock.mockReturnValue({ kind: "all", sort: "name" });
+    render(wrap(<DeckView deckId="d" />));
+    const rows = await screen.findAllByRole("listitem");
+    const names = rows.map((li) => li.querySelector("strong")?.textContent);
+    expect(names).toEqual(["Alpha Item", "Bravo Item", "Cantrip"]);
+  });
+
+  it("counts stay correct after filtering (counts reflect unfiltered totals)", async () => {
+    setupDeck();
+    useSearchMock.mockReturnValue({ kind: "item", sort: "updated" });
+    render(wrap(<DeckView deckId="d" />));
+    expect(await screen.findByRole("radio", { name: "All (3)" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Items (2)" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "Spells (1)" })).toBeInTheDocument();
+  });
+
+  it("read-only deck still shows the toolbar", async () => {
+    setupDeck({ is_owner: false });
+    render(wrap(<DeckView deckId="d" />));
+    expect(await screen.findByRole("radio", { name: "All (3)" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /sort.*last updated/i })).toBeInTheDocument();
+  });
+});
+```
+
+NOTE: `wrap` is the existing helper at lines 39–46 of the file (named `wrap` there). If it's imported under a different name, use that.
+
+- [ ] **Step 3: Run tests to verify red**
+
+```bash
+npm test -- --run src/views/DeckView.test.tsx
+```
+
+Expected: All new toolbar tests fail — toolbar doesn't render yet.
+
+- [ ] **Step 4: Implement the toolbar in `src/views/DeckView.tsx`**
+
+Update imports at the top of the file:
+
+```tsx
+import { Link, useNavigate, useSearch } from "@tanstack/react-router";
+import { useState } from "react";
+import {
+  Menu,
+  MenuItem,
+  MenuTrigger,
+  Popover,
+  Button as RACButton,
+} from "react-aria-components";
+import { deckListing } from "../decks/deckListing";
+import { useDeleteCard, useRenameDeck } from "../decks/mutations";
+import { useDeck, useDeckCards } from "../decks/queries";
+import { Button } from "../lib/ui/Button";
+import { IconButton } from "../lib/ui/IconButton";
+import { Input } from "../lib/ui/Input";
+import { PencilIcon } from "../lib/ui/icons/PencilIcon";
+import { ToggleButton } from "../lib/ui/ToggleButton";
+import { ToggleButtonGroup } from "../lib/ui/ToggleButtonGroup";
+import { TrashIcon } from "../lib/ui/icons/TrashIcon";
+import { LoadingState } from "../lib/ui/LoadingState";
+import { BrowseApiModal } from "./BrowseApiModal";
+import styles from "./DeckView.module.css";
+```
+
+Add at the top of the `DeckView` function body, replacing the current `const cards = cardsQuery.data ?? [];` line:
+
+```tsx
+const search = useSearch({ from: "/deck/$deckId" });
+const navigate = useNavigate();
+const rawCards = cardsQuery.data ?? [];
+const { cards, counts } = deckListing(rawCards, { kind: search.kind, sort: search.sort });
+```
+
+Add the toolbar right above the existing `{cards.length === 0 ? ( ... ) : (` block:
+
+```tsx
+{rawCards.length > 0 && (
+  <div className={styles.toolbar}>
+    <ToggleButtonGroup
+      aria-label="Filter by kind"
+      selectionMode="single"
+      disallowEmptySelection
+      selectedKeys={[search.kind]}
+      onSelectionChange={(keys) => {
+        const next = Array.from(keys)[0];
+        if (next === "all" || next === "item" || next === "spell") {
+          navigate({ search: (prev) => ({ ...prev, kind: next }) });
+        }
+      }}
+    >
+      <ToggleButton id="all">All ({counts.all})</ToggleButton>
+      <ToggleButton id="item">Items ({counts.item})</ToggleButton>
+      <ToggleButton id="spell">Spells ({counts.spell})</ToggleButton>
+    </ToggleButtonGroup>
+    <MenuTrigger>
+      <RACButton
+        aria-label={`Sort: ${search.sort === "updated" ? "Last updated" : "Name"}`}
+        className={styles.sortTrigger}
+      >
+        Sort: {search.sort === "updated" ? "Last updated" : "Name"}{" "}
+        <span aria-hidden="true">▾</span>
+      </RACButton>
+      <Popover className={styles.sortPopover} placement="bottom end">
+        <Menu
+          className={styles.sortMenu}
+          onAction={(key) => {
+            if (key === "updated" || key === "name") {
+              navigate({ search: (prev) => ({ ...prev, sort: key }) });
+            }
+          }}
+        >
+          <MenuItem id="updated" className={styles.sortMenuItem}>
+            Last updated
+          </MenuItem>
+          <MenuItem id="name" className={styles.sortMenuItem}>
+            Name
+          </MenuItem>
+        </Menu>
+      </Popover>
+    </MenuTrigger>
+  </div>
+)}
+```
+
+The list section continues to iterate over `cards` (now the filtered+sorted output) — no further change needed to the `<ul>`.
+
+- [ ] **Step 5: Add toolbar styles to `src/views/DeckView.module.css`**
+
+Append to the file:
+
+```css
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.sortTrigger {
+  font: inherit;
+  font-family: var(--font-body);
+  font-size: var(--fs-sm);
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.sortTrigger[data-hovered] {
+  background: var(--color-surface-2);
+  border-color: var(--color-border-strong);
+}
+
+.sortTrigger[data-pressed] {
+  background: var(--color-border);
+}
+
+.sortTrigger[data-focus-visible] {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.sortPopover {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  outline: none;
+}
+
+.sortMenu {
+  padding: var(--space-1);
+  outline: none;
+}
+
+.sortMenuItem {
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-sm);
+  cursor: pointer;
+  outline: none;
+}
+
+.sortMenuItem[data-hovered],
+.sortMenuItem[data-focused] {
+  background: var(--color-surface-2);
+}
+```
+
+- [ ] **Step 6: Run tests to verify green**
+
+```bash
+npm test -- --run src/views/DeckView.test.tsx
+```
+
+Expected: New toolbar tests pass; existing logged-out/owner tests still pass.
+
+- [ ] **Step 7: Run full suite + typecheck**
+
+```bash
+npm test -- --run
+npm run build
+```
+
+Expected: all tests pass; build succeeds.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/views/DeckView.tsx src/views/DeckView.module.css src/views/DeckView.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(deck): kind filter + sort dropdown on deck view
+
+Renders three filter buttons (All/Items/Spells, with counts) and
+a sort dropdown (Last updated/Name) above the deck list. Reads
+state from URL search params and applies deckListing to filter +
+sort the rendered cards.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Wire filter and sort selection to URL via navigate
+
+**Files:**
+- Modify: `src/views/DeckView.test.tsx` (add interaction tests)
+
+Task 4 already wired `onSelectionChange` and `onAction` to `navigate`. This task adds explicit tests verifying the navigate calls so a future regression in those handlers is caught.
+
+- [ ] **Step 1: Write failing tests for interactions**
+
+Add to the `describe("DeckView toolbar", ...)` block:
+
+```tsx
+it("clicking Items navigates with kind=item, leaving sort untouched", async () => {
+  setupDeck();
+  render(wrap(<DeckView deckId="d" />));
+  await userEvent.click(await screen.findByRole("radio", { name: "Items (2)" }));
+  expect(navigate).toHaveBeenCalledWith({ search: expect.any(Function) });
+  const [{ search }] = navigate.mock.calls[navigate.mock.calls.length - 1] as [
+    { search: (prev: { kind: string; sort: string }) => { kind: string; sort: string } },
+  ];
+  expect(search({ kind: "all", sort: "updated" })).toEqual({ kind: "item", sort: "updated" });
+});
+
+it("selecting Name from sort menu navigates with sort=name, leaving kind untouched", async () => {
+  setupDeck();
+  useSearchMock.mockReturnValue({ kind: "spell", sort: "updated" });
+  render(wrap(<DeckView deckId="d" />));
+  await userEvent.click(await screen.findByRole("button", { name: /sort.*last updated/i }));
+  await userEvent.click(await screen.findByRole("menuitem", { name: "Name" }));
+  expect(navigate).toHaveBeenCalledWith({ search: expect.any(Function) });
+  const [{ search }] = navigate.mock.calls[navigate.mock.calls.length - 1] as [
+    { search: (prev: { kind: string; sort: string }) => { kind: string; sort: string } },
+  ];
+  expect(search({ kind: "spell", sort: "updated" })).toEqual({ kind: "spell", sort: "name" });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+npm test -- --run src/views/DeckView.test.tsx
+```
+
+Expected: both new tests pass (handlers are already wired from Task 4).
+
+- [ ] **Step 3: Full suite + typecheck**
+
+```bash
+npm test -- --run
+npm run build
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/views/DeckView.test.tsx
+git commit -m "$(cat <<'EOF'
+test(deck): assert navigate calls for filter and sort selection
+
+Captures the search callback and invokes it with a sample prev to
+verify produced search object, per the spec's URL assertion pattern.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Empty states — hide toolbar for empty deck, show contextual message for empty filter
+
+**Files:**
+- Modify: `src/views/DeckView.tsx`
+- Modify: `src/views/DeckView.module.css`
+- Modify: `src/views/DeckView.test.tsx`
+
+Task 4 already guards the toolbar render with `rawCards.length > 0`. The list section, however, still uses the old `cards.length === 0 ? "No cards yet."` check — which now also fires when a filter has zero matches, showing the wrong message. Fix the messaging.
+
+- [ ] **Step 1: Write failing tests**
+
+Add to the `describe("DeckView toolbar", ...)` block:
+
+```tsx
+it("hides the toolbar when the deck has zero cards", async () => {
+  const deck = makePublicDeck.build({ is_owner: true });
+  server.use(
+    http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(deck)),
+    http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json([])),
+  );
+  render(wrap(<DeckView deckId="d" />));
+  await waitFor(() => expect(screen.getByText(/no cards yet/i)).toBeInTheDocument());
+  expect(screen.queryByRole("radio", { name: /^all/i })).not.toBeInTheDocument();
+});
+
+it("shows 'No spells in this deck.' when the Spells filter has zero matches", async () => {
+  setupDeck(); // 2 items, 1 spell
+  // Make it items-only by overriding the cards endpoint:
+  const deck = makePublicDeck.build({ is_owner: true });
+  const item = makeCardRow.build({
+    deck_id: deck.id,
+    payload: makeItemPayload.build({ name: "Sword" }),
+  });
+  server.use(
+    http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(deck)),
+    http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json([item])),
+  );
+  useSearchMock.mockReturnValue({ kind: "spell", sort: "updated" });
+  render(wrap(<DeckView deckId="d" />));
+  expect(await screen.findByText(/no spells in this deck/i)).toBeInTheDocument();
+  // The Spells count still shows 0, the Items count still shows 1.
+  expect(screen.getByRole("radio", { name: "Items (1)" })).toBeInTheDocument();
+  expect(screen.getByRole("radio", { name: "Spells (0)" })).toBeInTheDocument();
+});
+
+it("shows 'No items in this deck.' when the Items filter has zero matches", async () => {
+  const deck = makePublicDeck.build({ is_owner: true });
+  const spell = makeCardRow.build({
+    deck_id: deck.id,
+    payload: makeSpellPayload.build({ name: "Bolt" }),
+  });
+  server.use(
+    http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(deck)),
+    http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json([spell])),
+  );
+  useSearchMock.mockReturnValue({ kind: "item", sort: "updated" });
+  render(wrap(<DeckView deckId="d" />));
+  expect(await screen.findByText(/no items in this deck/i)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run tests to verify red**
+
+```bash
+npm test -- --run src/views/DeckView.test.tsx
+```
+
+Expected: the two empty-filter tests fail (current code says "No cards yet." regardless of filter). The "hides toolbar" test should already pass from Task 4.
+
+- [ ] **Step 3: Update `DeckView.tsx` rendering**
+
+Replace the existing empty/list branch:
+
+```tsx
+{cards.length === 0 ? (
+  <p className={styles.empty}>No cards yet.</p>
+) : (
+  <ul className={styles.list}> ... </ul>
+)}
+```
+
+with:
+
+```tsx
+{rawCards.length === 0 ? (
+  <p className={styles.empty}>No cards yet.</p>
+) : cards.length === 0 ? (
+  <p className={styles.empty}>
+    {search.kind === "item"
+      ? "No items in this deck."
+      : search.kind === "spell"
+        ? "No spells in this deck."
+        : "No cards yet."}
+  </p>
+) : (
+  <ul className={styles.list}> ... </ul>
+)}
+```
+
+(The `<ul>...</ul>` content is unchanged.)
+
+- [ ] **Step 4: Run tests to verify green**
+
+```bash
+npm test -- --run src/views/DeckView.test.tsx
+```
+
+Expected: all tests pass, including the two new empty-filter tests.
+
+- [ ] **Step 5: Full suite + typecheck**
+
+```bash
+npm test -- --run
+npm run build
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/views/DeckView.tsx src/views/DeckView.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(deck): contextual empty-filter messages
+
+When a kind filter yields zero matches in a non-empty deck, show
+"No items in this deck." / "No spells in this deck." instead of
+the generic "No cards yet." Toolbar stays visible so the user
+can pivot back to All.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Final verification
+
+- [ ] **Step 1: Confirm full test suite passes**
+
+```bash
+npm test -- --run
+```
+
+Expected: all tests pass (was 604 at baseline; expect ~620+ after this plan).
+
+- [ ] **Step 2: Confirm build (typecheck) passes**
+
+```bash
+npm run build
+```
+
+Expected: no TS errors; production build succeeds.
+
+- [ ] **Step 3: Lint check (Biome)**
+
+```bash
+npx biome check src
+```
+
+Expected: clean. If anything is flagged, accept Biome's reformatting.
+
+- [ ] **Step 4: Manual sanity check in dev**
+
+```bash
+npm run dev
+```
+
+Open a deck with a mix of items and spells. Verify:
+- All / Items / Spells buttons show the right counts.
+- Clicking each filter updates the URL and the visible cards.
+- Sort dropdown toggles between Last updated / Name and updates URL.
+- Refresh while on `?kind=spell&sort=name` lands on the same view.
+- A deck with zero cards has no toolbar.
+- A deck with only items shows "No spells in this deck." on the Spells filter, with the toolbar still visible.
+
+Stop the dev server when done.
+
+- [ ] **Step 5: Confirm the branch is ready**
+
+```bash
+git log --oneline worktree-deck-tabs-sort ^origin/main
+```
+
+Expected: a clean sequence of commits — one per task — ready for review.
+
+---
+
+## Self-review against the spec
+
+Each spec requirement maps to a task:
+
+| Spec requirement | Task |
+|---|---|
+| Three filter buttons (All/Items/Spells) with counts | 4 |
+| Sort dropdown (Last updated default, Name) | 4 |
+| URL state: `kind`, `sort` with defaults via `validateSearch` | 2 + 3 |
+| `validateDeckSearch` coerces unknowns | 2 |
+| Pure `deckListing(cards, opts)` helper | 1 |
+| Helper: ability cards in `all` only | 1 |
+| Sort `updated`: desc with name+id tie-breaks | 1 |
+| Sort `name`: locale-aware with id tie-break | 1 |
+| Filter buttons use `ToggleButtonGroup` | 4 |
+| Sort uses `MenuTrigger`/`Popover`/`Menu` (BrowseApiModal pattern) | 4 |
+| Toolbar hidden for zero-card deck | 6 |
+| Empty-filter message ("No items/spells in this deck.") | 6 |
+| Read-only deck shows toolbar | 4 |
+| Counts unchanged after filtering | 4 |
+| `navigate({ search: prev => ... })` writes URL on selection | 4 + 5 |
+
+No placeholders. Type names (`DeckKindFilter`, `DeckSort`, `DeckSearch`, `deckListing`, `validateDeckSearch`) are used consistently across tasks.

--- a/docs/superpowers/specs/2026-05-13-deck-tabs-sort-design.md
+++ b/docs/superpowers/specs/2026-05-13-deck-tabs-sort-design.md
@@ -26,38 +26,35 @@ The browse-catalog dialog (`src/views/BrowseApiModal.tsx`) already uses tabs per
 
 ## URL state
 
-Two search params on the existing `/deck/$deckId` route, declared via TanStack Router's `validateSearch`:
+Two search params on the existing `/deck/$deckId` route, declared via TanStack Router's `validateSearch`. Both fields are **optional in the URL** — omission means default, so default state has no query string at all:
 
 ```ts
-type DeckSearch = {
-  kind: "all" | "item" | "spell"; // default "all"
-  sort: "updated" | "name";       // default "updated"
+export type DeckSearch = {
+  kind?: "item" | "spell"; // omit for the implicit "all" default
+  sort?: "name";           // omit for the implicit "updated" default
 };
 ```
+
+Why optional: a deck list at default state should have a clean URL (`/deck/abc`), not `/deck/abc?kind=all&sort=updated`. The query string appears only when the user has made a non-default selection. `<Link>` / `navigate` callers who don't care about filter/sort can pass `search: {}` (or omit `search` if TanStack Router allows it for all-optional shapes), and the validator strips invalid values to defaults.
 
 No route in this repo currently uses `validateSearch`, so this introduces a new pattern. Implement as a hand-rolled validator (no Zod). To keep it independently testable (the route is consumed via mocked `useNavigate` in view tests, so route-level coercion can't be exercised from `DeckView.test.tsx`), extract the validator as a pure exported function in `src/app/router.tsx`:
 
 ```ts
-const ALLOWED_KINDS = ["all", "item", "spell"] as const;
-const ALLOWED_SORTS = ["updated", "name"] as const;
-type KindFilter = (typeof ALLOWED_KINDS)[number];
-type Sort = (typeof ALLOWED_SORTS)[number];
-
 export function validateDeckSearch(raw: Record<string, unknown>): DeckSearch {
-  const kind = raw.kind;
-  const sort = raw.sort;
-  return {
-    kind: (ALLOWED_KINDS as readonly string[]).includes(kind as string) ? (kind as KindFilter) : "all",
-    sort: (ALLOWED_SORTS as readonly string[]).includes(sort as string) ? (sort as Sort) : "updated",
-  };
+  const out: DeckSearch = {};
+  if (raw.kind === "item" || raw.kind === "spell") out.kind = raw.kind;
+  if (raw.sort === "name") out.sort = raw.sort;
+  return out;
 }
 ```
 
-The `as readonly string[]` cast is the minimum needed for TS's `Array.includes` under strict + `noUncheckedIndexedAccess`. The route wires it via `validateSearch: validateDeckSearch`. The pure function gets its own unit tests in `src/app/router.test.ts`.
+Defaults (`kind: "all"`, `sort: "updated"`) are never written into the output — they're represented by absence. URLs like `?kind=all` get normalized to a clean URL via TanStack Router's `validateSearch` round-trip. The validator gets its own unit tests in `src/app/router.test.ts`.
 
-Reading uses `useSearch({ from: "/deck/$deckId" })`. Writing: TanStack Router's `useNavigate()` accepts `navigate({ search: prev => ({ ...prev, kind: "spell" }) })` standalone — it stays on the current route and only updates search. No `to` or `params` needed for in-place search updates.
+Reading uses `useSearch({ from: "/deck/$deckId" })` and defaults at the read site: `const kind = search.kind ?? "all"; const sort = search.sort ?? "updated";`.
 
-**User-facing label mapping:** `sort: "updated"` displays as `"Last updated"` in the UI.
+Writing: TanStack Router's `useNavigate()` accepts `navigate({ search: prev => ({ ...prev, kind: nextKind === "all" ? undefined : nextKind }) })` standalone — it stays on the current route and only updates search. `undefined` keys are dropped from the URL, keeping it clean when the user toggles back to defaults.
+
+**User-facing label mapping:** `sort: undefined` (or `"updated"`) displays as `"Last updated"` in the UI.
 
 ## Filter / sort helper
 
@@ -171,10 +168,13 @@ No changes to `useDeckCards`, the RPC, the schema, factories, or `Card` types.
 
 Tested as a pure function — `DeckView.test.tsx` mocks `useNavigate` and does not render the real router, so route-level coercion can't be exercised from view tests.
 
-- `validateDeckSearch({})` returns `{ kind: "all", sort: "updated" }`.
-- `validateDeckSearch({ kind: "weapons" })` coerces `kind` to `"all"`.
-- `validateDeckSearch({ sort: "rarity" })` coerces `sort` to `"updated"`.
-- Valid values pass through unchanged.
+- `validateDeckSearch({})` returns `{}` (no keys; defaults are implicit).
+- Valid non-default values pass through: `{ kind: "spell", sort: "name" }` → same.
+- Default values are stripped: `{ kind: "all", sort: "updated" }` → `{}`.
+- Unknown `kind` is dropped: `{ kind: "weapons" }` → `{}`.
+- Unknown `sort` is dropped: `{ sort: "rarity" }` → `{}`.
+- Non-string values are dropped.
+- Unknown keys are ignored: `{ kind: "spell", extra: "x" }` → `{ kind: "spell" }`.
 
 ### `DeckView.test.tsx`
 

--- a/docs/superpowers/specs/2026-05-13-deck-tabs-sort-design.md
+++ b/docs/superpowers/specs/2026-05-13-deck-tabs-sort-design.md
@@ -1,4 +1,4 @@
-# Deck view — kind tabs & sort
+# Deck view — kind filter & sort
 
 ## Problem
 
@@ -11,9 +11,9 @@ The browse-catalog dialog (`src/views/BrowseApiModal.tsx`) already uses tabs per
 
 ## Goals
 
-- Tabs at the top of the deck list: **All**, **Items**, **Spells**, each labeled with its count.
+- A kind filter at the top of the deck list: **All**, **Items**, **Spells**, each labeled with its count.
 - A sort picker offering **Last updated** (default, newest first) and **Name** (A→Z).
-- Active tab and sort are reflected in the URL so refresh/back/share all preserve the view.
+- Active filter and sort are reflected in the URL so refresh/back/share all preserve the view.
 - Filtering and sorting happen client-side over the existing `useDeckCards` result — no RPC or schema changes.
 - Read-only viewers of a shared deck get the same affordances.
 
@@ -21,12 +21,12 @@ The browse-catalog dialog (`src/views/BrowseApiModal.tsx`) already uses tabs per
 
 - Sorting by rarity, spell level, or spell school. The card model is intentionally unstructured (free-form tags), so a robust implementation would require parsing tag strings — deferred until tag conventions stabilize.
 - A free-text or fuzzy filter inside the deck view. Tracked separately if needed.
-- Bulk operations across tabs (multi-select, move, delete-many).
+- Bulk operations (multi-select, move, delete-many).
 - Surfacing the `ability` card kind. The type exists in `src/cards/types.ts` and `src/decks/schema.ts` but no code path creates one today (the editor uses `RenderableCard`, and no API mapper produces it). Treat the deck list as item-or-spell only.
 
 ## URL state
 
-Two search params on the existing `/deck/$deckId` route, declared via the router's `validateSearch`:
+Two search params on the existing `/deck/$deckId` route, declared via TanStack Router's `validateSearch`:
 
 ```ts
 type DeckSearch = {
@@ -35,14 +35,18 @@ type DeckSearch = {
 };
 ```
 
-`validateSearch` coerces unknown values back to defaults so render code never has to defend against bad params. Reading uses `useSearch({ from: ... })`; writing uses the router's `navigate({ search: prev => ({ ...prev, kind: "spell" }) })` pattern (or `<Link search>` where appropriate).
+No route in this repo currently uses `validateSearch`, so this introduces a new pattern. Implement as a hand-rolled validator (no Zod) — the value space is two enums; a small `validateSearch: (raw): DeckSearch => ({ kind: ALLOWED_KINDS.includes(raw.kind) ? raw.kind : "all", sort: ALLOWED_SORTS.includes(raw.sort) ? raw.sort : "updated" })` is enough. Coercion guarantees render code never has to defend against bad params.
+
+Reading uses `useSearch({ from: ... })`; writing uses `navigate({ search: prev => ({ ...prev, kind: "spell" }) })`.
+
+**User-facing label mapping:** `sort: "updated"` displays as `"Last updated"` in the UI.
 
 ## Filter / sort helper
 
-A pure helper, colocated with `DeckView.tsx`:
+A pure helper in the domain folder (matches `src/decks/queries.ts`, `mutations.ts`, `rowMappers.ts`; `src/views/` is component-only):
 
 ```ts
-// src/views/deckListing.ts
+// src/decks/deckListing.ts
 type Sort = "updated" | "name";
 type KindFilter = "all" | "item" | "spell";
 
@@ -71,17 +75,36 @@ Pure, no React imports, trivially unit-testable.
 ```
 ┌─ header (title, count, actions: Print / Browse / New) ──────┐
 ├─ toolbar ────────────────────────────────────────────────────┤
-│  [ All (12) ] [ Items (5) ] [ Spells (7) ]  Sort: Last updated ▾ │
+│  ( All (12) | Items (5) | Spells (7) )  Sort: Last updated ▾ │
 ├─ list (filtered + sorted) ───────────────────────────────────┤
 │  card row …                                                  │
 │  card row …                                                  │
 ```
 
-### Tabs
+### Kind filter
 
-`react-aria-components` `Tabs` + `TabList` + `Tab` (horizontal). `selectedKey={kind}`. `onSelectionChange` calls `navigate({ search: prev => ({ ...prev, kind: key }) })`. Labels include counts: `"All (12)"`, `"Items (5)"`, `"Spells (7)"`. Zero-count tabs render normally (`"Spells (0)"`) — never hidden.
+These are filter buttons, not tabs (the list region below stays the same; only its filter changes), so we use the existing `ToggleButtonGroup` + `ToggleButton` primitives from `src/lib/ui/` rather than react-aria `Tabs`. This avoids the a11y problem of using `Tabs` without `TabPanel` (no `tabpanel` role for screen readers) and matches the existing pattern in `CardEditor.tsx:90-102`.
 
-No `TabPanel` components: the list below is a single `<ul>` that re-renders from the filtered data. The tabs are purely a filter signal. This keeps row keys stable across tab changes and avoids three near-identical list templates.
+```tsx
+<ToggleButtonGroup
+  aria-label="Filter by kind"
+  selectionMode="single"
+  disallowEmptySelection
+  selectedKeys={[kind]}
+  onSelectionChange={(keys) => {
+    const next = Array.from(keys)[0];
+    if (next === "all" || next === "item" || next === "spell") {
+      navigate({ search: (prev) => ({ ...prev, kind: next }) });
+    }
+  }}
+>
+  <ToggleButton id="all">All ({counts.all})</ToggleButton>
+  <ToggleButton id="item">Items ({counts.item})</ToggleButton>
+  <ToggleButton id="spell">Spells ({counts.spell})</ToggleButton>
+</ToggleButtonGroup>
+```
+
+Zero-count buttons render normally (`"Spells (0)"`) — never hidden.
 
 ### Sort dropdown
 
@@ -92,48 +115,58 @@ Reuses the `MenuTrigger` + `RACButton` + `Popover` + `Menu` pattern from `Browse
 | Condition | Treatment |
 |---|---|
 | Deck has zero cards | Toolbar row is hidden. Existing `"No cards yet."` message shows where the list would be. |
-| Active tab has zero matches (e.g. Spells in an items-only deck) | Toolbar stays visible. List area shows `"No items in this deck."` / `"No spells in this deck."`. The zero in the tab count makes the reason obvious. |
+| Active filter has zero matches (e.g. Spells in an items-only deck) | Toolbar stays visible. List area shows `"No items in this deck."` / `"No spells in this deck."`. The zero in the count makes the reason obvious. |
 | All filter with zero cards | Same as the first row — toolbar hidden, no-cards message shown. (Equivalent to deck-empty.) |
 
 No inline "Add a card" CTA in the empty-tab state; `New card` and `Browse Catalog` are already in the header right above.
 
 ## Read-only decks
 
-Shared decks (non-owner viewers) get the full tabs + sort UI. Filtering and sorting help viewers too. Owner-only affordances (delete, rename) stay gated as today.
+Shared decks (non-owner viewers) get the full filter + sort toolbar. Filtering and sorting help viewers too. Owner-only affordances (delete, rename) stay gated as today.
 
 ## Components touched
 
 - `src/views/DeckView.tsx` — add toolbar row, wire URL params, consume the helper.
-- `src/views/DeckView.module.css` — toolbar layout, tab styling, sort-trigger styling (mirror `BrowseApiModal.module.css`'s `menuTrigger`).
-- `src/views/deckListing.ts` (new) — pure filter/sort helper.
-- `src/views/deckListing.test.ts` (new) — helper unit tests.
-- `src/views/DeckView.test.tsx` — integration tests for tabs, sort, URL state, empty tabs.
-- Route file for `/deck/$deckId` — add `validateSearch` for `kind` + `sort`.
+- `src/views/DeckView.module.css` — toolbar layout, sort-trigger styling (mirror `BrowseApiModal.module.css`'s `menuTrigger`). No new styles needed for the filter buttons — `ToggleButtonGroup`/`ToggleButton` already own that look.
+- `src/decks/deckListing.ts` (new) — pure filter/sort helper.
+- `src/decks/deckListing.test.ts` (new) — helper unit tests.
+- `src/views/DeckView.test.tsx` — integration tests for filter buttons, sort, URL state, empty states.
+- `src/app/router.tsx` — add `validateSearch` to `deckViewRoute` for `kind` + `sort`.
 
 No changes to `useDeckCards`, the RPC, the schema, factories, or `Card` types.
 
 ## Testing
 
-### Helper (`deckListing.test.ts`)
+### Helper (`src/decks/deckListing.test.ts`)
 
-- `kind: "all"` returns all cards in input order subject to sort.
+- `kind: "all"` returns all cards, sorted as requested.
 - `kind: "item"` returns only items; `"spell"` returns only spells.
+- Ability cards: when `kind: "all"` they are included in the result; for `"item"` / `"spell"` they are excluded.
 - `counts` is correct for mixed, single-kind, and empty inputs.
 - `sort: "updated"` orders newest-first by `updatedAt`.
 - `sort: "name"` orders A→Z, with `localeCompare`-style behavior on accented characters.
-- Tie-break for `updated`: equal `updatedAt` falls through to name then id.
+- Tie-break for `updated`: equal `updatedAt` falls through to name; equal name then falls through to id. (Two separate assertions so the chain is provable.)
 - Tie-break for `name`: equal name falls through to id.
+
+### Route (`src/app/router.tsx` via integration in `DeckView.test.tsx`)
+
+- `validateSearch` coerces an unknown `kind` (e.g. `"weapons"`) to `"all"`.
+- `validateSearch` coerces an unknown `sort` to `"updated"`.
+- Missing params resolve to defaults.
 
 ### `DeckView.test.tsx`
 
-- Tabs render with correct counts when the deck has a mix of items and spells.
-- Tab row is absent when the deck has zero cards.
+- Filter buttons render with correct counts when the deck has a mix of items and spells.
+- Toolbar row is absent when the deck has zero cards.
 - Default render lands on All + Last updated, with cards in `updatedAt`-desc order.
-- Clicking the Items tab filters the list to items (assert via rendered card names) and writes `kind=item` to the URL.
-- Switching the sort dropdown to Name reorders the list alphabetically and writes `sort=name`.
-- Mounting the route at `?kind=spell&sort=name` lands on the Spells tab in name order without a click.
-- Empty-tab message: a deck with only items renders `"No spells in this deck."` on the Spells tab; counts still show `Items (N)` and `Spells (0)`.
-- A read-only deck (non-owner) still shows tabs + sort.
+- Clicking the Items button filters the list to items (assert via rendered card names) and triggers a `navigate` call writing `kind: "item"`.
+- Counts stay correct after filtering: with Items selected, the Spells button still shows `Spells (M)` where M is the unfiltered spell count.
+- Switching the sort dropdown to Name reorders the list alphabetically and triggers a `navigate` call writing `sort: "name"`.
+- Mounting the route at `?kind=spell&sort=name` lands on Spells in name order without a click.
+- Empty-tab message: a deck with only items renders `"No spells in this deck."` on the Spells filter; counts still show `Items (N)` and `Spells (0)`.
+- A read-only deck (non-owner) shows the full toolbar (filter buttons + sort).
+
+**URL assertion pattern:** Existing view tests in this repo mock `useNavigate` and `Link` rather than rendering the real router (see `src/views/DeckView.test.tsx`). Assert on the mocked `navigate` call (`expect(navigate).toHaveBeenCalledWith({ search: expect.any(Function) })`, then invoke the callback with a sample prev to verify the produced object). Avoid asserting on `router.state.location.search` — that is not the established pattern here.
 
 Factories pass only the fields each test asserts on (`name`, `kind`, `updatedAt`).
 

--- a/docs/superpowers/specs/2026-05-13-deck-tabs-sort-design.md
+++ b/docs/superpowers/specs/2026-05-13-deck-tabs-sort-design.md
@@ -35,9 +35,27 @@ type DeckSearch = {
 };
 ```
 
-No route in this repo currently uses `validateSearch`, so this introduces a new pattern. Implement as a hand-rolled validator (no Zod) — the value space is two enums; a small `validateSearch: (raw): DeckSearch => ({ kind: ALLOWED_KINDS.includes(raw.kind) ? raw.kind : "all", sort: ALLOWED_SORTS.includes(raw.sort) ? raw.sort : "updated" })` is enough. Coercion guarantees render code never has to defend against bad params.
+No route in this repo currently uses `validateSearch`, so this introduces a new pattern. Implement as a hand-rolled validator (no Zod). To keep it independently testable (the route is consumed via mocked `useNavigate` in view tests, so route-level coercion can't be exercised from `DeckView.test.tsx`), extract the validator as a pure exported function in `src/app/router.tsx`:
 
-Reading uses `useSearch({ from: ... })`; writing uses `navigate({ search: prev => ({ ...prev, kind: "spell" }) })`.
+```ts
+const ALLOWED_KINDS = ["all", "item", "spell"] as const;
+const ALLOWED_SORTS = ["updated", "name"] as const;
+type KindFilter = (typeof ALLOWED_KINDS)[number];
+type Sort = (typeof ALLOWED_SORTS)[number];
+
+export function validateDeckSearch(raw: Record<string, unknown>): DeckSearch {
+  const kind = raw.kind;
+  const sort = raw.sort;
+  return {
+    kind: (ALLOWED_KINDS as readonly string[]).includes(kind as string) ? (kind as KindFilter) : "all",
+    sort: (ALLOWED_SORTS as readonly string[]).includes(sort as string) ? (sort as Sort) : "updated",
+  };
+}
+```
+
+The `as readonly string[]` cast is the minimum needed for TS's `Array.includes` under strict + `noUncheckedIndexedAccess`. The route wires it via `validateSearch: validateDeckSearch`. The pure function gets its own unit tests in `src/app/router.test.ts`.
+
+Reading uses `useSearch({ from: "/deck/$deckId" })`. Writing: TanStack Router's `useNavigate()` accepts `navigate({ search: prev => ({ ...prev, kind: "spell" }) })` standalone — it stays on the current route and only updates search. No `to` or `params` needed for in-place search updates.
 
 **User-facing label mapping:** `sort: "updated"` displays as `"Last updated"` in the UI.
 
@@ -75,7 +93,7 @@ Pure, no React imports, trivially unit-testable.
 ```
 ┌─ header (title, count, actions: Print / Browse / New) ──────┐
 ├─ toolbar ────────────────────────────────────────────────────┤
-│  ( All (12) | Items (5) | Spells (7) )  Sort: Last updated ▾ │
+│  [All (12)] [Items (5)] [Spells (7)]    Sort: Last updated ▾ │
 ├─ list (filtered + sorted) ───────────────────────────────────┤
 │  card row …                                                  │
 │  card row …                                                  │
@@ -131,7 +149,8 @@ Shared decks (non-owner viewers) get the full filter + sort toolbar. Filtering a
 - `src/decks/deckListing.ts` (new) — pure filter/sort helper.
 - `src/decks/deckListing.test.ts` (new) — helper unit tests.
 - `src/views/DeckView.test.tsx` — integration tests for filter buttons, sort, URL state, empty states.
-- `src/app/router.tsx` — add `validateSearch` to `deckViewRoute` for `kind` + `sort`.
+- `src/app/router.tsx` — export `validateDeckSearch` and wire it into `deckViewRoute` as `validateSearch`.
+- `src/app/router.test.ts` (new) — unit tests for `validateDeckSearch`.
 
 No changes to `useDeckCards`, the RPC, the schema, factories, or `Card` types.
 
@@ -148,11 +167,14 @@ No changes to `useDeckCards`, the RPC, the schema, factories, or `Card` types.
 - Tie-break for `updated`: equal `updatedAt` falls through to name; equal name then falls through to id. (Two separate assertions so the chain is provable.)
 - Tie-break for `name`: equal name falls through to id.
 
-### Route (`src/app/router.tsx` via integration in `DeckView.test.tsx`)
+### Route validator (`src/app/router.test.ts`)
 
-- `validateSearch` coerces an unknown `kind` (e.g. `"weapons"`) to `"all"`.
-- `validateSearch` coerces an unknown `sort` to `"updated"`.
-- Missing params resolve to defaults.
+Tested as a pure function — `DeckView.test.tsx` mocks `useNavigate` and does not render the real router, so route-level coercion can't be exercised from view tests.
+
+- `validateDeckSearch({})` returns `{ kind: "all", sort: "updated" }`.
+- `validateDeckSearch({ kind: "weapons" })` coerces `kind` to `"all"`.
+- `validateDeckSearch({ sort: "rarity" })` coerces `sort` to `"updated"`.
+- Valid values pass through unchanged.
 
 ### `DeckView.test.tsx`
 
@@ -166,7 +188,7 @@ No changes to `useDeckCards`, the RPC, the schema, factories, or `Card` types.
 - Empty-tab message: a deck with only items renders `"No spells in this deck."` on the Spells filter; counts still show `Items (N)` and `Spells (0)`.
 - A read-only deck (non-owner) shows the full toolbar (filter buttons + sort).
 
-**URL assertion pattern:** Existing view tests in this repo mock `useNavigate` and `Link` rather than rendering the real router (see `src/views/DeckView.test.tsx`). Assert on the mocked `navigate` call (`expect(navigate).toHaveBeenCalledWith({ search: expect.any(Function) })`, then invoke the callback with a sample prev to verify the produced object). Avoid asserting on `router.state.location.search` — that is not the established pattern here.
+**URL assertion pattern:** Existing view tests in this repo mock `useNavigate` and `Link` rather than rendering the real router (see `src/views/DeckView.test.tsx`). The implementation calls `navigate({ search: prev => ({ ...prev, kind: "spell" }) })` (TanStack Router allows search-only navigation that stays on the current route — no `to`/`params` needed). Tests assert on the mocked call: `expect(navigate).toHaveBeenCalledWith({ search: expect.any(Function) })`, then invoke the captured callback with a sample prev (`{ kind: "all", sort: "updated" }`) and verify the returned object (`{ kind: "spell", sort: "updated" }`). Avoid asserting on `router.state.location.search` — that is not the established pattern here.
 
 Factories pass only the fields each test asserts on (`name`, `kind`, `updatedAt`).
 

--- a/docs/superpowers/specs/2026-05-13-deck-tabs-sort-design.md
+++ b/docs/superpowers/specs/2026-05-13-deck-tabs-sort-design.md
@@ -1,0 +1,143 @@
+# Deck view — kind tabs & sort
+
+## Problem
+
+The deck list at `/deck/$deckId` (`src/views/DeckView.tsx`) shows every card in one flat list, sorted by whatever order `get_public_deck_cards` returns. For a deck with a mix of items and spells, there is no way to:
+
+- Scope the view to just items or just spells.
+- Reorder by name or recency.
+
+The browse-catalog dialog (`src/views/BrowseApiModal.tsx`) already uses tabs per content type, so users have a precedent for thinking of the deck as splittable by kind.
+
+## Goals
+
+- Tabs at the top of the deck list: **All**, **Items**, **Spells**, each labeled with its count.
+- A sort picker offering **Last updated** (default, newest first) and **Name** (A→Z).
+- Active tab and sort are reflected in the URL so refresh/back/share all preserve the view.
+- Filtering and sorting happen client-side over the existing `useDeckCards` result — no RPC or schema changes.
+- Read-only viewers of a shared deck get the same affordances.
+
+## Non-goals
+
+- Sorting by rarity, spell level, or spell school. The card model is intentionally unstructured (free-form tags), so a robust implementation would require parsing tag strings — deferred until tag conventions stabilize.
+- A free-text or fuzzy filter inside the deck view. Tracked separately if needed.
+- Bulk operations across tabs (multi-select, move, delete-many).
+- Surfacing the `ability` card kind. The type exists in `src/cards/types.ts` and `src/decks/schema.ts` but no code path creates one today (the editor uses `RenderableCard`, and no API mapper produces it). Treat the deck list as item-or-spell only.
+
+## URL state
+
+Two search params on the existing `/deck/$deckId` route, declared via the router's `validateSearch`:
+
+```ts
+type DeckSearch = {
+  kind: "all" | "item" | "spell"; // default "all"
+  sort: "updated" | "name";       // default "updated"
+};
+```
+
+`validateSearch` coerces unknown values back to defaults so render code never has to defend against bad params. Reading uses `useSearch({ from: ... })`; writing uses the router's `navigate({ search: prev => ({ ...prev, kind: "spell" }) })` pattern (or `<Link search>` where appropriate).
+
+## Filter / sort helper
+
+A pure helper, colocated with `DeckView.tsx`:
+
+```ts
+// src/views/deckListing.ts
+type Sort = "updated" | "name";
+type KindFilter = "all" | "item" | "spell";
+
+export type DeckListing = {
+  cards: Card[];             // filtered + sorted
+  counts: { all: number; item: number; spell: number };
+};
+
+export function deckListing(cards: Card[], opts: { kind: KindFilter; sort: Sort }): DeckListing;
+```
+
+Behavior:
+
+- **Filter:** `kind === "all"` returns every card; otherwise `card.kind === kind`. Ability cards (if any ever land in a deck) are excluded from Items and Spells; they appear under All.
+- **Counts:** `all` = total, `item` = `kind === "item"`, `spell` = `kind === "spell"`. Computed in the same pass.
+- **Sort:**
+  - `updated`: `updatedAt` descending (ISO strings compare lexicographically). Tie-break: `name` ascending (`localeCompare`), then `id` ascending.
+  - `name`: `name` ascending via `localeCompare(undefined, { sensitivity: "base" })` so accented characters sort intuitively. Tie-break: `id` ascending.
+
+Pure, no React imports, trivially unit-testable.
+
+## UI structure
+
+`DeckView.tsx` gains a toolbar row between the existing `<header>` and the `<ul>`:
+
+```
+┌─ header (title, count, actions: Print / Browse / New) ──────┐
+├─ toolbar ────────────────────────────────────────────────────┤
+│  [ All (12) ] [ Items (5) ] [ Spells (7) ]  Sort: Last updated ▾ │
+├─ list (filtered + sorted) ───────────────────────────────────┤
+│  card row …                                                  │
+│  card row …                                                  │
+```
+
+### Tabs
+
+`react-aria-components` `Tabs` + `TabList` + `Tab` (horizontal). `selectedKey={kind}`. `onSelectionChange` calls `navigate({ search: prev => ({ ...prev, kind: key }) })`. Labels include counts: `"All (12)"`, `"Items (5)"`, `"Spells (7)"`. Zero-count tabs render normally (`"Spells (0)"`) — never hidden.
+
+No `TabPanel` components: the list below is a single `<ul>` that re-renders from the filtered data. The tabs are purely a filter signal. This keeps row keys stable across tab changes and avoids three near-identical list templates.
+
+### Sort dropdown
+
+Reuses the `MenuTrigger` + `RACButton` + `Popover` + `Menu` pattern from `BrowseApiModal.tsx`'s `SourceMenu` (lines 144–169) so styling and a11y match the existing source picker. Trigger label: `"Sort: Last updated ▾"` / `"Sort: Name ▾"`. `onAction` writes `sort` to URL.
+
+## Empty states
+
+| Condition | Treatment |
+|---|---|
+| Deck has zero cards | Toolbar row is hidden. Existing `"No cards yet."` message shows where the list would be. |
+| Active tab has zero matches (e.g. Spells in an items-only deck) | Toolbar stays visible. List area shows `"No items in this deck."` / `"No spells in this deck."`. The zero in the tab count makes the reason obvious. |
+| All filter with zero cards | Same as the first row — toolbar hidden, no-cards message shown. (Equivalent to deck-empty.) |
+
+No inline "Add a card" CTA in the empty-tab state; `New card` and `Browse Catalog` are already in the header right above.
+
+## Read-only decks
+
+Shared decks (non-owner viewers) get the full tabs + sort UI. Filtering and sorting help viewers too. Owner-only affordances (delete, rename) stay gated as today.
+
+## Components touched
+
+- `src/views/DeckView.tsx` — add toolbar row, wire URL params, consume the helper.
+- `src/views/DeckView.module.css` — toolbar layout, tab styling, sort-trigger styling (mirror `BrowseApiModal.module.css`'s `menuTrigger`).
+- `src/views/deckListing.ts` (new) — pure filter/sort helper.
+- `src/views/deckListing.test.ts` (new) — helper unit tests.
+- `src/views/DeckView.test.tsx` — integration tests for tabs, sort, URL state, empty tabs.
+- Route file for `/deck/$deckId` — add `validateSearch` for `kind` + `sort`.
+
+No changes to `useDeckCards`, the RPC, the schema, factories, or `Card` types.
+
+## Testing
+
+### Helper (`deckListing.test.ts`)
+
+- `kind: "all"` returns all cards in input order subject to sort.
+- `kind: "item"` returns only items; `"spell"` returns only spells.
+- `counts` is correct for mixed, single-kind, and empty inputs.
+- `sort: "updated"` orders newest-first by `updatedAt`.
+- `sort: "name"` orders A→Z, with `localeCompare`-style behavior on accented characters.
+- Tie-break for `updated`: equal `updatedAt` falls through to name then id.
+- Tie-break for `name`: equal name falls through to id.
+
+### `DeckView.test.tsx`
+
+- Tabs render with correct counts when the deck has a mix of items and spells.
+- Tab row is absent when the deck has zero cards.
+- Default render lands on All + Last updated, with cards in `updatedAt`-desc order.
+- Clicking the Items tab filters the list to items (assert via rendered card names) and writes `kind=item` to the URL.
+- Switching the sort dropdown to Name reorders the list alphabetically and writes `sort=name`.
+- Mounting the route at `?kind=spell&sort=name` lands on the Spells tab in name order without a click.
+- Empty-tab message: a deck with only items renders `"No spells in this deck."` on the Spells tab; counts still show `Items (N)` and `Spells (0)`.
+- A read-only deck (non-owner) still shows tabs + sort.
+
+Factories pass only the fields each test asserts on (`name`, `kind`, `updatedAt`).
+
+## Out of scope / follow-ups
+
+- **Sort by rarity / spell level / spell school.** Requires either structured fields on the card model or a tag-string parser tolerant of `"lvl 3"` / `"level 3"` / `"3rd-level"` and abbreviations. Worth reconsidering once tag conventions stabilize, or paired with a free-text filter.
+- **Free-text or fuzzy filter inside the deck view.** A natural complement to the tabs; not bundled here to keep this change focused.

--- a/src/app/router.test.ts
+++ b/src/app/router.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { validateDeckSearch } from "./router";
+
+describe("validateDeckSearch", () => {
+  it("returns empty object for empty input (defaults are implicit)", () => {
+    expect(validateDeckSearch({})).toEqual({});
+  });
+
+  it("strips explicit default values so the URL normalizes to clean", () => {
+    expect(validateDeckSearch({ kind: "all", sort: "updated" })).toEqual({});
+  });
+
+  it("passes non-default values through", () => {
+    expect(validateDeckSearch({ kind: "spell", sort: "name" })).toEqual({
+      kind: "spell",
+      sort: "name",
+    });
+    expect(validateDeckSearch({ kind: "item" })).toEqual({ kind: "item" });
+  });
+
+  it("drops unknown kind", () => {
+    expect(validateDeckSearch({ kind: "weapons" })).toEqual({});
+  });
+
+  it("drops unknown sort", () => {
+    expect(validateDeckSearch({ sort: "rarity" })).toEqual({});
+  });
+
+  it("drops non-string values", () => {
+    expect(validateDeckSearch({ kind: 42, sort: null })).toEqual({});
+  });
+
+  it("ignores unknown keys", () => {
+    expect(validateDeckSearch({ kind: "spell", sort: "name", extra: "x" })).toEqual({
+      kind: "spell",
+      sort: "name",
+    });
+  });
+
+  it("treats mixed inputs independently (strip one, keep the other)", () => {
+    expect(validateDeckSearch({ kind: "spell", sort: "updated" })).toEqual({ kind: "spell" });
+    expect(validateDeckSearch({ kind: "all", sort: "name" })).toEqual({ sort: "name" });
+  });
+});

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -11,6 +11,18 @@ import { Root } from "./Root";
 
 const rootRoute = createRootRoute({ component: Root });
 
+export type DeckSearch = {
+  kind?: "item" | "spell";
+  sort?: "name";
+};
+
+export function validateDeckSearch(raw: Record<string, unknown>): DeckSearch {
+  const out: DeckSearch = {};
+  if (raw.kind === "item" || raw.kind === "spell") out.kind = raw.kind;
+  if (raw.sort === "name") out.sort = raw.sort;
+  return out;
+}
+
 const homeRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/",

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -32,6 +32,7 @@ const homeRoute = createRoute({
 const deckViewRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/deck/$deckId",
+  validateSearch: validateDeckSearch,
   component: function DeckViewRoute() {
     const { deckId } = deckViewRoute.useParams();
     return <DeckView deckId={deckId} />;

--- a/src/decks/deckListing.test.ts
+++ b/src/decks/deckListing.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import type { Card } from "../cards/types";
+import { deckListing } from "./deckListing";
+
+function card(overrides: Partial<Card> & Pick<Card, "id" | "kind" | "name" | "updatedAt">): Card {
+  return {
+    body: "",
+    source: "custom",
+    headerTags: [],
+    footerTags: [],
+    createdAt: overrides.updatedAt,
+    ...overrides,
+  } as Card;
+}
+
+describe("deckListing", () => {
+  it("returns counts for items, spells, and total across all kinds", () => {
+    const cards = [
+      card({ id: "1", kind: "item", name: "A", updatedAt: "2026-01-01T00:00:00.000Z" }),
+      card({ id: "2", kind: "item", name: "B", updatedAt: "2026-01-02T00:00:00.000Z" }),
+      card({ id: "3", kind: "spell", name: "C", updatedAt: "2026-01-03T00:00:00.000Z" }),
+      card({ id: "4", kind: "ability", name: "D", updatedAt: "2026-01-04T00:00:00.000Z" }),
+    ];
+    const { counts } = deckListing(cards, { kind: "all", sort: "updated" });
+    expect(counts).toEqual({ all: 4, item: 2, spell: 1 });
+  });
+
+  it("kind=all includes ability cards", () => {
+    const cards = [
+      card({ id: "1", kind: "item", name: "A", updatedAt: "2026-01-01T00:00:00.000Z" }),
+      card({ id: "2", kind: "ability", name: "B", updatedAt: "2026-01-02T00:00:00.000Z" }),
+    ];
+    const { cards: out } = deckListing(cards, { kind: "all", sort: "name" });
+    expect(out.map((c) => c.id)).toEqual(["1", "2"]);
+  });
+
+  it("kind=item excludes spells and abilities", () => {
+    const cards = [
+      card({ id: "1", kind: "item", name: "A", updatedAt: "2026-01-01T00:00:00.000Z" }),
+      card({ id: "2", kind: "spell", name: "B", updatedAt: "2026-01-02T00:00:00.000Z" }),
+      card({ id: "3", kind: "ability", name: "C", updatedAt: "2026-01-03T00:00:00.000Z" }),
+    ];
+    const { cards: out } = deckListing(cards, { kind: "item", sort: "name" });
+    expect(out.map((c) => c.id)).toEqual(["1"]);
+  });
+
+  it("kind=spell excludes items and abilities", () => {
+    const cards = [
+      card({ id: "1", kind: "item", name: "A", updatedAt: "2026-01-01T00:00:00.000Z" }),
+      card({ id: "2", kind: "spell", name: "B", updatedAt: "2026-01-02T00:00:00.000Z" }),
+      card({ id: "3", kind: "ability", name: "C", updatedAt: "2026-01-03T00:00:00.000Z" }),
+    ];
+    const { cards: out } = deckListing(cards, { kind: "spell", sort: "name" });
+    expect(out.map((c) => c.id)).toEqual(["2"]);
+  });
+
+  it("sort=updated orders newest first by updatedAt", () => {
+    const cards = [
+      card({ id: "1", kind: "item", name: "A", updatedAt: "2026-01-01T00:00:00.000Z" }),
+      card({ id: "2", kind: "item", name: "B", updatedAt: "2026-03-01T00:00:00.000Z" }),
+      card({ id: "3", kind: "item", name: "C", updatedAt: "2026-02-01T00:00:00.000Z" }),
+    ];
+    const { cards: out } = deckListing(cards, { kind: "all", sort: "updated" });
+    expect(out.map((c) => c.id)).toEqual(["2", "3", "1"]);
+  });
+
+  it("sort=name orders A->Z with locale-aware comparison", () => {
+    const cards = [
+      card({ id: "1", kind: "item", name: "banana", updatedAt: "2026-01-01T00:00:00.000Z" }),
+      card({ id: "2", kind: "item", name: "Apple", updatedAt: "2026-01-02T00:00:00.000Z" }),
+      card({ id: "3", kind: "item", name: "Éclair", updatedAt: "2026-01-03T00:00:00.000Z" }),
+    ];
+    const { cards: out } = deckListing(cards, { kind: "all", sort: "name" });
+    expect(out.map((c) => c.id)).toEqual(["2", "1", "3"]);
+  });
+
+  it("sort=updated tie-break falls through to name ascending", () => {
+    const t = "2026-01-01T00:00:00.000Z";
+    const cards = [
+      card({ id: "1", kind: "item", name: "Bravo", updatedAt: t }),
+      card({ id: "2", kind: "item", name: "Alpha", updatedAt: t }),
+    ];
+    const { cards: out } = deckListing(cards, { kind: "all", sort: "updated" });
+    expect(out.map((c) => c.id)).toEqual(["2", "1"]);
+  });
+
+  it("sort=updated tie-break falls through to id when name also ties", () => {
+    const t = "2026-01-01T00:00:00.000Z";
+    const cards = [
+      card({ id: "b", kind: "item", name: "Same", updatedAt: t }),
+      card({ id: "a", kind: "item", name: "Same", updatedAt: t }),
+    ];
+    const { cards: out } = deckListing(cards, { kind: "all", sort: "updated" });
+    expect(out.map((c) => c.id)).toEqual(["a", "b"]);
+  });
+
+  it("sort=name tie-break falls through to id", () => {
+    const cards = [
+      card({ id: "b", kind: "item", name: "Same", updatedAt: "2026-01-01T00:00:00.000Z" }),
+      card({ id: "a", kind: "item", name: "Same", updatedAt: "2026-01-02T00:00:00.000Z" }),
+    ];
+    const { cards: out } = deckListing(cards, { kind: "all", sort: "name" });
+    expect(out.map((c) => c.id)).toEqual(["a", "b"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const cards = [
+      card({ id: "1", kind: "item", name: "B", updatedAt: "2026-01-01T00:00:00.000Z" }),
+      card({ id: "2", kind: "item", name: "A", updatedAt: "2026-01-02T00:00:00.000Z" }),
+    ];
+    const snapshot = cards.map((c) => c.id);
+    deckListing(cards, { kind: "all", sort: "name" });
+    expect(cards.map((c) => c.id)).toEqual(snapshot);
+  });
+
+  it("returns empty cards with zero counts for empty input", () => {
+    const result = deckListing([], { kind: "all", sort: "updated" });
+    expect(result).toEqual({ cards: [], counts: { all: 0, item: 0, spell: 0 } });
+  });
+});

--- a/src/decks/deckListing.ts
+++ b/src/decks/deckListing.ts
@@ -1,0 +1,49 @@
+import type { Card } from "../cards/types";
+
+export const DECK_KIND_FILTERS = ["all", "item", "spell"] as const;
+export const DECK_SORTS = ["updated", "name"] as const;
+
+export type DeckKindFilter = (typeof DECK_KIND_FILTERS)[number];
+export type DeckSort = (typeof DECK_SORTS)[number];
+
+export type DeckListing = {
+  cards: Card[];
+  counts: { all: number; item: number; spell: number };
+};
+
+const nameCollator = new Intl.Collator(undefined, { sensitivity: "base" });
+
+function compareByName(a: Card, b: Card): number {
+  return nameCollator.compare(a.name, b.name);
+}
+
+function compareById(a: Card, b: Card): number {
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+function compareByUpdated(a: Card, b: Card): number {
+  if (a.updatedAt === b.updatedAt) return 0;
+  return a.updatedAt < b.updatedAt ? 1 : -1;
+}
+
+export function deckListing(
+  cards: Card[],
+  opts: { kind: DeckKindFilter; sort: DeckSort },
+): DeckListing {
+  let item = 0;
+  let spell = 0;
+  for (const c of cards) {
+    if (c.kind === "item") item++;
+    else if (c.kind === "spell") spell++;
+  }
+
+  const filtered = opts.kind === "all" ? cards.slice() : cards.filter((c) => c.kind === opts.kind);
+
+  if (opts.sort === "updated") {
+    filtered.sort((a, b) => compareByUpdated(a, b) || compareByName(a, b) || compareById(a, b));
+  } else {
+    filtered.sort((a, b) => compareByName(a, b) || compareById(a, b));
+  }
+
+  return { cards: filtered, counts: { all: cards.length, item, spell } };
+}

--- a/src/views/DeckView.module.css
+++ b/src/views/DeckView.module.css
@@ -133,3 +133,64 @@
   font-weight: 600;
   padding: var(--space-1) var(--space-3);
 }
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.sortTrigger {
+  font: inherit;
+  font-family: var(--font-body);
+  font-size: var(--fs-sm);
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.sortTrigger[data-hovered] {
+  background: var(--color-surface-2);
+  border-color: var(--color-border-strong);
+}
+
+.sortTrigger[data-pressed] {
+  background: var(--color-border);
+}
+
+.sortTrigger[data-focus-visible] {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.sortPopover {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  outline: none;
+}
+
+.sortMenu {
+  padding: var(--space-1);
+  outline: none;
+}
+
+.sortMenuItem {
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-sm);
+  cursor: pointer;
+  outline: none;
+}
+
+.sortMenuItem[data-hovered],
+.sortMenuItem[data-focused] {
+  background: var(--color-surface-2);
+}

--- a/src/views/DeckView.test.tsx
+++ b/src/views/DeckView.test.tsx
@@ -4,14 +4,18 @@ import { HttpResponse, http } from "msw";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { supabase } from "../api/supabase";
+import type { DeckSearch } from "../app/router";
 import { AuthProvider } from "../auth/AuthProvider";
-import { makeCardRow, makePublicDeck } from "../test/factories";
+import { makeCardRow, makeItemPayload, makePublicDeck, makeSpellPayload } from "../test/factories";
 import { server } from "../test/msw";
 import { render, screen, waitFor } from "../test/render";
 import { signInTestUser } from "../test/signInTestUser";
 import { DeckView } from "./DeckView";
 
 const SB = "http://localhost:54321";
+
+const navigate = vi.fn();
+const useSearchMock = vi.fn<() => DeckSearch>(() => ({}));
 
 vi.mock("@tanstack/react-router", async () => {
   const actual =
@@ -32,7 +36,8 @@ vi.mock("@tanstack/react-router", async () => {
         {children}
       </a>
     ),
-    useNavigate: () => vi.fn(),
+    useNavigate: () => navigate,
+    useSearch: () => useSearchMock(),
   };
 });
 
@@ -47,6 +52,8 @@ function wrap(ui: ReactNode) {
 
 describe("DeckView (logged-out)", () => {
   beforeEach(async () => {
+    navigate.mockClear();
+    useSearchMock.mockReturnValue({});
     await supabase.auth.signOut();
   });
 
@@ -79,6 +86,8 @@ describe("DeckView (logged-out)", () => {
 
 describe("DeckView (owner)", () => {
   beforeEach(async () => {
+    navigate.mockClear();
+    useSearchMock.mockReturnValue({});
     await supabase.auth.signOut();
   });
 
@@ -101,5 +110,103 @@ describe("DeckView (owner)", () => {
     await waitFor(() => expect(onDelete).toHaveBeenCalled());
     expect(screen.getByRole("link", { name: /new card/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /browse catalog/i })).toBeInTheDocument();
+  });
+});
+
+describe("DeckView toolbar", () => {
+  beforeEach(async () => {
+    navigate.mockClear();
+    useSearchMock.mockReturnValue({});
+    await supabase.auth.signOut();
+  });
+
+  function setupDeck(opts: { is_owner?: boolean } = {}) {
+    const deck = makePublicDeck.build({ is_owner: opts.is_owner ?? true });
+    const item1 = makeCardRow.build({
+      deck_id: deck.id,
+      payload: makeItemPayload.build({
+        name: "Alpha Item",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      }),
+    });
+    const item2 = makeCardRow.build({
+      deck_id: deck.id,
+      payload: makeItemPayload.build({
+        name: "Bravo Item",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      }),
+    });
+    const spell1 = makeCardRow.build({
+      deck_id: deck.id,
+      payload: makeSpellPayload.build({
+        name: "Cantrip",
+        updatedAt: "2026-02-01T00:00:00.000Z",
+      }),
+    });
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(deck)),
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () =>
+        HttpResponse.json([item1, item2, spell1]),
+      ),
+    );
+    return { deck, item1, item2, spell1 };
+  }
+
+  it("renders All/Items/Spells filter buttons with counts", async () => {
+    setupDeck();
+    render(wrap(<DeckView deckId="d" />));
+    expect(await screen.findByRole("radio", { name: "All (3)" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Items (2)" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Spells (1)" })).toBeInTheDocument();
+  });
+
+  it("All is selected by default; default sort is Last updated", async () => {
+    setupDeck();
+    render(wrap(<DeckView deckId="d" />));
+    expect(await screen.findByRole("radio", { name: "All (3)" })).toBeChecked();
+    expect(screen.getByRole("button", { name: /sort.*last updated/i })).toBeInTheDocument();
+  });
+
+  it("default render sorts by updatedAt descending", async () => {
+    const { item1, item2, spell1 } = setupDeck();
+    render(wrap(<DeckView deckId="d" />));
+    const rows = await screen.findAllByRole("listitem");
+    const names = rows.map((li) => li.querySelector("strong")?.textContent);
+    expect(names).toEqual([item2.payload.name, spell1.payload.name, item1.payload.name]);
+  });
+
+  it("mounting at kind=spell shows only spells with the Spells filter checked", async () => {
+    const { spell1 } = setupDeck();
+    useSearchMock.mockReturnValue({ kind: "spell" });
+    render(wrap(<DeckView deckId="d" />));
+    expect(await screen.findByRole("radio", { name: "Spells (1)" })).toBeChecked();
+    const rows = screen.getAllByRole("listitem");
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.textContent).toContain(spell1.payload.name);
+  });
+
+  it("mounting at sort=name reorders by name", async () => {
+    setupDeck();
+    useSearchMock.mockReturnValue({ sort: "name" });
+    render(wrap(<DeckView deckId="d" />));
+    const rows = await screen.findAllByRole("listitem");
+    const names = rows.map((li) => li.querySelector("strong")?.textContent);
+    expect(names).toEqual(["Alpha Item", "Bravo Item", "Cantrip"]);
+  });
+
+  it("counts stay correct after filtering (counts reflect unfiltered totals)", async () => {
+    setupDeck();
+    useSearchMock.mockReturnValue({ kind: "item" });
+    render(wrap(<DeckView deckId="d" />));
+    expect(await screen.findByRole("radio", { name: "All (3)" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Items (2)" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "Spells (1)" })).toBeInTheDocument();
+  });
+
+  it("read-only deck still shows the toolbar", async () => {
+    setupDeck({ is_owner: false });
+    render(wrap(<DeckView deckId="d" />));
+    expect(await screen.findByRole("radio", { name: "All (3)" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /sort.*last updated/i })).toBeInTheDocument();
   });
 });

--- a/src/views/DeckView.test.tsx
+++ b/src/views/DeckView.test.tsx
@@ -209,4 +209,68 @@ describe("DeckView toolbar", () => {
     expect(await screen.findByRole("radio", { name: "All (3)" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /sort.*last updated/i })).toBeInTheDocument();
   });
+
+  it("clicking Items navigates with kind=item, leaving other search keys untouched", async () => {
+    setupDeck();
+    render(wrap(<DeckView deckId="d" />));
+    await userEvent.click(await screen.findByRole("radio", { name: "Items (2)" }));
+    expect(navigate).toHaveBeenCalledWith({
+      from: "/deck/$deckId",
+      search: expect.any(Function),
+    });
+    const lastCall = navigate.mock.calls[navigate.mock.calls.length - 1] as
+      | undefined
+      | [{ search: (prev: DeckSearch) => DeckSearch }];
+    const result = lastCall?.[0].search({ sort: "name" });
+    expect(result).toEqual({ kind: "item", sort: "name" });
+  });
+
+  it("clicking All navigates with kind=undefined so the URL strips the default", async () => {
+    setupDeck();
+    useSearchMock.mockReturnValue({ kind: "spell" });
+    render(wrap(<DeckView deckId="d" />));
+    await userEvent.click(await screen.findByRole("radio", { name: "All (3)" }));
+    expect(navigate).toHaveBeenCalledWith({
+      from: "/deck/$deckId",
+      search: expect.any(Function),
+    });
+    const lastCall = navigate.mock.calls[navigate.mock.calls.length - 1] as
+      | undefined
+      | [{ search: (prev: DeckSearch) => DeckSearch }];
+    const result = lastCall?.[0].search({ kind: "spell", sort: "name" });
+    expect(result).toEqual({ kind: undefined, sort: "name" });
+  });
+
+  it("selecting Name from sort menu navigates with sort=name", async () => {
+    setupDeck();
+    render(wrap(<DeckView deckId="d" />));
+    await userEvent.click(await screen.findByRole("button", { name: /sort.*last updated/i }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: "Name" }));
+    expect(navigate).toHaveBeenCalledWith({
+      from: "/deck/$deckId",
+      search: expect.any(Function),
+    });
+    const lastCall = navigate.mock.calls[navigate.mock.calls.length - 1] as
+      | undefined
+      | [{ search: (prev: DeckSearch) => DeckSearch }];
+    const result = lastCall?.[0].search({ kind: "spell" });
+    expect(result).toEqual({ kind: "spell", sort: "name" });
+  });
+
+  it("selecting Last updated from sort menu navigates with sort=undefined", async () => {
+    setupDeck();
+    useSearchMock.mockReturnValue({ sort: "name" });
+    render(wrap(<DeckView deckId="d" />));
+    await userEvent.click(await screen.findByRole("button", { name: /sort.*name/i }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: "Last updated" }));
+    expect(navigate).toHaveBeenCalledWith({
+      from: "/deck/$deckId",
+      search: expect.any(Function),
+    });
+    const lastCall = navigate.mock.calls[navigate.mock.calls.length - 1] as
+      | undefined
+      | [{ search: (prev: DeckSearch) => DeckSearch }];
+    const result = lastCall?.[0].search({ kind: "spell", sort: "name" });
+    expect(result).toEqual({ kind: "spell", sort: undefined });
+  });
 });

--- a/src/views/DeckView.test.tsx
+++ b/src/views/DeckView.test.tsx
@@ -273,4 +273,47 @@ describe("DeckView toolbar", () => {
     const result = lastCall?.[0].search({ kind: "spell", sort: "name" });
     expect(result).toEqual({ kind: "spell", sort: undefined });
   });
+
+  it("hides the toolbar when the deck has zero cards", async () => {
+    const deck = makePublicDeck.build({ is_owner: true });
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(deck)),
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json([])),
+    );
+    render(wrap(<DeckView deckId="d" />));
+    await waitFor(() => expect(screen.getByText(/no cards yet/i)).toBeInTheDocument());
+    expect(screen.queryByRole("radio", { name: /^all/i })).not.toBeInTheDocument();
+  });
+
+  it("shows 'No spells in this deck.' when the Spells filter has zero matches", async () => {
+    const deck = makePublicDeck.build({ is_owner: true });
+    const item = makeCardRow.build({
+      deck_id: deck.id,
+      payload: makeItemPayload.build({ name: "Sword" }),
+    });
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(deck)),
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json([item])),
+    );
+    useSearchMock.mockReturnValue({ kind: "spell" });
+    render(wrap(<DeckView deckId="d" />));
+    expect(await screen.findByText(/no spells in this deck/i)).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Items (1)" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Spells (0)" })).toBeInTheDocument();
+  });
+
+  it("shows 'No items in this deck.' when the Items filter has zero matches", async () => {
+    const deck = makePublicDeck.build({ is_owner: true });
+    const spell = makeCardRow.build({
+      deck_id: deck.id,
+      payload: makeSpellPayload.build({ name: "Bolt" }),
+    });
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck`, () => HttpResponse.json(deck)),
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json([spell])),
+    );
+    useSearchMock.mockReturnValue({ kind: "item" });
+    render(wrap(<DeckView deckId="d" />));
+    expect(await screen.findByText(/no items in this deck/i)).toBeInTheDocument();
+  });
 });

--- a/src/views/DeckView.tsx
+++ b/src/views/DeckView.tsx
@@ -1,6 +1,7 @@
 import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { useState } from "react";
 import { Menu, MenuItem, MenuTrigger, Popover, Button as RACButton } from "react-aria-components";
+import type { DeckSearch } from "../app/router";
 import { deckListing } from "../decks/deckListing";
 import { useDeleteCard, useRenameDeck } from "../decks/mutations";
 import { useDeck, useDeckCards } from "../decks/queries";
@@ -24,6 +25,8 @@ export function DeckView({ deckId }: Props) {
   const deleteCard = useDeleteCard();
   const search = useSearch({ from: "/deck/$deckId" });
   const navigate = useNavigate();
+  const updateSearch = (patch: Partial<DeckSearch>) =>
+    navigate({ from: "/deck/$deckId", search: (prev) => ({ ...prev, ...patch }) });
   const [browseOpen, setBrowseOpen] = useState(false);
 
   if (deckQuery.isLoading || cardsQuery.isLoading) return <LoadingState />;
@@ -77,17 +80,8 @@ export function DeckView({ deckId }: Props) {
             selectedKeys={[kind]}
             onSelectionChange={(keys) => {
               const next = Array.from(keys)[0];
-              if (next === "all") {
-                navigate({
-                  from: "/deck/$deckId",
-                  search: (prev) => ({ ...prev, kind: undefined }),
-                });
-              } else if (next === "item" || next === "spell") {
-                navigate({
-                  from: "/deck/$deckId",
-                  search: (prev) => ({ ...prev, kind: next }),
-                });
-              }
+              if (next === "all") updateSearch({ kind: undefined });
+              else if (next === "item" || next === "spell") updateSearch({ kind: next });
             }}
           >
             <ToggleButton id="all">All ({counts.all})</ToggleButton>
@@ -95,27 +89,15 @@ export function DeckView({ deckId }: Props) {
             <ToggleButton id="spell">Spells ({counts.spell})</ToggleButton>
           </ToggleButtonGroup>
           <MenuTrigger>
-            <RACButton
-              aria-label={`Sort: ${sort === "updated" ? "Last updated" : "Name"}`}
-              className={styles.sortTrigger}
-            >
+            <RACButton className={styles.sortTrigger}>
               Sort: {sort === "updated" ? "Last updated" : "Name"} <span aria-hidden="true">▾</span>
             </RACButton>
             <Popover className={styles.sortPopover} placement="bottom end">
               <Menu
                 className={styles.sortMenu}
                 onAction={(key) => {
-                  if (key === "updated") {
-                    navigate({
-                      from: "/deck/$deckId",
-                      search: (prev) => ({ ...prev, sort: undefined }),
-                    });
-                  } else if (key === "name") {
-                    navigate({
-                      from: "/deck/$deckId",
-                      search: (prev) => ({ ...prev, sort: "name" }),
-                    });
-                  }
+                  if (key === "updated") updateSearch({ sort: undefined });
+                  else if (key === "name") updateSearch({ sort: "name" });
                 }}
               >
                 <MenuItem id="updated" className={styles.sortMenuItem}>

--- a/src/views/DeckView.tsx
+++ b/src/views/DeckView.tsx
@@ -112,8 +112,16 @@ export function DeckView({ deckId }: Props) {
         </div>
       )}
 
-      {cards.length === 0 ? (
+      {rawCards.length === 0 ? (
         <p className={styles.empty}>No cards yet.</p>
+      ) : cards.length === 0 ? (
+        <p className={styles.empty}>
+          {kind === "item"
+            ? "No items in this deck."
+            : kind === "spell"
+              ? "No spells in this deck."
+              : "No cards yet."}
+        </p>
       ) : (
         <ul className={styles.list}>
           {cards.map((card) => (

--- a/src/views/DeckView.tsx
+++ b/src/views/DeckView.tsx
@@ -1,5 +1,7 @@
-import { Link } from "@tanstack/react-router";
+import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { useState } from "react";
+import { Menu, MenuItem, MenuTrigger, Popover, Button as RACButton } from "react-aria-components";
+import { deckListing } from "../decks/deckListing";
 import { useDeleteCard, useRenameDeck } from "../decks/mutations";
 import { useDeck, useDeckCards } from "../decks/queries";
 import { Button } from "../lib/ui/Button";
@@ -8,6 +10,8 @@ import { Input } from "../lib/ui/Input";
 import { PencilIcon } from "../lib/ui/icons/PencilIcon";
 import { TrashIcon } from "../lib/ui/icons/TrashIcon";
 import { LoadingState } from "../lib/ui/LoadingState";
+import { ToggleButton } from "../lib/ui/ToggleButton";
+import { ToggleButtonGroup } from "../lib/ui/ToggleButtonGroup";
 import { BrowseApiModal } from "./BrowseApiModal";
 import styles from "./DeckView.module.css";
 
@@ -18,13 +22,18 @@ export function DeckView({ deckId }: Props) {
   const cardsQuery = useDeckCards(deckId);
   const renameDeck = useRenameDeck();
   const deleteCard = useDeleteCard();
+  const search = useSearch({ from: "/deck/$deckId" });
+  const navigate = useNavigate();
   const [browseOpen, setBrowseOpen] = useState(false);
 
   if (deckQuery.isLoading || cardsQuery.isLoading) return <LoadingState />;
   if (!deckQuery.data) return <p>This deck no longer exists.</p>;
 
   const deck = deckQuery.data;
-  const cards = cardsQuery.data ?? [];
+  const rawCards = cardsQuery.data ?? [];
+  const kind = search.kind ?? "all";
+  const sort = search.sort ?? "updated";
+  const { cards, counts } = deckListing(rawCards, { kind, sort });
   const isOwner = deck.is_owner;
 
   return (
@@ -58,6 +67,68 @@ export function DeckView({ deckId }: Props) {
           )}
         </div>
       </header>
+
+      {rawCards.length > 0 && (
+        <div className={styles.toolbar}>
+          <ToggleButtonGroup
+            aria-label="Filter by kind"
+            selectionMode="single"
+            disallowEmptySelection
+            selectedKeys={[kind]}
+            onSelectionChange={(keys) => {
+              const next = Array.from(keys)[0];
+              if (next === "all") {
+                navigate({
+                  from: "/deck/$deckId",
+                  search: (prev) => ({ ...prev, kind: undefined }),
+                });
+              } else if (next === "item" || next === "spell") {
+                navigate({
+                  from: "/deck/$deckId",
+                  search: (prev) => ({ ...prev, kind: next }),
+                });
+              }
+            }}
+          >
+            <ToggleButton id="all">All ({counts.all})</ToggleButton>
+            <ToggleButton id="item">Items ({counts.item})</ToggleButton>
+            <ToggleButton id="spell">Spells ({counts.spell})</ToggleButton>
+          </ToggleButtonGroup>
+          <MenuTrigger>
+            <RACButton
+              aria-label={`Sort: ${sort === "updated" ? "Last updated" : "Name"}`}
+              className={styles.sortTrigger}
+            >
+              Sort: {sort === "updated" ? "Last updated" : "Name"} <span aria-hidden="true">▾</span>
+            </RACButton>
+            <Popover className={styles.sortPopover} placement="bottom end">
+              <Menu
+                className={styles.sortMenu}
+                onAction={(key) => {
+                  if (key === "updated") {
+                    navigate({
+                      from: "/deck/$deckId",
+                      search: (prev) => ({ ...prev, sort: undefined }),
+                    });
+                  } else if (key === "name") {
+                    navigate({
+                      from: "/deck/$deckId",
+                      search: (prev) => ({ ...prev, sort: "name" }),
+                    });
+                  }
+                }}
+              >
+                <MenuItem id="updated" className={styles.sortMenuItem}>
+                  Last updated
+                </MenuItem>
+                <MenuItem id="name" className={styles.sortMenuItem}>
+                  Name
+                </MenuItem>
+              </Menu>
+            </Popover>
+          </MenuTrigger>
+        </div>
+      )}
 
       {cards.length === 0 ? (
         <p className={styles.empty}>No cards yet.</p>


### PR DESCRIPTION
## Summary

Adds a toolbar above the deck list with:

- **Kind filter** — three buttons (All / Items / Spells) using the project's `ToggleButtonGroup`, each labeled with its count (e.g. `Items (5)`).
- **Sort dropdown** — Last updated (default, newest first) and Name (locale-aware A→Z), reusing the `MenuTrigger` + `Popover` + `Menu` pattern from `BrowseApiModal`.

State lives in the URL via TanStack Router `validateSearch`, so refresh / back / share all preserve the view.

## URL hygiene

`DeckSearch` fields are **optional** — defaults are represented by absence. The validator strips defaults from the URL on round-trip, so:

- `/deck/abc` — default state (no query string)
- `/deck/abc?kind=spell` — filter applied
- `/deck/abc?sort=name` — sort applied

Navigation writes `undefined` (not `\"all\"` / `\"updated\"`) for default values; TanStack drops `undefined` keys from the URL.

## What's where

- `src/decks/deckListing.ts` (new) — pure filter / sort / counts helper. Locale-aware name sort, deterministic tie-breaks (name → id).
- `src/app/router.tsx` — exports `validateDeckSearch` and wires it onto `deckViewRoute`. Validator is unit-tested independently because view tests mock \`useNavigate\` and don't render the real router.
- `src/views/DeckView.tsx` — reads URL state, applies the helper, renders the toolbar. Filter/sort handlers go through a small `updateSearch(patch)` helper to avoid duplicating the `navigate({ from, search: prev => ... })` boilerplate.
- `src/views/DeckView.module.css` — toolbar layout and sort-dropdown styling.

## Behavior notes

- **Ability cards** are visible only under \"All\" — they're not a UI-creatable kind today (the editor only produces item/spell, and no API mapper emits ability), but the helper handles them correctly if any ever land in a deck.
- **Empty states**: zero-card deck hides the toolbar entirely and shows the existing \"No cards yet.\" message. A non-empty deck with a filter that has zero matches keeps the toolbar visible and shows \"No items in this deck.\" / \"No spells in this deck.\" so the user can see the counts (\`Items (N)\`, \`Spells (0)\`) and pivot back to All.
- **Read-only viewers** of a shared deck get the same toolbar — filtering / sorting helps viewers too.
- **Editor round-trip** discards filter / sort: navigating into the editor from a filtered deck and saving returns to defaults. The editor route doesn't carry `kind`/`sort`, so preserving the filter would require propagating it through the editor URL. Filed as a follow-up below.

## Test plan

CI covers the bulk. To validate manually:

- Open a deck with a mix of items and spells. Verify counts.
- Click each filter button and confirm URL hygiene (`?kind=spell` appears; default URL has no query string).
- Toggle sort between Last updated and Name; confirm URL (`?sort=name` only when non-default) and list reorder.
- Reload on `/deck/<id>?kind=spell&sort=name` and confirm the view is restored.
- A deck with only items + Spells filter → \"No spells in this deck.\" with toolbar still visible.
- A deck with zero cards → toolbar hidden, \"No cards yet.\" shown.

Tests added: `deckListing` helper (11 unit tests), `validateDeckSearch` (8 unit tests), `DeckView` toolbar / interactions / empty states (~14 RTL tests).

## Known follow-ups

- **CSS dedup**: the sort-dropdown styles in `DeckView.module.css` are a near-verbatim copy of the menu styles in `BrowseApiModal.module.css` (~51 lines). Worth extracting a shared `MenuButton` primitive into `src/lib/ui/` since we now have two consumers — flagged by review, deferred to avoid scope creep here.
- **Editor preserves filter/sort**: navigations from `DeckView` into the editor (and back) currently reset the user's filter/sort selection because the editor route doesn't carry those params. Worth fixing if multi-card editing of a filtered subset becomes a common workflow.

## Spec and plan

The full design and implementation plan are checked in alongside the code:

- `docs/superpowers/specs/2026-05-13-deck-tabs-sort-design.md`
- `docs/superpowers/plans/2026-05-13-deck-tabs-sort.md`