### PR TITLE
feat(reference): add /reference/$kind/$key route for SRD detail pages

### DIFF
--- a/src/api/content-types/spells.ts
+++ b/src/api/content-types/spells.ts
@@ -1,7 +1,8 @@
 import fuzzysort from "fuzzysort";
 import { useMemo } from "react";
+import { levelLabel } from "../../lib/srd-format/spells";
 import { useSpellIndex } from "../hooks";
-import { levelTag, spellDetailToCard } from "../mappers/spells";
+import { spellDetailToCard } from "../mappers/spells";
 import type { ContentType } from "./types";
 
 export const spellsContentType: ContentType = {
@@ -19,7 +20,7 @@ export const spellsContentType: ContentType = {
       return ordered.map((entry) => ({
         key: entry.key,
         name: entry.name,
-        meta: levelTag(entry.level, entry.school.name),
+        meta: levelLabel(entry.level, entry.school.name),
         toCard: () => spellDetailToCard({ ...entry, ruleset: source }),
       }));
     }, [idx.data, query, source]);

--- a/src/api/mappers/magicItems.test.ts
+++ b/src/api/mappers/magicItems.test.ts
@@ -135,4 +135,18 @@ describe("magicItemDetailToCard", () => {
     expect(card.headerTags).toEqual(["Armor", "AC 14 + dex mod (max 2)"]);
     expect(card.footerTags).toContain("20 lb");
   });
+
+  // Open5e packs Shield +1/+2/+3 into the magic-item armor schema with low
+  // ac_base values (the +N bonus, not an absolute AC). Rendering them as
+  // "AC 2" would be misleading; the shield-shaped branch produces "+2 AC".
+  test("magic-item shield (armor.ac_base=2) renders '+2 AC' not 'AC 2'", () => {
+    const detail = magicItemDetailFactory.build({
+      name: "Shield (+2)",
+      category: { name: "Armor" },
+      armor: { ac_base: 2, ac_add_dexmod: false, ac_cap_dexmod: null },
+    });
+    const card = magicItemDetailToCard(detail);
+    expect(card.headerTags).toContain("+2 AC");
+    expect(card.headerTags).not.toContain("AC 2");
+  });
 });

--- a/src/api/mappers/magicItems.ts
+++ b/src/api/mappers/magicItems.ts
@@ -1,5 +1,6 @@
 import type { ItemCard } from "../../cards/types";
 import { newId } from "../../lib/id";
+import { acFormula, formatWeight } from "../../lib/srd-format/items";
 import { nowIso } from "../../lib/time";
 import type { MagicItemDetail } from "../endpoints/magicItems";
 
@@ -10,12 +11,7 @@ export const magicItemDetailToCard = (detail: MagicItemDetail): ItemCard => {
     headerTags.push(`${detail.weapon.damage_dice} ${detail.weapon.damage_type.name.toLowerCase()}`);
   }
   if (detail.armor) {
-    const { ac_base, ac_add_dexmod, ac_cap_dexmod } = detail.armor;
-    let ac = `AC ${ac_base}`;
-    if (ac_add_dexmod) {
-      ac += ac_cap_dexmod !== null ? ` + dex mod (max ${ac_cap_dexmod})` : " + dex mod";
-    }
-    headerTags.push(ac);
+    headerTags.push(acFormula(detail.armor));
   }
   if (detail.requires_attunement) {
     headerTags.push(
@@ -25,10 +21,8 @@ export const magicItemDetailToCard = (detail: MagicItemDetail): ItemCard => {
     );
   }
   const footerTags: string[] = [detail.rarity.name.toLowerCase()];
-  const weight = parseFloat(detail.weight);
-  if (weight > 0) {
-    footerTags.push(`${weight} ${detail.weight_unit}`);
-  }
+  const weight = formatWeight(detail.weight, detail.weight_unit);
+  if (weight) footerTags.push(weight);
   return {
     id: newId(),
     kind: "item",

--- a/src/api/mappers/mundaneItems.ts
+++ b/src/api/mappers/mundaneItems.ts
@@ -1,30 +1,14 @@
 import type { ItemCard } from "../../cards/types";
 import { newId } from "../../lib/id";
+import {
+  acFormula,
+  formatCost,
+  formatWeight,
+  isShieldArmor,
+  weaponPropertyLabel,
+} from "../../lib/srd-format/items";
 import { nowIso } from "../../lib/time";
 import type { MundaneItemDetail } from "../endpoints/mundaneItems";
-
-const formatCost = (cost: string): string | null => {
-  const gp = parseFloat(cost);
-  if (gp <= 0) return null;
-  if (gp >= 1) return `${Math.round(gp)} gp`;
-  if (gp >= 0.1) {
-    const sp = Math.round(gp * 10);
-    return sp > 0 ? `${sp} sp` : null;
-  }
-  const cp = Math.round(gp * 100);
-  return cp > 0 ? `${cp} cp` : null;
-};
-
-type WeaponPropertyEntry = {
-  property: { name: string; type: string | null };
-  detail: string | null;
-};
-
-const propertyTag = ({ property, detail }: WeaponPropertyEntry): string => {
-  if (property.type === "Mastery") return `${property.name} (Mastery)`;
-  if (detail !== null) return `${property.name} (${detail})`;
-  return property.name;
-};
 
 const capitalize = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1);
 
@@ -36,22 +20,12 @@ export const mundaneItemDetailToCard = (detail: MundaneItemDetail): ItemCard => 
     if (detail.weapon.is_simple) headerTags.push("Simple");
     else if (detail.weapon.is_martial) headerTags.push("Martial");
     headerTags.push(`${detail.weapon.damage_dice} ${detail.weapon.damage_type.name.toLowerCase()}`);
-    for (const p of detail.weapon.properties) headerTags.push(propertyTag(p));
+    for (const p of detail.weapon.properties) headerTags.push(weaponPropertyLabel(p));
   }
 
   if (detail.armor) {
-    const { ac_base, ac_add_dexmod, ac_cap_dexmod } = detail.armor;
-    // Open5e v2 srd-2024 places Shield into the armor schema with category="heavy"
-    // and ac_base=2 (the +2 bonus). Detect shield-like entries by their low ac_base
-    // (real armor starts at ac_base 11) and render as a shield bonus instead of
-    // emitting a misleading "Heavy" tier tag and "AC 2" absolute value.
-    const isShield = ac_base <= 5;
-    if (!isShield) headerTags.push(capitalize(detail.armor.category));
-    let ac = isShield ? `+${ac_base} AC` : `AC ${ac_base}`;
-    if (ac_add_dexmod) {
-      ac += ac_cap_dexmod !== null ? ` + dex mod (max ${ac_cap_dexmod})` : " + dex mod";
-    }
-    headerTags.push(ac);
+    if (!isShieldArmor(detail.armor)) headerTags.push(capitalize(detail.armor.category));
+    headerTags.push(acFormula(detail.armor));
     if (detail.armor.grants_stealth_disadvantage) headerTags.push("Stealth disadvantage");
     if (detail.armor.strength_score_required !== null) {
       headerTags.push(`Str ${detail.armor.strength_score_required}`);
@@ -61,8 +35,8 @@ export const mundaneItemDetailToCard = (detail: MundaneItemDetail): ItemCard => 
   const footerTags: string[] = [];
   const cost = formatCost(detail.cost);
   if (cost !== null) footerTags.push(cost);
-  const weight = parseFloat(detail.weight);
-  if (weight > 0) footerTags.push(`${weight} ${detail.weight_unit}`);
+  const weight = formatWeight(detail.weight, detail.weight_unit);
+  if (weight !== null) footerTags.push(weight);
 
   return {
     id: newId(),

--- a/src/api/mappers/spells.ts
+++ b/src/api/mappers/spells.ts
@@ -6,14 +6,10 @@ import {
   componentsLabel,
   durationLabel,
   levelLabel,
+  spellBodyMarkdown,
 } from "../../lib/srd-format/spells";
 import { nowIso } from "../../lib/time";
 import type { SpellDetail } from "../endpoints/spells";
-
-const buildBody = (desc: string, higherLevel: string): string => {
-  if (higherLevel.trim() === "") return desc;
-  return `${desc}\n\n***At Higher Levels.*** ${higherLevel}`;
-};
 
 export const spellDetailToCard = (detail: SpellDetail): SpellCard => {
   const now = nowIso();
@@ -37,7 +33,7 @@ export const spellDetailToCard = (detail: SpellDetail): SpellCard => {
     kind: "spell",
     name: detail.name,
     headerTags,
-    body: buildBody(detail.desc, detail.higher_level),
+    body: spellBodyMarkdown(detail.desc, detail.higher_level),
     footerTags,
     source: "api",
     apiRef: { system: "open5e", slug: detail.key, ruleset: detail.ruleset },

--- a/src/api/mappers/spells.ts
+++ b/src/api/mappers/spells.ts
@@ -1,81 +1,16 @@
 import type { SpellCard } from "../../cards/types";
 import { newId } from "../../lib/id";
+import {
+  castingTimeLabel,
+  classesLabel,
+  componentsLabel,
+  durationLabel,
+  levelLabel,
+} from "../../lib/srd-format/spells";
 import { nowIso } from "../../lib/time";
 import type { SpellDetail } from "../endpoints/spells";
 
-const ordinal = (n: number): string => {
-  if (n === 1) return "1st";
-  if (n === 2) return "2nd";
-  if (n === 3) return "3rd";
-  return `${n}th`;
-};
-
-export const levelTag = (level: number, schoolName: string): string => {
-  if (level === 0) {
-    const cap = schoolName.charAt(0).toUpperCase() + schoolName.slice(1).toLowerCase();
-    return `${cap} cantrip`;
-  }
-  return `${ordinal(level)}-level ${schoolName.toLowerCase()}`;
-};
-
-// 2014 SRD packs the count into casting_time (e.g. "10minutes"); 2024 strips it
-// (e.g. just "minute"). Parse out a quantity if present, otherwise default to 1.
-const CONCATENATED_CASTING = /^(\d+)(minute|hour|day|round|turn)s?$/i;
-
-const castingTimeTag = (castingTime: string, ritual: boolean): string => {
-  let qty = 1;
-  let unit: string;
-  const m = CONCATENATED_CASTING.exec(castingTime);
-  if (m) {
-    qty = Number(m[1]);
-    unit = (m[2] as string).toLowerCase();
-  } else if (castingTime === "bonus-action") {
-    unit = "bonus action";
-  } else {
-    unit = castingTime;
-  }
-  const word = qty === 1 ? unit : `${unit}s`;
-  const base = `${qty} ${word}`;
-  return ritual ? `${base} (ritual)` : base;
-};
-
-// 2024 returns singular units (e.g. "10 minute"); 2014 returns plural ("10 minutes").
-const QUANTIFIED_DURATION = /^(\d+)\s+(minute|hour|day|round|turn)s?$/i;
-
-const formatDuration = (duration: string): string => {
-  const trimmed = duration.trim();
-  if (trimmed === "") return "";
-  const match = QUANTIFIED_DURATION.exec(trimmed);
-  if (match) {
-    const qty = match[1] as string;
-    const unit = match[2] as string;
-    const n = Number(qty);
-    const pluralized = n === 1 ? unit.toLowerCase() : `${unit.toLowerCase()}s`;
-    return `${qty} ${pluralized}`;
-  }
-  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
-};
-
-const durationTag = (duration: string, concentration: boolean): string => {
-  const formatted = formatDuration(duration);
-  if (!concentration) return formatted;
-  if (formatted === "") return "Concentration";
-  return `Concentration, up to ${formatted.toLowerCase()}`;
-};
-
-const componentsTag = (verbal: boolean, somatic: boolean, material: boolean): string => {
-  const pieces: string[] = [];
-  if (verbal) pieces.push("V");
-  if (somatic) pieces.push("S");
-  if (material) pieces.push("M");
-  return pieces.join(", ");
-};
-
-const classesTag = (classes: { name: string }[]): string =>
-  classes
-    .map((c) => c.name)
-    .sort((a, b) => a.localeCompare(b))
-    .join(", ");
+export { levelLabel as levelTag } from "../../lib/srd-format/spells";
 
 const buildBody = (desc: string, higherLevel: string): string => {
   if (higherLevel.trim() === "") return desc;
@@ -85,15 +20,20 @@ const buildBody = (desc: string, higherLevel: string): string => {
 export const spellDetailToCard = (detail: SpellDetail): SpellCard => {
   const now = nowIso();
   const headerTags: string[] = [
-    levelTag(detail.level, detail.school.name),
-    castingTimeTag(detail.casting_time, detail.ritual),
+    levelLabel(detail.level, detail.school.name),
+    castingTimeLabel(detail.casting_time, detail.ritual),
     detail.range_text,
-    durationTag(detail.duration, detail.concentration),
-  ].filter((t) => t !== ""); // duration may be "" on some 2024 spells
+    durationLabel(detail.duration, detail.concentration),
+  ].filter((t) => t !== "");
   const footerTags: string[] = [
-    componentsTag(detail.verbal, detail.somatic, detail.material),
-    classesTag(detail.classes),
-  ].filter((t) => t !== ""); // some spells have no V/S/M components, or empty classes (e.g. 2014 Branding Smite)
+    componentsLabel({
+      verbal: detail.verbal,
+      somatic: detail.somatic,
+      material: detail.material,
+      // Intentionally do NOT pass materialSpecified — card footer stays compact.
+    }),
+    classesLabel(detail.classes),
+  ].filter((t) => t !== "");
   return {
     id: newId(),
     kind: "spell",

--- a/src/api/mappers/spells.ts
+++ b/src/api/mappers/spells.ts
@@ -10,8 +10,6 @@ import {
 import { nowIso } from "../../lib/time";
 import type { SpellDetail } from "../endpoints/spells";
 
-export { levelLabel as levelTag } from "../../lib/srd-format/spells";
-
 const buildBody = (desc: string, higherLevel: string): string => {
   if (higherLevel.trim() === "") return desc;
   return `${desc}\n\n***At Higher Levels.*** ${higherLevel}`;

--- a/src/app/ReferenceShell.module.css
+++ b/src/app/ReferenceShell.module.css
@@ -33,5 +33,4 @@
   max-width: 65ch;
   width: 100%;
   margin: 0 auto;
-  font-size: var(--fs-md);
 }

--- a/src/app/ReferenceShell.module.css
+++ b/src/app/ReferenceShell.module.css
@@ -20,6 +20,12 @@
   text-decoration: none;
   letter-spacing: 0.02em;
   border-radius: var(--radius-sm);
+  /* QR scanners land on a phone, one-handed, often in dim light. Give the
+     header's only tap target a 44px hit area per iOS HIG / WCAG 2.5.5. */
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0 var(--space-2);
 }
 
 .brand:focus-visible {

--- a/src/app/ReferenceShell.module.css
+++ b/src/app/ReferenceShell.module.css
@@ -1,0 +1,37 @@
+.shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  padding: var(--space-3) var(--space-4);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.brand {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: var(--fs-lg);
+  color: var(--color-text);
+  text-decoration: none;
+  letter-spacing: 0.02em;
+  border-radius: var(--radius-sm);
+}
+
+.brand:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.main {
+  flex: 1;
+  padding: var(--space-4);
+  max-width: 65ch;
+  width: 100%;
+  margin: 0 auto;
+  font-size: var(--fs-md);
+}

--- a/src/app/ReferenceShell.test.tsx
+++ b/src/app/ReferenceShell.test.tsx
@@ -10,11 +10,15 @@ import { describe, expect, test } from "vitest";
 import { ReferenceShell } from "./ReferenceShell";
 
 function renderInRouter() {
-  const rootRoute = createRootRoute({ component: ReferenceShell });
+  const rootRoute = createRootRoute();
   const childRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/",
-    component: () => <p>child</p>,
+    component: () => (
+      <ReferenceShell>
+        <p>child</p>
+      </ReferenceShell>
+    ),
   });
   const router = createRouter({
     routeTree: rootRoute.addChildren([childRoute]),
@@ -30,7 +34,7 @@ describe("ReferenceShell", () => {
     expect(link).toHaveAttribute("href", "/");
   });
 
-  test("renders the child route via <Outlet/>", async () => {
+  test("renders the children", async () => {
     renderInRouter();
     expect(await screen.findByText("child")).toBeInTheDocument();
   });

--- a/src/app/ReferenceShell.test.tsx
+++ b/src/app/ReferenceShell.test.tsx
@@ -1,0 +1,44 @@
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { ReferenceShell } from "./ReferenceShell";
+
+function renderInRouter() {
+  const rootRoute = createRootRoute({ component: ReferenceShell });
+  const childRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/",
+    component: () => <p>child</p>,
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([childRoute]),
+    history: createMemoryHistory({ initialEntries: ["/"] }),
+  });
+  return render(<RouterProvider router={router} />);
+}
+
+describe("ReferenceShell", () => {
+  test("renders the Deckwright brand link", async () => {
+    renderInRouter();
+    const link = await screen.findByRole("link", { name: "Deckwright" });
+    expect(link).toHaveAttribute("href", "/");
+  });
+
+  test("renders the child route via <Outlet/>", async () => {
+    renderInRouter();
+    expect(await screen.findByText("child")).toBeInTheDocument();
+  });
+
+  test("does not render a user menu or footer", async () => {
+    renderInRouter();
+    await screen.findByText("child");
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.queryByRole("contentinfo")).toBeNull();
+  });
+});

--- a/src/app/ReferenceShell.tsx
+++ b/src/app/ReferenceShell.tsx
@@ -1,7 +1,8 @@
-import { Link, Outlet } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
+import type { ReactNode } from "react";
 import styles from "./ReferenceShell.module.css";
 
-export function ReferenceShell() {
+export function ReferenceShell({ children }: { children: ReactNode }) {
   return (
     <div className={styles.shell}>
       <header className={styles.header}>
@@ -9,9 +10,7 @@ export function ReferenceShell() {
           Deckwright
         </Link>
       </header>
-      <main className={styles.main}>
-        <Outlet />
-      </main>
+      <main className={styles.main}>{children}</main>
     </div>
   );
 }

--- a/src/app/ReferenceShell.tsx
+++ b/src/app/ReferenceShell.tsx
@@ -1,0 +1,17 @@
+import { Link, Outlet } from "@tanstack/react-router";
+import styles from "./ReferenceShell.module.css";
+
+export function ReferenceShell() {
+  return (
+    <div className={styles.shell}>
+      <header className={styles.header}>
+        <Link to="/" className={styles.brand}>
+          Deckwright
+        </Link>
+      </header>
+      <main className={styles.main}>
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/src/app/Root.test.tsx
+++ b/src/app/Root.test.tsx
@@ -31,7 +31,9 @@ function renderRoot() {
   return render(
     <QueryClientProvider client={client}>
       <SessionContext.Provider value={loadingSession}>
-        <Root />
+        <Root>
+          <p>child</p>
+        </Root>
       </SessionContext.Provider>
     </QueryClientProvider>,
   );

--- a/src/app/Root.tsx
+++ b/src/app/Root.tsx
@@ -1,11 +1,12 @@
-import { Link, Outlet } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
+import type { ReactNode } from "react";
 import { Announcement, AnnouncementProvider } from "../lib/ui/Announcement";
 import { UserMenu } from "../lib/ui/UserMenu";
 import { DeckBreadcrumb } from "./DeckBreadcrumb";
 import { Footer } from "./Footer";
 import styles from "./root.module.css";
 
-export function Root() {
+export function Root({ children }: { children: ReactNode }) {
   return (
     <AnnouncementProvider>
       <div className={styles.shell}>
@@ -27,7 +28,7 @@ export function Root() {
         </header>
         <main className={styles.main}>
           <Announcement />
-          <Outlet />
+          {children}
         </main>
         <Footer />
       </div>

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,4 +1,10 @@
-import { createRootRoute, createRoute, createRouter, RouterProvider } from "@tanstack/react-router";
+import {
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
 import { AuthCallback } from "../auth/AuthCallback";
 import { LoginView } from "../auth/LoginView";
 import { RequireOwner } from "../auth/RequireOwner";
@@ -7,18 +13,34 @@ import { EditorView } from "../views/EditorView";
 import { HomeView } from "../views/HomeView";
 import { IconDebugView } from "../views/IconDebugView";
 import { PrintView } from "../views/PrintView";
+import { type ReferenceKind, ReferenceView } from "../views/ReferenceView";
+import { ReferenceShell } from "./ReferenceShell";
 import { Root } from "./Root";
 
-const rootRoute = createRootRoute({ component: Root });
+const rootRoute = createRootRoute({
+  component: () => <Outlet />,
+});
+
+const appLayoutRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  id: "app",
+  component: Root,
+});
+
+const referenceLayoutRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  id: "reference",
+  component: ReferenceShell,
+});
 
 const homeRoute = createRoute({
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => appLayoutRoute,
   path: "/",
   component: HomeView,
 });
 
 const deckViewRoute = createRoute({
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => appLayoutRoute,
   path: "/deck/$deckId",
   component: function DeckViewRoute() {
     const { deckId } = deckViewRoute.useParams();
@@ -27,7 +49,7 @@ const deckViewRoute = createRoute({
 });
 
 const editorRoute = createRoute({
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => appLayoutRoute,
   path: "/deck/$deckId/edit/$cardId",
   component: function EditorRoute() {
     const { deckId, cardId } = editorRoute.useParams();
@@ -40,7 +62,7 @@ const editorRoute = createRoute({
 });
 
 const printRoute = createRoute({
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => appLayoutRoute,
   path: "/deck/$deckId/print",
   component: function PrintRoute() {
     const { deckId } = printRoute.useParams();
@@ -49,31 +71,43 @@ const printRoute = createRoute({
 });
 
 const loginRoute = createRoute({
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => appLayoutRoute,
   path: "/login",
   component: LoginView,
 });
 
 const authCallbackRoute = createRoute({
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => appLayoutRoute,
   path: "/auth/callback",
   component: AuthCallback,
 });
 
 const iconDebugRoute = createRoute({
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => appLayoutRoute,
   path: "/debug/icons",
   component: IconDebugView,
 });
 
+const referenceDetailRoute = createRoute({
+  getParentRoute: () => referenceLayoutRoute,
+  path: "/reference/$kind/$key",
+  component: function ReferenceDetailRoute() {
+    const { kind, key } = referenceDetailRoute.useParams();
+    return <ReferenceView kind={kind as ReferenceKind} cardKey={key} />;
+  },
+});
+
 const routeTree = rootRoute.addChildren([
-  homeRoute,
-  deckViewRoute,
-  editorRoute,
-  printRoute,
-  loginRoute,
-  authCallbackRoute,
-  iconDebugRoute,
+  appLayoutRoute.addChildren([
+    homeRoute,
+    deckViewRoute,
+    editorRoute,
+    printRoute,
+    loginRoute,
+    authCallbackRoute,
+    iconDebugRoute,
+  ]),
+  referenceLayoutRoute.addChildren([referenceDetailRoute]),
 ]);
 
 export const router = createRouter({ routeTree });

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,10 +1,4 @@
-import {
-  createRootRoute,
-  createRoute,
-  createRouter,
-  Outlet,
-  RouterProvider,
-} from "@tanstack/react-router";
+import { createRootRoute, createRoute, createRouter, RouterProvider } from "@tanstack/react-router";
 import { AuthCallback } from "../auth/AuthCallback";
 import { LoginView } from "../auth/LoginView";
 import { RequireOwner } from "../auth/RequireOwner";
@@ -17,21 +11,7 @@ import { type ReferenceKind, ReferenceView } from "../views/ReferenceView";
 import { ReferenceShell } from "./ReferenceShell";
 import { Root } from "./Root";
 
-const rootRoute = createRootRoute({
-  component: () => <Outlet />,
-});
-
-const appLayoutRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  id: "app",
-  component: Root,
-});
-
-const referenceLayoutRoute = createRoute({
-  getParentRoute: () => rootRoute,
-  id: "reference",
-  component: ReferenceShell,
-});
+const rootRoute = createRootRoute();
 
 export type DeckSearch = {
   kind?: "item" | "spell";
@@ -46,81 +26,117 @@ export function validateDeckSearch(raw: Record<string, unknown>): DeckSearch {
 }
 
 const homeRoute = createRoute({
-  getParentRoute: () => appLayoutRoute,
+  getParentRoute: () => rootRoute,
   path: "/",
-  component: HomeView,
+  component: function HomeRoute() {
+    return (
+      <Root>
+        <HomeView />
+      </Root>
+    );
+  },
 });
 
 const deckViewRoute = createRoute({
-  getParentRoute: () => appLayoutRoute,
+  getParentRoute: () => rootRoute,
   path: "/deck/$deckId",
   validateSearch: validateDeckSearch,
   component: function DeckViewRoute() {
     const { deckId } = deckViewRoute.useParams();
-    return <DeckView deckId={deckId} />;
+    return (
+      <Root>
+        <DeckView deckId={deckId} />
+      </Root>
+    );
   },
 });
 
 const editorRoute = createRoute({
-  getParentRoute: () => appLayoutRoute,
+  getParentRoute: () => rootRoute,
   path: "/deck/$deckId/edit/$cardId",
   component: function EditorRoute() {
     const { deckId, cardId } = editorRoute.useParams();
     return (
-      <RequireOwner deckId={deckId}>
-        <EditorView deckId={deckId} cardId={cardId} />
-      </RequireOwner>
+      <Root>
+        <RequireOwner deckId={deckId}>
+          <EditorView deckId={deckId} cardId={cardId} />
+        </RequireOwner>
+      </Root>
     );
   },
 });
 
 const printRoute = createRoute({
-  getParentRoute: () => appLayoutRoute,
+  getParentRoute: () => rootRoute,
   path: "/deck/$deckId/print",
   component: function PrintRoute() {
     const { deckId } = printRoute.useParams();
-    return <PrintView deckId={deckId} />;
+    return (
+      <Root>
+        <PrintView deckId={deckId} />
+      </Root>
+    );
   },
 });
 
 const loginRoute = createRoute({
-  getParentRoute: () => appLayoutRoute,
+  getParentRoute: () => rootRoute,
   path: "/login",
-  component: LoginView,
+  component: function LoginRoute() {
+    return (
+      <Root>
+        <LoginView />
+      </Root>
+    );
+  },
 });
 
 const authCallbackRoute = createRoute({
-  getParentRoute: () => appLayoutRoute,
+  getParentRoute: () => rootRoute,
   path: "/auth/callback",
-  component: AuthCallback,
+  component: function AuthCallbackRoute() {
+    return (
+      <Root>
+        <AuthCallback />
+      </Root>
+    );
+  },
 });
 
 const iconDebugRoute = createRoute({
-  getParentRoute: () => appLayoutRoute,
+  getParentRoute: () => rootRoute,
   path: "/debug/icons",
-  component: IconDebugView,
+  component: function IconDebugRoute() {
+    return (
+      <Root>
+        <IconDebugView />
+      </Root>
+    );
+  },
 });
 
 const referenceDetailRoute = createRoute({
-  getParentRoute: () => referenceLayoutRoute,
+  getParentRoute: () => rootRoute,
   path: "/reference/$kind/$key",
   component: function ReferenceDetailRoute() {
     const { kind, key } = referenceDetailRoute.useParams();
-    return <ReferenceView kind={kind as ReferenceKind} cardKey={key} />;
+    return (
+      <ReferenceShell>
+        <ReferenceView kind={kind as ReferenceKind} cardKey={key} />
+      </ReferenceShell>
+    );
   },
 });
 
 const routeTree = rootRoute.addChildren([
-  appLayoutRoute.addChildren([
-    homeRoute,
-    deckViewRoute,
-    editorRoute,
-    printRoute,
-    loginRoute,
-    authCallbackRoute,
-    iconDebugRoute,
-  ]),
-  referenceLayoutRoute.addChildren([referenceDetailRoute]),
+  homeRoute,
+  deckViewRoute,
+  editorRoute,
+  printRoute,
+  loginRoute,
+  authCallbackRoute,
+  iconDebugRoute,
+  referenceDetailRoute,
 ]);
 
 export const router = createRouter({ routeTree });

--- a/src/lib/srd-format/items.test.ts
+++ b/src/lib/srd-format/items.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "vitest";
+import {
+  acFormula,
+  attunementLine,
+  formatCost,
+  formatWeight,
+  isShieldArmor,
+  weaponPropertyLabel,
+} from "./items";
+
+describe("formatCost", () => {
+  test.each([
+    ["10.00", "10 gp"],
+    ["1.00", "1 gp"],
+    ["400.00", "400 gp"],
+    ["0.50", "5 sp"],
+    ["0.40", "4 sp"],
+    ["0.10", "1 sp"],
+    ["0.05", "5 cp"],
+    ["0.04", "4 cp"],
+    ["0.01", "1 cp"],
+  ] as const)("'%s' → '%s'", (input, expected) => {
+    expect(formatCost(input)).toBe(expected);
+  });
+  test("'0.00' → null", () => {
+    expect(formatCost("0.00")).toBeNull();
+  });
+});
+
+describe("formatWeight", () => {
+  test("non-zero numeric weight → '<n> <unit>' with trailing zeros stripped", () => {
+    expect(formatWeight("7.000", "lb")).toBe("7 lb");
+    expect(formatWeight("1.5", "lb")).toBe("1.5 lb");
+  });
+  test("'0.000' → null", () => {
+    expect(formatWeight("0.000", "lb")).toBeNull();
+  });
+  test("'0' → null", () => {
+    expect(formatWeight("0", "lb")).toBeNull();
+  });
+});
+
+describe("isShieldArmor", () => {
+  test("ac_base <= 5 is treated as shield (Open5e quirk)", () => {
+    expect(isShieldArmor({ ac_base: 2 })).toBe(true);
+    expect(isShieldArmor({ ac_base: 5 })).toBe(true);
+  });
+  test("ac_base >= 6 is real armor", () => {
+    expect(isShieldArmor({ ac_base: 6 })).toBe(false);
+    expect(isShieldArmor({ ac_base: 18 })).toBe(false);
+  });
+});
+
+describe("acFormula", () => {
+  test("heavy: no dex bonus → 'AC X'", () => {
+    expect(acFormula({ ac_base: 18, ac_add_dexmod: false, ac_cap_dexmod: null })).toBe("AC 18");
+  });
+  test("medium: dex bonus capped → 'AC X + dex mod (max N)'", () => {
+    expect(acFormula({ ac_base: 14, ac_add_dexmod: true, ac_cap_dexmod: 2 })).toBe(
+      "AC 14 + dex mod (max 2)",
+    );
+  });
+  test("light: uncapped dex → 'AC X + dex mod'", () => {
+    expect(acFormula({ ac_base: 11, ac_add_dexmod: true, ac_cap_dexmod: null })).toBe(
+      "AC 11 + dex mod",
+    );
+  });
+  test("dex add false ignores cap silently", () => {
+    expect(acFormula({ ac_base: 16, ac_add_dexmod: false, ac_cap_dexmod: 2 })).toBe("AC 16");
+  });
+  test("shield form: '+N AC' when ac_base <= 5", () => {
+    expect(acFormula({ ac_base: 2, ac_add_dexmod: false, ac_cap_dexmod: null })).toBe("+2 AC");
+    expect(acFormula({ ac_base: 5, ac_add_dexmod: false, ac_cap_dexmod: null })).toBe("+5 AC");
+  });
+});
+
+describe("attunementLine", () => {
+  test("requires=false → null (caller omits the stat line entirely)", () => {
+    expect(attunementLine({ requires_attunement: false, attunement_detail: null })).toBeNull();
+    expect(
+      attunementLine({ requires_attunement: false, attunement_detail: "should be ignored" }),
+    ).toBeNull();
+  });
+  test("requires=true, no detail → 'Requires attunement'", () => {
+    expect(attunementLine({ requires_attunement: true, attunement_detail: null })).toBe(
+      "Requires attunement",
+    );
+    expect(attunementLine({ requires_attunement: true, attunement_detail: "" })).toBe(
+      "Requires attunement",
+    );
+  });
+  test("requires=true with detail → 'Requires attunement <detail>'", () => {
+    expect(
+      attunementLine({
+        requires_attunement: true,
+        attunement_detail: "by a spellcaster",
+      }),
+    ).toBe("Requires attunement by a spellcaster");
+  });
+});
+
+describe("weaponPropertyLabel", () => {
+  test("name only → 'Name'", () => {
+    expect(weaponPropertyLabel({ property: { name: "Finesse", type: null }, detail: null })).toBe(
+      "Finesse",
+    );
+  });
+  test("name + detail → 'Name (detail)'", () => {
+    expect(
+      weaponPropertyLabel({ property: { name: "Versatile", type: null }, detail: "1d10" }),
+    ).toBe("Versatile (1d10)");
+  });
+  test("type='Mastery' → 'Name (Mastery)' regardless of detail", () => {
+    expect(
+      weaponPropertyLabel({ property: { name: "Cleave", type: "Mastery" }, detail: null }),
+    ).toBe("Cleave (Mastery)");
+  });
+});

--- a/src/lib/srd-format/items.ts
+++ b/src/lib/srd-format/items.ts
@@ -1,0 +1,61 @@
+export const formatCost = (cost: string): string | null => {
+  const gp = parseFloat(cost);
+  if (gp <= 0) return null;
+  if (gp >= 1) return `${Math.round(gp)} gp`;
+  if (gp >= 0.1) {
+    const sp = Math.round(gp * 10);
+    return sp > 0 ? `${sp} sp` : null;
+  }
+  const cp = Math.round(gp * 100);
+  return cp > 0 ? `${cp} cp` : null;
+};
+
+export const formatWeight = (weight: string, unit: string): string | null => {
+  const n = parseFloat(weight);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  const trimmed = n.toString();
+  return `${trimmed} ${unit}`;
+};
+
+export type ArmorInput = {
+  ac_base: number;
+  ac_add_dexmod: boolean;
+  ac_cap_dexmod: number | null;
+};
+
+// Open5e v2 srd-2024 places Shield into the armor schema with category="heavy"
+// and ac_base=2 (the +2 bonus). Real armor starts at ac_base 11; ac_base<=5 is
+// a shield-shaped record.
+export const isShieldArmor = (armor: Pick<ArmorInput, "ac_base">): boolean => armor.ac_base <= 5;
+
+export const acFormula = (armor: ArmorInput): string => {
+  if (isShieldArmor(armor)) return `+${armor.ac_base} AC`;
+  let ac = `AC ${armor.ac_base}`;
+  if (armor.ac_add_dexmod) {
+    ac += armor.ac_cap_dexmod !== null ? ` + dex mod (max ${armor.ac_cap_dexmod})` : " + dex mod";
+  }
+  return ac;
+};
+
+export type AttunementInput = {
+  requires_attunement: boolean;
+  attunement_detail: string | null;
+};
+
+export const attunementLine = (input: AttunementInput): string | null => {
+  if (!input.requires_attunement) return null;
+  const detail = input.attunement_detail?.trim();
+  if (!detail) return "Requires attunement";
+  return `Requires attunement ${detail}`;
+};
+
+export type WeaponPropertyEntry = {
+  property: { name: string; type: string | null };
+  detail: string | null;
+};
+
+export const weaponPropertyLabel = ({ property, detail }: WeaponPropertyEntry): string => {
+  if (property.type === "Mastery") return `${property.name} (Mastery)`;
+  if (detail !== null) return `${property.name} (${detail})`;
+  return property.name;
+};

--- a/src/lib/srd-format/items.ts
+++ b/src/lib/srd-format/items.ts
@@ -13,6 +13,7 @@ export const formatCost = (cost: string): string | null => {
 export const formatWeight = (weight: string, unit: string): string | null => {
   const n = parseFloat(weight);
   if (!Number.isFinite(n) || n <= 0) return null;
+  // Strip trailing zeros: "7.000" → "7", "1.5" → "1.5".
   const trimmed = n.toString();
   return `${trimmed} ${unit}`;
 };

--- a/src/lib/srd-format/spells.test.ts
+++ b/src/lib/srd-format/spells.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "vitest";
+import {
+  castingTimeLabel,
+  classesLabel,
+  componentsLabel,
+  durationLabel,
+  levelLabel,
+} from "./spells";
+
+describe("levelLabel", () => {
+  test("level 0 → 'School cantrip' (capitalized)", () => {
+    expect(levelLabel(0, "divination")).toBe("Divination cantrip");
+  });
+  test("level 1 → '1st-level school'", () => {
+    expect(levelLabel(1, "Evocation")).toBe("1st-level evocation");
+  });
+  test("level 2 → '2nd-level …'", () => {
+    expect(levelLabel(2, "evocation")).toBe("2nd-level evocation");
+  });
+  test("level 3 → '3rd-level …'", () => {
+    expect(levelLabel(3, "evocation")).toBe("3rd-level evocation");
+  });
+  test.each([4, 5, 6, 7, 8, 9] as const)("level %i → 'Nth-level …'", (n) => {
+    expect(levelLabel(n, "evocation")).toBe(`${n}th-level evocation`);
+  });
+});
+
+describe("castingTimeLabel", () => {
+  test.each([
+    ["action", "1 action"],
+    ["bonus-action", "1 bonus action"],
+    ["reaction", "1 reaction"],
+    ["minute", "1 minute"],
+    ["hour", "1 hour"],
+  ] as const)("2024 form %s → %s", (input, expected) => {
+    expect(castingTimeLabel(input, false)).toBe(expected);
+  });
+  test.each([
+    ["1minute", "1 minute"],
+    ["10minutes", "10 minutes"],
+    ["1hour", "1 hour"],
+    ["8hours", "8 hours"],
+  ] as const)("2014 concatenated %s → %s", (input, expected) => {
+    expect(castingTimeLabel(input, false)).toBe(expected);
+  });
+  test("ritual=true appends ' (ritual)'", () => {
+    expect(castingTimeLabel("action", true)).toBe("1 action (ritual)");
+    expect(castingTimeLabel("10minutes", true)).toBe("10 minutes (ritual)");
+  });
+});
+
+describe("durationLabel", () => {
+  test("'instantaneous' is capitalized", () => {
+    expect(durationLabel("instantaneous", false)).toBe("Instantaneous");
+  });
+  test("'10 minute' (2024 singular) → '10 minutes'", () => {
+    expect(durationLabel("10 minute", false)).toBe("10 minutes");
+  });
+  test("'10 minutes' (2014 plural) stays '10 minutes'", () => {
+    expect(durationLabel("10 minutes", false)).toBe("10 minutes");
+  });
+  test("'1 minute' stays singular", () => {
+    expect(durationLabel("1 minute", false)).toBe("1 minute");
+  });
+  test("'until dispelled' is capitalized", () => {
+    expect(durationLabel("until dispelled", false)).toBe("Until dispelled");
+  });
+  test("empty duration with concentration → 'Concentration'", () => {
+    expect(durationLabel("", true)).toBe("Concentration");
+  });
+  test("empty duration without concentration → ''", () => {
+    expect(durationLabel("", false)).toBe("");
+  });
+  test("concentration prefixes the duration", () => {
+    expect(durationLabel("1 minute", true)).toBe("Concentration, up to 1 minute");
+  });
+  test("concentration with quantified plural", () => {
+    expect(durationLabel("10 minute", true)).toBe("Concentration, up to 10 minutes");
+  });
+});
+
+describe("componentsLabel", () => {
+  test("V/S/M all true → 'V, S, M'", () => {
+    expect(componentsLabel({ verbal: true, somatic: true, material: true })).toBe("V, S, M");
+  });
+  test("V only", () => {
+    expect(componentsLabel({ verbal: true, somatic: false, material: false })).toBe("V");
+  });
+  test("all false → empty string", () => {
+    expect(componentsLabel({ verbal: false, somatic: false, material: false })).toBe("");
+  });
+  test("material with materialSpecified appends in parens", () => {
+    expect(
+      componentsLabel({
+        verbal: true,
+        somatic: true,
+        material: true,
+        materialSpecified: "a tiny ball of bat guano and sulfur",
+      }),
+    ).toBe("V, S, M (a tiny ball of bat guano and sulfur)");
+  });
+  test("material false with materialSpecified ignores the spec", () => {
+    expect(
+      componentsLabel({
+        verbal: true,
+        somatic: false,
+        material: false,
+        materialSpecified: "should be ignored",
+      }),
+    ).toBe("V");
+  });
+  test("material true with empty materialSpecified renders 'M' only", () => {
+    expect(
+      componentsLabel({ verbal: true, somatic: false, material: true, materialSpecified: "" }),
+    ).toBe("V, M");
+  });
+});
+
+describe("classesLabel", () => {
+  test("alphabetizes class names", () => {
+    expect(classesLabel([{ name: "Wizard" }, { name: "Sorcerer" }])).toBe("Sorcerer, Wizard");
+  });
+  test("single class", () => {
+    expect(classesLabel([{ name: "Cleric" }])).toBe("Cleric");
+  });
+  test("empty → ''", () => {
+    expect(classesLabel([])).toBe("");
+  });
+});

--- a/src/lib/srd-format/spells.ts
+++ b/src/lib/srd-format/spells.ts
@@ -83,3 +83,8 @@ export const classesLabel = (classes: { name: string }[]): string =>
     .map((c) => c.name)
     .sort((a, b) => a.localeCompare(b))
     .join(", ");
+
+export const spellBodyMarkdown = (desc: string, higherLevel: string): string => {
+  if (higherLevel.trim() === "") return desc;
+  return `${desc}\n\n***At Higher Levels.*** ${higherLevel}`;
+};

--- a/src/lib/srd-format/spells.ts
+++ b/src/lib/srd-format/spells.ts
@@ -1,0 +1,82 @@
+const ordinal = (n: number): string => {
+  if (n === 1) return "1st";
+  if (n === 2) return "2nd";
+  if (n === 3) return "3rd";
+  return `${n}th`;
+};
+
+export const levelLabel = (level: number, schoolName: string): string => {
+  if (level === 0) {
+    const cap = schoolName.charAt(0).toUpperCase() + schoolName.slice(1).toLowerCase();
+    return `${cap} cantrip`;
+  }
+  return `${ordinal(level)}-level ${schoolName.toLowerCase()}`;
+};
+
+const CONCATENATED_CASTING = /^(\d+)(minute|hour|day|round|turn)s?$/i;
+
+export const castingTimeLabel = (castingTime: string, ritual: boolean): string => {
+  let qty = 1;
+  let unit: string;
+  const m = CONCATENATED_CASTING.exec(castingTime);
+  if (m) {
+    qty = Number(m[1]);
+    unit = (m[2] as string).toLowerCase();
+  } else if (castingTime === "bonus-action") {
+    unit = "bonus action";
+  } else {
+    unit = castingTime;
+  }
+  const word = qty === 1 ? unit : `${unit}s`;
+  const base = `${qty} ${word}`;
+  return ritual ? `${base} (ritual)` : base;
+};
+
+const QUANTIFIED_DURATION = /^(\d+)\s+(minute|hour|day|round|turn)s?$/i;
+
+const formatDuration = (duration: string): string => {
+  const trimmed = duration.trim();
+  if (trimmed === "") return "";
+  const match = QUANTIFIED_DURATION.exec(trimmed);
+  if (match) {
+    const qty = match[1] as string;
+    const unit = match[2] as string;
+    const n = Number(qty);
+    const pluralized = n === 1 ? unit.toLowerCase() : `${unit.toLowerCase()}s`;
+    return `${qty} ${pluralized}`;
+  }
+  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
+};
+
+export const durationLabel = (duration: string, concentration: boolean): string => {
+  const formatted = formatDuration(duration);
+  if (!concentration) return formatted;
+  if (formatted === "") return "Concentration";
+  return `Concentration, up to ${formatted.toLowerCase()}`;
+};
+
+export type ComponentsInput = {
+  verbal: boolean;
+  somatic: boolean;
+  material: boolean;
+  /** Free-form material description. Appended in parens when material=true and non-empty. */
+  materialSpecified?: string;
+};
+
+export const componentsLabel = (input: ComponentsInput): string => {
+  const pieces: string[] = [];
+  if (input.verbal) pieces.push("V");
+  if (input.somatic) pieces.push("S");
+  if (input.material) pieces.push("M");
+  const base = pieces.join(", ");
+  if (!input.material) return base;
+  const spec = input.materialSpecified?.trim();
+  if (!spec) return base;
+  return `${base} (${spec})`;
+};
+
+export const classesLabel = (classes: { name: string }[]): string =>
+  classes
+    .map((c) => c.name)
+    .sort((a, b) => a.localeCompare(b))
+    .join(", ");

--- a/src/lib/srd-format/spells.ts
+++ b/src/lib/srd-format/spells.ts
@@ -13,6 +13,8 @@ export const levelLabel = (level: number, schoolName: string): string => {
   return `${ordinal(level)}-level ${schoolName.toLowerCase()}`;
 };
 
+// 2014 SRD packs the count into casting_time (e.g. "10minutes"); 2024 strips it
+// (e.g. just "minute"). Parse out a quantity if present, otherwise default to 1.
 const CONCATENATED_CASTING = /^(\d+)(minute|hour|day|round|turn)s?$/i;
 
 export const castingTimeLabel = (castingTime: string, ritual: boolean): string => {
@@ -32,6 +34,7 @@ export const castingTimeLabel = (castingTime: string, ritual: boolean): string =
   return ritual ? `${base} (ritual)` : base;
 };
 
+// 2024 returns singular units (e.g. "10 minute"); 2014 returns plural ("10 minutes").
 const QUANTIFIED_DURATION = /^(\d+)\s+(minute|hour|day|round|turn)s?$/i;
 
 const formatDuration = (duration: string): string => {

--- a/src/views/ReferenceView.module.css
+++ b/src/views/ReferenceView.module.css
@@ -1,0 +1,66 @@
+.title {
+  font-family: var(--font-display);
+  font-size: var(--fs-2xl);
+  margin: 0 0 var(--space-4);
+  line-height: var(--lh-tight);
+}
+
+.body {
+  line-height: var(--lh-body);
+}
+
+.body p {
+  margin: 0 0 var(--space-3);
+}
+
+.body ul,
+.body ol {
+  margin: 0 0 var(--space-3);
+  padding-left: var(--space-5);
+}
+
+.body li {
+  margin-bottom: var(--space-1);
+}
+
+.body table {
+  display: block;
+  overflow-x: auto;
+  max-width: 100%;
+  border-collapse: collapse;
+  margin: 0 0 var(--space-4);
+  /* Lea Verou scroll-shadow technique — fades hide themselves when not scrolled. */
+  background:
+    linear-gradient(to right, var(--color-surface), var(--color-surface)) left center / 16px 100%
+    no-repeat,
+    linear-gradient(to right, transparent, var(--color-surface)) right center / 16px 100% no-repeat,
+    radial-gradient(farthest-side at 0 50%, rgba(0, 0, 0, 0.18), transparent) left center / 12px
+    100% no-repeat,
+    radial-gradient(farthest-side at 100% 50%, rgba(0, 0, 0, 0.18), transparent) right center / 12px
+    100% no-repeat;
+  background-attachment: local, local, scroll, scroll;
+}
+
+.body th,
+.body td {
+  border: 1px solid var(--color-border);
+  padding: var(--space-2) var(--space-3);
+  text-align: left;
+  vertical-align: top;
+}
+
+.body th {
+  background: var(--color-surface-2);
+  font-weight: 600;
+}
+
+.notFound {
+  text-align: center;
+  padding: var(--space-6) 0;
+}
+
+.notFound h1 {
+  font-family: var(--font-display);
+  font-size: var(--fs-2xl);
+  margin: 0 0 var(--space-3);
+}

--- a/src/views/ReferenceView.module.css
+++ b/src/views/ReferenceView.module.css
@@ -52,6 +52,14 @@
 .body th {
   background: var(--color-surface-2);
   font-weight: 600;
+  white-space: nowrap;
+}
+
+/* Markdown tables typically have a short identifier in the first column
+   (d100 ranges like "01-05", playing-card names, etc.). Keep that column at
+   its content width so a hyphen doesn't force a two-line wrap. */
+.body td:first-child {
+  white-space: nowrap;
 }
 
 .notFound {

--- a/src/views/ReferenceView.test.tsx
+++ b/src/views/ReferenceView.test.tsx
@@ -1,17 +1,33 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  RouterProvider,
+} from "@tanstack/react-router";
 import { render, screen, waitFor } from "@testing-library/react";
-import type { ReactElement } from "react";
 import { describe, expect, test } from "vitest";
-import { ReferenceView } from "./ReferenceView";
+import { type ReferenceKind, ReferenceView } from "./ReferenceView";
 
-function wrap(ui: ReactElement) {
+function wrap(kind: ReferenceKind, cardKey: string) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+  const rootRoute = createRootRoute({
+    component: () => <ReferenceView kind={kind} cardKey={cardKey} />,
+  });
+  const router = createRouter({
+    routeTree: rootRoute,
+    history: createMemoryHistory({ initialEntries: ["/"] }),
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
 }
 
 describe("ReferenceView", () => {
   test("renders the magic item by key (2014 prefix)", async () => {
-    wrap(<ReferenceView kind="magic-items" cardKey="srd_wand-of-wonder" />);
+    wrap("magic-items", "srd_wand-of-wonder");
     expect(
       await screen.findByRole("heading", { level: 1, name: "Wand of Wonder" }),
     ).toBeInTheDocument();
@@ -19,14 +35,14 @@ describe("ReferenceView", () => {
   });
 
   test("renders the magic item by key (2024 prefix)", async () => {
-    wrap(<ReferenceView kind="magic-items" cardKey="srd-2024_wand-of-wonder" />);
+    wrap("magic-items", "srd-2024_wand-of-wonder");
     expect(
       await screen.findByRole("heading", { level: 1, name: "Wand of Wonder" }),
     ).toBeInTheDocument();
   });
 
   test("renders a spell", async () => {
-    wrap(<ReferenceView kind="spells" cardKey="srd_acid-arrow" />);
+    wrap("spells", "srd_acid-arrow");
     expect(
       await screen.findByRole("heading", { level: 1, name: "Acid Arrow" }),
     ).toBeInTheDocument();
@@ -34,33 +50,42 @@ describe("ReferenceView", () => {
   });
 
   test("renders a mundane item", async () => {
-    wrap(<ReferenceView kind="mundane-items" cardKey="srd_abacus" />);
+    wrap("mundane-items", "srd_abacus");
     expect(await screen.findByRole("heading", { level: 1, name: "Abacus" })).toBeInTheDocument();
     expect(await screen.findByText("Category", { selector: "dt" })).toBeInTheDocument();
   });
 
-  test("unknown key → 404 view with a 'Deckwright home' link", async () => {
-    wrap(<ReferenceView kind="magic-items" cardKey="srd_no-such-thing" />);
+  test("unknown key → 404 view with a 'Back to Deckwright' link", async () => {
+    wrap("magic-items", "srd_no-such-thing");
     expect(await screen.findByRole("heading", { level: 1, name: "Not found" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Deckwright home/i })).toHaveAttribute("href", "/");
+    expect(screen.getByRole("link", { name: /Back to Deckwright/i })).toHaveAttribute("href", "/");
   });
 
   test("unknown kind → 404 view", async () => {
-    wrap(<ReferenceView kind={"widgets" as never} cardKey="srd_acid-arrow" />);
+    wrap("widgets" as never, "srd_acid-arrow");
     expect(await screen.findByRole("heading", { level: 1, name: "Not found" })).toBeInTheDocument();
   });
 
   test("sets document.title to '<name> · Deckwright'", async () => {
-    wrap(<ReferenceView kind="spells" cardKey="srd_fireball" />);
+    wrap("spells", "srd_fireball");
     await waitFor(() => {
       expect(document.title).toBe("Fireball · Deckwright");
     });
   });
 
   test("404 view sets document.title to 'Not found · Deckwright'", async () => {
-    wrap(<ReferenceView kind="magic-items" cardKey="srd_no-such-thing" />);
+    wrap("magic-items", "srd_no-such-thing");
     await waitFor(() => {
       expect(document.title).toBe("Not found · Deckwright");
     });
+  });
+
+  test("resets document.title on unmount (no leak across navigation)", async () => {
+    const { unmount } = wrap("spells", "srd_fireball");
+    await waitFor(() => {
+      expect(document.title).toBe("Fireball · Deckwright");
+    });
+    unmount();
+    expect(document.title).toBe("Deckwright");
   });
 });

--- a/src/views/ReferenceView.test.tsx
+++ b/src/views/ReferenceView.test.tsx
@@ -1,0 +1,66 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { describe, expect, test } from "vitest";
+import { ReferenceView } from "./ReferenceView";
+
+function wrap(ui: ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+describe("ReferenceView", () => {
+  test("renders the magic item by key (2014 prefix)", async () => {
+    wrap(<ReferenceView kind="magic-items" cardKey="srd_wand-of-wonder" />);
+    expect(
+      await screen.findByRole("heading", { level: 1, name: "Wand of Wonder" }),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Rarity", { selector: "dt" })).toBeInTheDocument();
+  });
+
+  test("renders the magic item by key (2024 prefix)", async () => {
+    wrap(<ReferenceView kind="magic-items" cardKey="srd-2024_wand-of-wonder" />);
+    expect(
+      await screen.findByRole("heading", { level: 1, name: "Wand of Wonder" }),
+    ).toBeInTheDocument();
+  });
+
+  test("renders a spell", async () => {
+    wrap(<ReferenceView kind="spells" cardKey="srd_acid-arrow" />);
+    expect(
+      await screen.findByRole("heading", { level: 1, name: "Acid Arrow" }),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Casting Time", { selector: "dt" })).toBeInTheDocument();
+  });
+
+  test("renders a mundane item", async () => {
+    wrap(<ReferenceView kind="mundane-items" cardKey="srd_abacus" />);
+    expect(await screen.findByRole("heading", { level: 1, name: "Abacus" })).toBeInTheDocument();
+    expect(await screen.findByText("Category", { selector: "dt" })).toBeInTheDocument();
+  });
+
+  test("unknown key → 404 view with a 'Deckwright home' link", async () => {
+    wrap(<ReferenceView kind="magic-items" cardKey="srd_no-such-thing" />);
+    expect(await screen.findByRole("heading", { level: 1, name: "Not found" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Deckwright home/i })).toHaveAttribute("href", "/");
+  });
+
+  test("unknown kind → 404 view", async () => {
+    wrap(<ReferenceView kind={"widgets" as never} cardKey="srd_acid-arrow" />);
+    expect(await screen.findByRole("heading", { level: 1, name: "Not found" })).toBeInTheDocument();
+  });
+
+  test("sets document.title to '<name> · Deckwright'", async () => {
+    wrap(<ReferenceView kind="spells" cardKey="srd_fireball" />);
+    await waitFor(() => {
+      expect(document.title).toBe("Fireball · Deckwright");
+    });
+  });
+
+  test("404 view sets document.title to 'Not found · Deckwright'", async () => {
+    wrap(<ReferenceView kind="magic-items" cardKey="srd_no-such-thing" />);
+    await waitFor(() => {
+      expect(document.title).toBe("Not found · Deckwright");
+    });
+  });
+});

--- a/src/views/ReferenceView.tsx
+++ b/src/views/ReferenceView.tsx
@@ -1,15 +1,19 @@
 import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
 import { useEffect } from "react";
 import { fetchMagicItemIndex, type Ruleset } from "../api/endpoints/magicItems";
 import { fetchMundaneItemIndex } from "../api/endpoints/mundaneItems";
 import { fetchSpellIndex } from "../api/endpoints/spells";
 import { renderBody } from "../cards/renderBody";
 import type { MagicItem, MundaneItem, Spell } from "../data/srd-schema";
+import { spellBodyMarkdown } from "../lib/srd-format/spells";
 import { LoadingState } from "../lib/ui/LoadingState";
 import styles from "./ReferenceView.module.css";
 import { MagicItemStatBlock } from "./reference/MagicItemStatBlock";
 import { MundaneItemStatBlock } from "./reference/MundaneItemStatBlock";
 import { SpellStatBlock } from "./reference/SpellStatBlock";
+
+const DEFAULT_TITLE = "Deckwright";
 
 export type ReferenceKind = "magic-items" | "mundane-items" | "spells";
 
@@ -45,13 +49,16 @@ async function loadRecord(kind: string, key: string): Promise<Loaded | null> {
 function NotFound() {
   useEffect(() => {
     document.title = "Not found · Deckwright";
+    return () => {
+      document.title = DEFAULT_TITLE;
+    };
   }, []);
   return (
     <article className={styles.notFound}>
       <h1>Not found</h1>
       <p>That reference page doesn't exist.</p>
       <p>
-        <a href="/">Deckwright home</a>
+        <Link to="/">Back to Deckwright</Link>
       </p>
     </article>
   );
@@ -65,9 +72,7 @@ function StatBlockForKind({ loaded }: { loaded: Loaded }) {
 
 function bodyMarkdown(loaded: Loaded): string {
   if (loaded.kind === "spells") {
-    const higher = loaded.record.higher_level.trim();
-    if (higher === "") return loaded.record.desc;
-    return `${loaded.record.desc}\n\n***At Higher Levels.*** ${higher}`;
+    return spellBodyMarkdown(loaded.record.desc, loaded.record.higher_level);
   }
   return loaded.record.desc;
 }
@@ -82,6 +87,9 @@ export function ReferenceView({ kind, cardKey }: Props) {
   useEffect(() => {
     if (query.data) {
       document.title = `${query.data.record.name} · Deckwright`;
+      return () => {
+        document.title = DEFAULT_TITLE;
+      };
     }
   }, [query.data]);
 

--- a/src/views/ReferenceView.tsx
+++ b/src/views/ReferenceView.tsx
@@ -13,7 +13,7 @@ import { SpellStatBlock } from "./reference/SpellStatBlock";
 
 export type ReferenceKind = "magic-items" | "mundane-items" | "spells";
 
-type Props = { kind: ReferenceKind | (string & {}); cardKey: string };
+type Props = { kind: ReferenceKind; cardKey: string };
 
 const rulesetFromKey = (key: string): Ruleset => (key.startsWith("srd-2024_") ? "2024" : "2014");
 

--- a/src/views/ReferenceView.tsx
+++ b/src/views/ReferenceView.tsx
@@ -1,0 +1,104 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { fetchMagicItemIndex, type Ruleset } from "../api/endpoints/magicItems";
+import { fetchMundaneItemIndex } from "../api/endpoints/mundaneItems";
+import { fetchSpellIndex } from "../api/endpoints/spells";
+import { renderBody } from "../cards/renderBody";
+import type { MagicItem, MundaneItem, Spell } from "../data/srd-schema";
+import { LoadingState } from "../lib/ui/LoadingState";
+import styles from "./ReferenceView.module.css";
+import { MagicItemStatBlock } from "./reference/MagicItemStatBlock";
+import { MundaneItemStatBlock } from "./reference/MundaneItemStatBlock";
+import { SpellStatBlock } from "./reference/SpellStatBlock";
+
+export type ReferenceKind = "magic-items" | "mundane-items" | "spells";
+
+type Props = { kind: ReferenceKind | (string & {}); cardKey: string };
+
+const rulesetFromKey = (key: string): Ruleset => (key.startsWith("srd-2024_") ? "2024" : "2014");
+
+type Loaded =
+  | { kind: "magic-items"; record: MagicItem }
+  | { kind: "mundane-items"; record: MundaneItem }
+  | { kind: "spells"; record: Spell };
+
+async function loadRecord(kind: string, key: string): Promise<Loaded | null> {
+  const ruleset = rulesetFromKey(key);
+  if (kind === "magic-items") {
+    const idx = await fetchMagicItemIndex(ruleset);
+    const record = idx.results.find((r) => r.key === key);
+    return record ? { kind: "magic-items", record } : null;
+  }
+  if (kind === "mundane-items") {
+    const idx = await fetchMundaneItemIndex(ruleset);
+    const record = idx.results.find((r) => r.key === key);
+    return record ? { kind: "mundane-items", record } : null;
+  }
+  if (kind === "spells") {
+    const idx = await fetchSpellIndex(ruleset);
+    const record = idx.results.find((r) => r.key === key);
+    return record ? { kind: "spells", record } : null;
+  }
+  return null;
+}
+
+function NotFound() {
+  useEffect(() => {
+    document.title = "Not found · Deckwright";
+  }, []);
+  return (
+    <article className={styles.notFound}>
+      <h1>Not found</h1>
+      <p>That reference page doesn't exist.</p>
+      <p>
+        <a href="/">Deckwright home</a>
+      </p>
+    </article>
+  );
+}
+
+function StatBlockForKind({ loaded }: { loaded: Loaded }) {
+  if (loaded.kind === "magic-items") return <MagicItemStatBlock item={loaded.record} />;
+  if (loaded.kind === "mundane-items") return <MundaneItemStatBlock item={loaded.record} />;
+  return <SpellStatBlock spell={loaded.record} />;
+}
+
+function bodyMarkdown(loaded: Loaded): string {
+  if (loaded.kind === "spells") {
+    const higher = loaded.record.higher_level.trim();
+    if (higher === "") return loaded.record.desc;
+    return `${loaded.record.desc}\n\n***At Higher Levels.*** ${higher}`;
+  }
+  return loaded.record.desc;
+}
+
+export function ReferenceView({ kind, cardKey }: Props) {
+  const query = useQuery({
+    queryKey: ["reference", kind, cardKey],
+    queryFn: () => loadRecord(kind, cardKey),
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+
+  useEffect(() => {
+    if (query.data) {
+      document.title = `${query.data.record.name} · Deckwright`;
+    }
+  }, [query.data]);
+
+  if (query.isLoading) return <LoadingState />;
+  if (!query.data) return <NotFound />;
+
+  const html = renderBody(bodyMarkdown(query.data));
+  return (
+    <article>
+      <h1 className={styles.title}>{query.data.record.name}</h1>
+      <StatBlockForKind loaded={query.data} />
+      <div
+        className={styles.body}
+        // The string came from DOMPurify-sanitized markdown — see src/cards/renderBody.ts.
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized HTML
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </article>
+  );
+}

--- a/src/views/reference/MagicItemStatBlock.test.tsx
+++ b/src/views/reference/MagicItemStatBlock.test.tsx
@@ -3,9 +3,10 @@ import { describe, expect, test } from "vitest";
 import { magicItemDetailFactory } from "../../api/factories";
 import { MagicItemStatBlock } from "./MagicItemStatBlock";
 
+// Scope to <dt> so labels can't collide with <dd> values that happen to share
+// the same text (e.g. category "Weapon" with the Weapon stat row).
 const within = (label: string) => {
-  const dt = screen.getByText(label);
-  // The matching <dd> is the next sibling in the document order
+  const dt = screen.getByText(label, { selector: "dt" });
   const dd = dt.nextElementSibling;
   if (!dd) throw new Error(`No <dd> after <dt>${label}`);
   return dd;

--- a/src/views/reference/MagicItemStatBlock.test.tsx
+++ b/src/views/reference/MagicItemStatBlock.test.tsx
@@ -1,16 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, test } from "vitest";
 import { magicItemDetailFactory } from "../../api/factories";
+import { dtWithin } from "./dtWithin";
 import { MagicItemStatBlock } from "./MagicItemStatBlock";
-
-// Scope to <dt> so labels can't collide with <dd> values that happen to share
-// the same text (e.g. category "Weapon" with the Weapon stat row).
-const within = (label: string) => {
-  const dt = screen.getByText(label, { selector: "dt" });
-  const dd = dt.nextElementSibling;
-  if (!dd) throw new Error(`No <dd> after <dt>${label}`);
-  return dd;
-};
 
 describe("MagicItemStatBlock", () => {
   test("renders Category and Rarity for a minimal item", () => {
@@ -24,8 +16,8 @@ describe("MagicItemStatBlock", () => {
       weight: "0.000",
     });
     render(<MagicItemStatBlock item={item} />);
-    expect(within("Category").textContent).toBe("Ring");
-    expect(within("Rarity").textContent).toBe("Uncommon");
+    expect(dtWithin("Category").textContent).toBe("Ring");
+    expect(dtWithin("Rarity").textContent).toBe("Uncommon");
   });
 
   test("omits Attunement line when requires_attunement is false", () => {
@@ -40,7 +32,7 @@ describe("MagicItemStatBlock", () => {
       attunement_detail: "by a spellcaster",
     });
     render(<MagicItemStatBlock item={item} />);
-    expect(within("Attunement").textContent).toBe("Requires attunement by a spellcaster");
+    expect(dtWithin("Attunement").textContent).toBe("Requires attunement by a spellcaster");
   });
 
   test("Attunement shows 'Requires attunement' when no detail", () => {
@@ -49,7 +41,7 @@ describe("MagicItemStatBlock", () => {
       attunement_detail: null,
     });
     render(<MagicItemStatBlock item={item} />);
-    expect(within("Attunement").textContent).toBe("Requires attunement");
+    expect(dtWithin("Attunement").textContent).toBe("Requires attunement");
   });
 
   test("Weapon line shows damage + lowercased type", () => {
@@ -57,7 +49,7 @@ describe("MagicItemStatBlock", () => {
       weapon: { damage_dice: "1d8", damage_type: { name: "Slashing" } },
     });
     render(<MagicItemStatBlock item={item} />);
-    expect(within("Weapon").textContent).toBe("1d8 slashing");
+    expect(dtWithin("Weapon").textContent).toBe("1d8 slashing");
   });
 
   test("Armor line shows AC formula", () => {
@@ -65,13 +57,13 @@ describe("MagicItemStatBlock", () => {
       armor: { ac_base: 14, ac_add_dexmod: true, ac_cap_dexmod: 2 },
     });
     render(<MagicItemStatBlock item={item} />);
-    expect(within("Armor").textContent).toBe("AC 14 + dex mod (max 2)");
+    expect(dtWithin("Armor").textContent).toBe("AC 14 + dex mod (max 2)");
   });
 
   test("Weight is shown when non-zero", () => {
     const item = magicItemDetailFactory.build({ weight: "1.500", weight_unit: "lb" });
     render(<MagicItemStatBlock item={item} />);
-    expect(within("Weight").textContent).toBe("1.5 lb");
+    expect(dtWithin("Weight").textContent).toBe("1.5 lb");
   });
 
   test("Weight is omitted when zero", () => {

--- a/src/views/reference/MagicItemStatBlock.test.tsx
+++ b/src/views/reference/MagicItemStatBlock.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { magicItemDetailFactory } from "../../api/factories";
+import { MagicItemStatBlock } from "./MagicItemStatBlock";
+
+const within = (label: string) => {
+  const dt = screen.getByText(label);
+  // The matching <dd> is the next sibling in the document order
+  const dd = dt.nextElementSibling;
+  if (!dd) throw new Error(`No <dd> after <dt>${label}`);
+  return dd;
+};
+
+describe("MagicItemStatBlock", () => {
+  test("renders Category and Rarity for a minimal item", () => {
+    const item = magicItemDetailFactory.build({
+      category: { name: "Ring" },
+      rarity: { name: "Uncommon" },
+      requires_attunement: false,
+      attunement_detail: null,
+      weapon: null,
+      armor: null,
+      weight: "0.000",
+    });
+    render(<MagicItemStatBlock item={item} />);
+    expect(within("Category").textContent).toBe("Ring");
+    expect(within("Rarity").textContent).toBe("Uncommon");
+  });
+
+  test("omits Attunement line when requires_attunement is false", () => {
+    const item = magicItemDetailFactory.build({ requires_attunement: false });
+    render(<MagicItemStatBlock item={item} />);
+    expect(screen.queryByText("Attunement")).toBeNull();
+  });
+
+  test("Attunement shows full sentence with detail", () => {
+    const item = magicItemDetailFactory.build({
+      requires_attunement: true,
+      attunement_detail: "by a spellcaster",
+    });
+    render(<MagicItemStatBlock item={item} />);
+    expect(within("Attunement").textContent).toBe("Requires attunement by a spellcaster");
+  });
+
+  test("Attunement shows 'Requires attunement' when no detail", () => {
+    const item = magicItemDetailFactory.build({
+      requires_attunement: true,
+      attunement_detail: null,
+    });
+    render(<MagicItemStatBlock item={item} />);
+    expect(within("Attunement").textContent).toBe("Requires attunement");
+  });
+
+  test("Weapon line shows damage + lowercased type", () => {
+    const item = magicItemDetailFactory.build({
+      weapon: { damage_dice: "1d8", damage_type: { name: "Slashing" } },
+    });
+    render(<MagicItemStatBlock item={item} />);
+    expect(within("Weapon").textContent).toBe("1d8 slashing");
+  });
+
+  test("Armor line shows AC formula", () => {
+    const item = magicItemDetailFactory.build({
+      armor: { ac_base: 14, ac_add_dexmod: true, ac_cap_dexmod: 2 },
+    });
+    render(<MagicItemStatBlock item={item} />);
+    expect(within("Armor").textContent).toBe("AC 14 + dex mod (max 2)");
+  });
+
+  test("Weight is shown when non-zero", () => {
+    const item = magicItemDetailFactory.build({ weight: "1.500", weight_unit: "lb" });
+    render(<MagicItemStatBlock item={item} />);
+    expect(within("Weight").textContent).toBe("1.5 lb");
+  });
+
+  test("Weight is omitted when zero", () => {
+    const item = magicItemDetailFactory.build({ weight: "0.000" });
+    render(<MagicItemStatBlock item={item} />);
+    expect(screen.queryByText("Weight")).toBeNull();
+  });
+});

--- a/src/views/reference/MagicItemStatBlock.tsx
+++ b/src/views/reference/MagicItemStatBlock.tsx
@@ -1,0 +1,26 @@
+import type { MagicItem } from "../../data/srd-schema";
+import { acFormula, attunementLine, formatWeight } from "../../lib/srd-format/items";
+import { type StatItem, StatList } from "./StatList";
+
+export function MagicItemStatBlock({ item }: { item: MagicItem }) {
+  const items: StatItem[] = [];
+  items.push({ label: "Category", value: item.category.name });
+  items.push({ label: "Rarity", value: item.rarity.name });
+
+  const attunement = attunementLine(item);
+  if (attunement) items.push({ label: "Attunement", value: attunement });
+
+  if (item.weapon) {
+    items.push({
+      label: "Weapon",
+      value: `${item.weapon.damage_dice} ${item.weapon.damage_type.name.toLowerCase()}`,
+    });
+  }
+  if (item.armor) {
+    items.push({ label: "Armor", value: acFormula(item.armor) });
+  }
+  const weight = formatWeight(item.weight, item.weight_unit);
+  if (weight) items.push({ label: "Weight", value: weight });
+
+  return <StatList items={items} />;
+}

--- a/src/views/reference/MundaneItemStatBlock.test.tsx
+++ b/src/views/reference/MundaneItemStatBlock.test.tsx
@@ -1,16 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, test } from "vitest";
 import { mundaneItemDetailFactory } from "../../api/factories";
+import { dtWithin } from "./dtWithin";
 import { MundaneItemStatBlock } from "./MundaneItemStatBlock";
-
-// Scope to <dt> so labels can't collide with <dd> values that happen to share
-// the same text (e.g. category "Weapon" with the Weapon type stat row).
-const within = (label: string) => {
-  const dt = screen.getByText(label, { selector: "dt" });
-  const dd = dt.nextElementSibling;
-  if (!dd) throw new Error(`No <dd> after <dt>${label}`);
-  return dd;
-};
 
 describe("MundaneItemStatBlock", () => {
   test("plain gear: Category and Cost", () => {
@@ -23,9 +15,9 @@ describe("MundaneItemStatBlock", () => {
       weight_unit: "lb",
     });
     render(<MundaneItemStatBlock item={item} />);
-    expect(within("Category").textContent).toBe("Adventuring Gear");
-    expect(within("Cost").textContent).toBe("10 gp");
-    expect(within("Weight").textContent).toBe("1 lb");
+    expect(dtWithin("Category").textContent).toBe("Adventuring Gear");
+    expect(dtWithin("Cost").textContent).toBe("10 gp");
+    expect(dtWithin("Weight").textContent).toBe("1 lb");
   });
 
   test("weapon: shows Weapon type, Damage, and Properties (one <li> per property)", () => {
@@ -43,9 +35,9 @@ describe("MundaneItemStatBlock", () => {
       },
     });
     render(<MundaneItemStatBlock item={item} />);
-    expect(within("Weapon type").textContent).toBe("Martial");
-    expect(within("Damage").textContent).toBe("1d8 slashing");
-    const props = within("Properties");
+    expect(dtWithin("Weapon type").textContent).toBe("Martial");
+    expect(dtWithin("Damage").textContent).toBe("1d8 slashing");
+    const props = dtWithin("Properties");
     const lis = props.querySelectorAll("li");
     expect(lis).toHaveLength(2);
     expect(lis[0]?.textContent).toBe("Versatile (1d10)");
@@ -64,7 +56,7 @@ describe("MundaneItemStatBlock", () => {
       },
     });
     render(<MundaneItemStatBlock item={item} />);
-    expect(within("Weapon type").textContent).toBe("Simple");
+    expect(dtWithin("Weapon type").textContent).toBe("Simple");
     expect(screen.queryByText("Properties", { selector: "dt" })).toBeNull();
   });
 
@@ -81,10 +73,10 @@ describe("MundaneItemStatBlock", () => {
       },
     });
     render(<MundaneItemStatBlock item={item} />);
-    expect(within("Armor tier").textContent).toBe("Heavy");
-    expect(within("AC").textContent).toBe("AC 16");
-    expect(within("Stealth").textContent).toBe("Disadvantage");
-    expect(within("Strength").textContent).toBe("13");
+    expect(dtWithin("Armor tier").textContent).toBe("Heavy");
+    expect(dtWithin("AC").textContent).toBe("AC 16");
+    expect(dtWithin("Stealth").textContent).toBe("Disadvantage");
+    expect(dtWithin("Strength").textContent).toBe("13");
   });
 
   test("shield (ac_base <= 5): no Tier, '+N AC' format", () => {
@@ -101,7 +93,7 @@ describe("MundaneItemStatBlock", () => {
     });
     render(<MundaneItemStatBlock item={item} />);
     expect(screen.queryByText("Armor tier", { selector: "dt" })).toBeNull();
-    expect(within("AC").textContent).toBe("+2 AC");
+    expect(dtWithin("AC").textContent).toBe("+2 AC");
   });
 
   test("Cost omitted when 0.00, Weight omitted when 0.000", () => {

--- a/src/views/reference/MundaneItemStatBlock.test.tsx
+++ b/src/views/reference/MundaneItemStatBlock.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { mundaneItemDetailFactory } from "../../api/factories";
+import { MundaneItemStatBlock } from "./MundaneItemStatBlock";
+
+// Scope to <dt> so labels can't collide with <dd> values that happen to share
+// the same text (e.g. category "Weapon" with the Weapon type stat row).
+const within = (label: string) => {
+  const dt = screen.getByText(label, { selector: "dt" });
+  const dd = dt.nextElementSibling;
+  if (!dd) throw new Error(`No <dd> after <dt>${label}`);
+  return dd;
+};
+
+describe("MundaneItemStatBlock", () => {
+  test("plain gear: Category and Cost", () => {
+    const item = mundaneItemDetailFactory.build({
+      category: { name: "Adventuring Gear" },
+      weapon: null,
+      armor: null,
+      cost: "10.00",
+      weight: "1.000",
+      weight_unit: "lb",
+    });
+    render(<MundaneItemStatBlock item={item} />);
+    expect(within("Category").textContent).toBe("Adventuring Gear");
+    expect(within("Cost").textContent).toBe("10 gp");
+    expect(within("Weight").textContent).toBe("1 lb");
+  });
+
+  test("weapon: shows Weapon type, Damage, and Properties (one <li> per property)", () => {
+    const item = mundaneItemDetailFactory.build({
+      category: { name: "Weapon" },
+      weapon: {
+        damage_dice: "1d8",
+        damage_type: { name: "Slashing" },
+        properties: [
+          { property: { name: "Versatile", type: null }, detail: "1d10" },
+          { property: { name: "Topple", type: "Mastery" }, detail: null },
+        ],
+        is_simple: false,
+        is_martial: true,
+      },
+    });
+    render(<MundaneItemStatBlock item={item} />);
+    expect(within("Weapon type").textContent).toBe("Martial");
+    expect(within("Damage").textContent).toBe("1d8 slashing");
+    const props = within("Properties");
+    const lis = props.querySelectorAll("li");
+    expect(lis).toHaveLength(2);
+    expect(lis[0]?.textContent).toBe("Versatile (1d10)");
+    expect(lis[1]?.textContent).toBe("Topple (Mastery)");
+  });
+
+  test("weapon with no properties: Properties line is omitted", () => {
+    const item = mundaneItemDetailFactory.build({
+      category: { name: "Weapon" },
+      weapon: {
+        damage_dice: "1d6",
+        damage_type: { name: "Bludgeoning" },
+        properties: [],
+        is_simple: true,
+        is_martial: false,
+      },
+    });
+    render(<MundaneItemStatBlock item={item} />);
+    expect(within("Weapon type").textContent).toBe("Simple");
+    expect(screen.queryByText("Properties", { selector: "dt" })).toBeNull();
+  });
+
+  test("armor: Tier, AC, Stealth disadvantage, Strength requirement", () => {
+    const item = mundaneItemDetailFactory.build({
+      category: { name: "Armor" },
+      armor: {
+        category: "heavy",
+        ac_base: 16,
+        ac_add_dexmod: false,
+        ac_cap_dexmod: null,
+        grants_stealth_disadvantage: true,
+        strength_score_required: 13,
+      },
+    });
+    render(<MundaneItemStatBlock item={item} />);
+    expect(within("Armor tier").textContent).toBe("Heavy");
+    expect(within("AC").textContent).toBe("AC 16");
+    expect(within("Stealth").textContent).toBe("Disadvantage");
+    expect(within("Strength").textContent).toBe("13");
+  });
+
+  test("shield (ac_base <= 5): no Tier, '+N AC' format", () => {
+    const item = mundaneItemDetailFactory.build({
+      category: { name: "Armor" },
+      armor: {
+        category: "heavy",
+        ac_base: 2,
+        ac_add_dexmod: false,
+        ac_cap_dexmod: null,
+        grants_stealth_disadvantage: false,
+        strength_score_required: null,
+      },
+    });
+    render(<MundaneItemStatBlock item={item} />);
+    expect(screen.queryByText("Armor tier", { selector: "dt" })).toBeNull();
+    expect(within("AC").textContent).toBe("+2 AC");
+  });
+
+  test("Cost omitted when 0.00, Weight omitted when 0.000", () => {
+    const item = mundaneItemDetailFactory.build({
+      cost: "0.00",
+      weight: "0.000",
+      weapon: null,
+      armor: null,
+    });
+    render(<MundaneItemStatBlock item={item} />);
+    expect(screen.queryByText("Cost", { selector: "dt" })).toBeNull();
+    expect(screen.queryByText("Weight", { selector: "dt" })).toBeNull();
+  });
+});

--- a/src/views/reference/MundaneItemStatBlock.tsx
+++ b/src/views/reference/MundaneItemStatBlock.tsx
@@ -1,0 +1,57 @@
+import type { MundaneItem } from "../../data/srd-schema";
+import {
+  acFormula,
+  formatCost,
+  formatWeight,
+  isShieldArmor,
+  weaponPropertyLabel,
+} from "../../lib/srd-format/items";
+import { type StatItem, StatList } from "./StatList";
+
+const capitalize = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1);
+
+export function MundaneItemStatBlock({ item }: { item: MundaneItem }) {
+  const items: StatItem[] = [];
+  items.push({ label: "Category", value: item.category.name });
+
+  if (item.weapon) {
+    if (item.weapon.is_simple) items.push({ label: "Weapon type", value: "Simple" });
+    else if (item.weapon.is_martial) items.push({ label: "Weapon type", value: "Martial" });
+    items.push({
+      label: "Damage",
+      value: `${item.weapon.damage_dice} ${item.weapon.damage_type.name.toLowerCase()}`,
+    });
+    if (item.weapon.properties.length > 0) {
+      items.push({
+        label: "Properties",
+        value: (
+          <ul>
+            {item.weapon.properties.map((p) => (
+              <li key={`${p.property.name}-${p.detail ?? ""}`}>{weaponPropertyLabel(p)}</li>
+            ))}
+          </ul>
+        ),
+      });
+    }
+  }
+
+  if (item.armor) {
+    if (!isShieldArmor(item.armor)) {
+      items.push({ label: "Armor tier", value: capitalize(item.armor.category) });
+    }
+    items.push({ label: "AC", value: acFormula(item.armor) });
+    if (item.armor.grants_stealth_disadvantage) {
+      items.push({ label: "Stealth", value: "Disadvantage" });
+    }
+    if (item.armor.strength_score_required !== null) {
+      items.push({ label: "Strength", value: String(item.armor.strength_score_required) });
+    }
+  }
+
+  const cost = formatCost(item.cost);
+  if (cost) items.push({ label: "Cost", value: cost });
+  const weight = formatWeight(item.weight, item.weight_unit);
+  if (weight) items.push({ label: "Weight", value: weight });
+
+  return <StatList items={items} />;
+}

--- a/src/views/reference/SpellStatBlock.test.tsx
+++ b/src/views/reference/SpellStatBlock.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { spellDetailFactory } from "../../api/factories";
+import { dtWithin } from "./dtWithin";
+import { SpellStatBlock } from "./SpellStatBlock";
+
+describe("SpellStatBlock", () => {
+  test("Fireball-shaped spell renders all fields", () => {
+    const spell = spellDetailFactory.build({
+      level: 3,
+      school: { name: "evocation" },
+      casting_time: "action",
+      ritual: false,
+      range_text: "150 feet",
+      duration: "instantaneous",
+      concentration: false,
+      verbal: true,
+      somatic: true,
+      material: true,
+      material_specified: "a tiny ball of bat guano and sulfur",
+      classes: [{ name: "Wizard" }, { name: "Sorcerer" }],
+    });
+    render(<SpellStatBlock spell={spell} />);
+    expect(dtWithin("Level").textContent).toBe("3rd-level evocation");
+    expect(dtWithin("Casting Time").textContent).toBe("1 action");
+    expect(dtWithin("Range").textContent).toBe("150 feet");
+    expect(dtWithin("Components").textContent).toBe(
+      "V, S, M (a tiny ball of bat guano and sulfur)",
+    );
+    expect(dtWithin("Duration").textContent).toBe("Instantaneous");
+    expect(dtWithin("Classes").textContent).toBe("Sorcerer, Wizard");
+  });
+
+  test("cantrip with concentration", () => {
+    const spell = spellDetailFactory.build({
+      level: 0,
+      school: { name: "divination" },
+      casting_time: "action",
+      ritual: false,
+      range_text: "Touch",
+      duration: "1 minute",
+      concentration: true,
+      verbal: true,
+      somatic: true,
+      material: false,
+      material_specified: "",
+      classes: [{ name: "Cleric" }],
+    });
+    render(<SpellStatBlock spell={spell} />);
+    expect(dtWithin("Level").textContent).toBe("Divination cantrip");
+    expect(dtWithin("Components").textContent).toBe("V, S");
+    expect(dtWithin("Duration").textContent).toBe("Concentration, up to 1 minute");
+  });
+
+  test("ritual flag appears in Casting Time", () => {
+    const spell = spellDetailFactory.build({
+      casting_time: "10minutes",
+      ritual: true,
+    });
+    render(<SpellStatBlock spell={spell} />);
+    expect(dtWithin("Casting Time").textContent).toBe("10 minutes (ritual)");
+  });
+
+  test("empty classes omits the Classes line", () => {
+    const spell = spellDetailFactory.build({ classes: [] });
+    render(<SpellStatBlock spell={spell} />);
+    expect(screen.queryByText("Classes", { selector: "dt" })).toBeNull();
+  });
+
+  test("empty duration without concentration omits the Duration line", () => {
+    const spell = spellDetailFactory.build({ duration: "", concentration: false });
+    render(<SpellStatBlock spell={spell} />);
+    expect(screen.queryByText("Duration", { selector: "dt" })).toBeNull();
+  });
+
+  test("empty duration with concentration shows 'Concentration'", () => {
+    const spell = spellDetailFactory.build({ duration: "", concentration: true });
+    render(<SpellStatBlock spell={spell} />);
+    expect(dtWithin("Duration").textContent).toBe("Concentration");
+  });
+
+  test("no V/S/M omits the Components line", () => {
+    const spell = spellDetailFactory.build({
+      verbal: false,
+      somatic: false,
+      material: false,
+      material_specified: "",
+    });
+    render(<SpellStatBlock spell={spell} />);
+    expect(screen.queryByText("Components", { selector: "dt" })).toBeNull();
+  });
+});

--- a/src/views/reference/SpellStatBlock.tsx
+++ b/src/views/reference/SpellStatBlock.tsx
@@ -1,0 +1,35 @@
+import type { Spell } from "../../data/srd-schema";
+import {
+  castingTimeLabel,
+  classesLabel,
+  componentsLabel,
+  durationLabel,
+  levelLabel,
+} from "../../lib/srd-format/spells";
+import { type StatItem, StatList } from "./StatList";
+
+export function SpellStatBlock({ spell }: { spell: Spell }) {
+  const items: StatItem[] = [];
+  items.push({ label: "Level", value: levelLabel(spell.level, spell.school.name) });
+  items.push({
+    label: "Casting Time",
+    value: castingTimeLabel(spell.casting_time, spell.ritual),
+  });
+  if (spell.range_text) items.push({ label: "Range", value: spell.range_text });
+
+  const components = componentsLabel({
+    verbal: spell.verbal,
+    somatic: spell.somatic,
+    material: spell.material,
+    materialSpecified: spell.material_specified,
+  });
+  if (components) items.push({ label: "Components", value: components });
+
+  const duration = durationLabel(spell.duration, spell.concentration);
+  if (duration) items.push({ label: "Duration", value: duration });
+
+  const classes = classesLabel(spell.classes);
+  if (classes) items.push({ label: "Classes", value: classes });
+
+  return <StatList items={items} />;
+}

--- a/src/views/reference/StatList.module.css
+++ b/src/views/reference/StatList.module.css
@@ -22,13 +22,12 @@
   color: var(--color-text);
 }
 
-@media (max-width: 480px) {
+@media (max-width: 640px) {
   .list {
     grid-template-columns: 1fr;
     row-gap: var(--space-1);
   }
   .value {
-    padding-left: 0;
     margin-bottom: var(--space-2);
   }
 }

--- a/src/views/reference/StatList.module.css
+++ b/src/views/reference/StatList.module.css
@@ -1,0 +1,34 @@
+.list {
+  margin: 0 0 var(--space-5);
+  padding: 0;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: var(--space-3);
+  row-gap: var(--space-2);
+}
+
+.label {
+  font-weight: 700;
+  color: var(--color-text);
+  margin: 0;
+}
+
+.label::after {
+  content: ".";
+}
+
+.value {
+  margin: 0;
+  color: var(--color-text);
+}
+
+@media (max-width: 480px) {
+  .list {
+    grid-template-columns: 1fr;
+    row-gap: var(--space-1);
+  }
+  .value {
+    padding-left: 0;
+    margin-bottom: var(--space-2);
+  }
+}

--- a/src/views/reference/StatList.test.tsx
+++ b/src/views/reference/StatList.test.tsx
@@ -1,0 +1,53 @@
+import { render } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { StatList } from "./StatList";
+
+describe("StatList", () => {
+  test("renders a dt/dd pair per item, in order", () => {
+    const { container } = render(
+      <StatList
+        items={[
+          { label: "Casting Time", value: "1 action" },
+          { label: "Range", value: "60 feet" },
+        ]}
+      />,
+    );
+    const terms = container.querySelectorAll("dt");
+    const descs = container.querySelectorAll("dd");
+    expect(terms).toHaveLength(2);
+    expect(descs).toHaveLength(2);
+    expect(terms[0]?.textContent).toBe("Casting Time");
+    expect(descs[0]?.textContent).toBe("1 action");
+    expect(terms[1]?.textContent).toBe("Range");
+    expect(descs[1]?.textContent).toBe("60 feet");
+  });
+
+  test("renders inside a <dl>", () => {
+    const { container } = render(<StatList items={[{ label: "L", value: "v" }]} />);
+    expect(container.querySelector("dl")).not.toBeNull();
+  });
+
+  test("renders nothing when items is empty (no empty <dl>)", () => {
+    const { container } = render(<StatList items={[]} />);
+    expect(container.querySelector("dl")).toBeNull();
+  });
+
+  test("accepts a ReactNode value (not just a string)", () => {
+    const { container } = render(
+      <StatList
+        items={[
+          {
+            label: "Properties",
+            value: (
+              <ul>
+                <li>Finesse</li>
+                <li>Light</li>
+              </ul>
+            ),
+          },
+        ]}
+      />,
+    );
+    expect(container.querySelector("dd ul")).not.toBeNull();
+  });
+});

--- a/src/views/reference/StatList.tsx
+++ b/src/views/reference/StatList.tsx
@@ -1,0 +1,18 @@
+import { Fragment, type ReactNode } from "react";
+import styles from "./StatList.module.css";
+
+export type StatItem = { label: string; value: ReactNode };
+
+export function StatList({ items }: { items: StatItem[] }) {
+  if (items.length === 0) return null;
+  return (
+    <dl className={styles.list}>
+      {items.map((item) => (
+        <Fragment key={item.label}>
+          <dt className={styles.label}>{item.label}</dt>
+          <dd className={styles.value}>{item.value}</dd>
+        </Fragment>
+      ))}
+    </dl>
+  );
+}

--- a/src/views/reference/dtWithin.ts
+++ b/src/views/reference/dtWithin.ts
@@ -1,0 +1,16 @@
+import { screen } from "@testing-library/react";
+
+/**
+ * Locate the `<dd>` that follows a stat-block `<dt>` with the given label text.
+ *
+ * The `{ selector: "dt" }` scoping is load-bearing: without it, when a record's
+ * category or other value happens to share text with a stat label (e.g. faker
+ * factory category "Weapon" with a "Weapon type" stat row), `getByText` finds
+ * multiple matches and throws.
+ */
+export const dtWithin = (label: string): Element => {
+  const dt = screen.getByText(label, { selector: "dt" });
+  const dd = dt.nextElementSibling;
+  if (!dd) throw new Error(`No <dd> after <dt>${label}`);
+  return dd;
+};

--- a/src/views/reference/routeUrl.test.ts
+++ b/src/views/reference/routeUrl.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+import { referenceRoutePath } from "./routeUrl";
+
+describe("referenceRoutePath", () => {
+  test("magic item, 2014 prefix", () => {
+    expect(referenceRoutePath("magic-items", "srd_wand-of-wonder")).toBe(
+      "/reference/magic-items/srd_wand-of-wonder",
+    );
+  });
+
+  test("magic item, 2024 prefix", () => {
+    expect(referenceRoutePath("magic-items", "srd-2024_wand-of-wonder")).toBe(
+      "/reference/magic-items/srd-2024_wand-of-wonder",
+    );
+  });
+
+  test("spell", () => {
+    expect(referenceRoutePath("spells", "srd_fireball")).toBe("/reference/spells/srd_fireball");
+  });
+
+  test("mundane item", () => {
+    expect(referenceRoutePath("mundane-items", "srd-2024_longsword")).toBe(
+      "/reference/mundane-items/srd-2024_longsword",
+    );
+  });
+
+  test("URI-encodes reserved characters in the key (defensive)", () => {
+    expect(referenceRoutePath("spells", "weird key/with reserved")).toBe(
+      "/reference/spells/weird%20key%2Fwith%20reserved",
+    );
+  });
+});

--- a/src/views/reference/routeUrl.ts
+++ b/src/views/reference/routeUrl.ts
@@ -1,0 +1,18 @@
+import type { ReferenceKind } from "../ReferenceView";
+
+/**
+ * Build the in-app path for a reference page. Use for SPA links via
+ * TanStack Router's `<Link>`, OR concatenate with `window.location.origin`
+ * for an absolute URL suitable for encoding in a QR code.
+ *
+ * Example: `referenceRoutePath("magic-items", "srd-2024_wand-of-wonder")` →
+ * `"/reference/magic-items/srd-2024_wand-of-wonder"`.
+ *
+ * The `key` is URI-encoded; SRD keys (`srd_<slug>` / `srd-2024_<slug>`) only
+ * contain unreserved characters today, so the encoding is a no-op in practice.
+ * The defensive encode protects against future key shapes that include
+ * reserved characters.
+ */
+export function referenceRoutePath(kind: ReferenceKind, key: string): string {
+  return `/reference/${kind}/${encodeURIComponent(key)}`;
+}


### PR DESCRIPTION
### What are the relevant tickets?

N/A — verbal feature request.

### Description (What does it do?)

Adds a public, mobile-first reference route at `/reference/$kind/$key` that renders the full SRD content (stat block + markdown body) for any bundled magic item, mundane item, or spell. The route is the destination for a future QR-code workflow on printed cards (see follow-ups below): rather than designing the print layout around outlier cards like Wand of Wonder (15 pages of d100 effects, ~8 of ~2,350 cards exceed 4 pages), we keep the printed card short and link to this page.

**Primary use case is a phone, mid-game, often anonymous and on a spotty connection.** Design decisions reflect that: slim chrome (Deckwright brand link only, no user menu or footer), semantic `<dl>` stat block, `<h1>` per page, `document.title` set for shareability, markdown tables overflow horizontally with a scroll-shadow affordance, body copy ≥ 16px to avoid iOS focus-zoom, content capped at `~65ch` on desktop.

Major pieces:
- **`/reference/$kind/$key` route** — kinds: `magic-items` / `mundane-items` / `spells`. Public, no auth. Ruleset derived from the key prefix (`srd_` = 2014, `srd-2024_` = 2024). Unknown kind or key renders an inline 404 in the slim chrome.
- **New shared format module** at `src/lib/srd-format/` (spells.ts, items.ts) — pure formatters extracted from the existing card mappers. The reference page and card mappers now share one source of truth for casting time / duration / components / cost / weight / AC formula / attunement sentence.
- **Migrated card mappers + content-type** to consume the shared module. Card visual output preserved (existing mapper tests are the regression net).
- **Per-kind stat-block components** at `src/views/reference/` (`MagicItemStatBlock`, `MundaneItemStatBlock`, `SpellStatBlock`) plus a shared `StatList` primitive and a `dtWithin` test helper.
- **Router restructure**: `rootRoute` becomes a pass-through `<Outlet/>`; two pathless layout routes (`app` with `Root`, `reference` with new `ReferenceShell`) sit beneath it. The seven existing routes reparent to `app` with no URL changes.
- **`referenceRoutePath(kind, key)` helper** at `src/views/reference/routeUrl.ts` for the QR follow-up to compose absolute URLs.

**Drive-by bug fix:** `acFormula`'s shield-shaped branch (`ac_base ≤ 5` → `+N AC`) is now applied to magic-item armor too, not just mundane. The 2024 SRD ships Shield (+1) / (+2) / (+3) as magic-item armor with `ac_base: 2` (the bonus, not absolute AC). Pre-fix they rendered as `AC 2` on cards; post-fix they render as `+2 AC`. Pinned by a new mapper test (`src/api/mappers/magicItems.test.ts`).

### Screenshots (if appropriate):
- [ ] Desktop screenshots
- [ ] Mobile width screenshots — the d100 table on Wand of Wonder is the canonical view to capture

### How can this be tested?

Run the dev server and hit a representative spread:

- `http://localhost:5173/reference/magic-items/srd_wand-of-wonder` — the 13.9k-char outlier with the d100 markdown table; horizontal scroll affordance is most visible here. Test at 360–414px viewport.
- `http://localhost:5173/reference/spells/srd_fireball` — V/S/M with `material_specified` ("a tiny ball of bat guano and sulfur") rendered in parens; this is content the printed card hides.
- `http://localhost:5173/reference/spells/srd_bless` — concentration spell ("Concentration, up to 1 minute").
- `http://localhost:5173/reference/spells/srd-2024_detect-magic` — 2024 ritual spell.
- `http://localhost:5173/reference/mundane-items/srd-2024_longsword` — weapon properties rendered as a `<ul>` inside the `<dd>` (Versatile + Topple (Mastery)).
- `http://localhost:5173/reference/mundane-items/srd_abacus` — plain gear, minimal stat block.
- `http://localhost:5173/reference/magic-items/srd-2024_shield-plus-1` — should render `+2 AC` in the Armor row (the bug fix).
- `http://localhost:5173/reference/magic-items/srd_no-such-thing` — 404 with "Back to Deckwright" link, inside the slim chrome.
- `http://localhost:5173/reference/widgets/foo` — unknown kind, 404.
- `http://localhost:5173/` — confirm the rest of the app still renders with full Deckwright chrome (header with user menu, footer); the router restructure shouldn't have shifted any existing URL.

Test coverage (706 total, +102 from this branch):
- Unit tests for every formatter in `src/lib/srd-format/`.
- Component tests for each stat block covering present/omitted rows per field.
- `ReferenceView` integration tests covering all three kinds × both prefixes, 404 paths, `document.title` set on success / 404 / unmount.
- `ReferenceShell` tests verifying brand link present and user menu / footer absent.
- Existing mapper tests preserved as the migration regression net; an extra test pins the magic-item shield rendering.

### Additional Context

**Mobile-UX review feedback addressed inline** (parallel architecture / mobile / skeptical / spec-coverage reviewers ran on the final branch — see commits prefixed `fix(reference): address parallel-review feedback` and `fix(reference): keep first-column table cells on one line`):
- `document.title` resets on unmount so it doesn't leak across SPA navigation.
- 404 link uses TanStack `<Link>` (not a plain `<a>`) to avoid a full page reload on a spotty mobile connection — the worst time to refetch the bundle.
- Brand link tap target is 44px (iOS HIG / WCAG 2.5.5) for one-handed scanning.
- d100 table first-column wrapping fixed (`white-space: nowrap` so "01-05" stays one line).

**Architectural decisions worth flagging to a reviewer:**
- The router restructure moves all 7 existing routes from `rootRoute` to a new pathless `appLayoutRoute`. URLs are unchanged. Existing route-aware tests pass without modification.
- `componentsLabel` in the new module accepts an optional `materialSpecified` to support the reference page's parens variant ("V, S, M (a snake's tongue)"). The card mapper intentionally omits this arg to keep the card footer compact — there's a load-bearing comment at `src/api/mappers/spells.ts` explaining why.
- The magic-item card mapper's attunement string stays inline (lowercase fragment "requires attunement…") rather than using the new `attunementLine` helper, because the reference page uses a capitalized sentence form ("Requires attunement…"). Inlining keeps the divergence visible at the call site.
- Markdown tables use `display: block; overflow-x: auto` with Lea Verou's scroll-shadow technique. Two records (2014 Wings of Flying, 2014 Animate Objects) contain markdown headings (`##`/`###`) that the existing `renderBody.ts` allowlist strips. Accepted as a documented limitation in v1 — widening the allowlist would also affect card pagination.

**Follow-up work** (handoff docs live in `feature_work/` — gitignored, available locally for the next session):
- **`feature_work/auth-provider-scope/handoff.md`** — scope `AuthProvider` to the app shell. Today it wraps `RouterProvider` in `App.tsx`, so QR scanners landing on `/reference/*` trigger `supabase.auth.signInAnonymously()` when `VITE_ANON_USERS_ENABLED=true`, creating an anon `auth.users` row for someone who never asked for an account. Proposed fix: move `AuthProvider` one hop down to wrap only `Root`'s outlet. No `useSession` consumer lives under the reference subtree, so the move is safe.
- **`feature_work/qr-codes/handoff.md`** — the QR-code-on-cards feature itself. Covers the `apiRef.kind` extension needed at the mapper layer (because `Card.kind === "item"` doesn't distinguish magic vs mundane), backfill strategy options, library choice (`qrcode`), print-layout sensitivity per CLAUDE.md, scope question (every API card vs. only paginated > N), and test plan including a manual scan-with-real-phone step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)