### PR TITLE
feat(apiRef): add required kind discriminator; null legacy apiRefs

### DIFF
--- a/src/api/mappers/magicItems.test.ts
+++ b/src/api/mappers/magicItems.test.ts
@@ -48,7 +48,7 @@ describe("magicItemDetailToCard", () => {
     expect(card.body).toBe("This suit of armor is reinforced with adamantine.");
   });
 
-  test("apiRef carries open5e system, the detail key as slug, and the ruleset", () => {
+  test("apiRef carries open5e system, the detail key as slug, the ruleset, and kind='magic-items'", () => {
     const detail = magicItemDetailFactory.build({
       key: "srd-2024_bag-of-holding",
     });
@@ -57,6 +57,7 @@ describe("magicItemDetailToCard", () => {
       system: "open5e",
       slug: "srd-2024_bag-of-holding",
       ruleset: "2024",
+      kind: "magic-items",
     });
   });
 

--- a/src/api/mappers/magicItems.ts
+++ b/src/api/mappers/magicItems.ts
@@ -31,7 +31,12 @@ export const magicItemDetailToCard = (detail: MagicItemDetail): ItemCard => {
     body: detail.desc,
     footerTags,
     source: "api",
-    apiRef: { system: "open5e", slug: detail.key, ruleset: detail.ruleset },
+    apiRef: {
+      system: "open5e",
+      slug: detail.key,
+      ruleset: detail.ruleset,
+      kind: "magic-items",
+    },
     createdAt: now,
     updatedAt: now,
   };

--- a/src/api/mappers/mundaneItems.test.ts
+++ b/src/api/mappers/mundaneItems.test.ts
@@ -25,13 +25,14 @@ describe("mundaneItemDetailToCard", () => {
     expect(card.body).toBe("50 feet of rope.");
   });
 
-  test("apiRef carries open5e system, the detail key as slug, and the ruleset", () => {
+  test("apiRef carries open5e system, the detail key as slug, the ruleset, and kind='mundane-items'", () => {
     const detail = mundaneItemDetailFactory.build({ key: "srd-2024_battleaxe" });
     const card = mundaneItemDetailToCard(detail);
     expect(card.apiRef).toEqual({
       system: "open5e",
       slug: "srd-2024_battleaxe",
       ruleset: detail.ruleset,
+      kind: "mundane-items",
     });
   });
 
@@ -42,6 +43,7 @@ describe("mundaneItemDetailToCard", () => {
       system: "open5e",
       slug: "srd_rope",
       ruleset: "2014",
+      kind: "mundane-items",
     });
   });
 

--- a/src/api/mappers/mundaneItems.ts
+++ b/src/api/mappers/mundaneItems.ts
@@ -46,7 +46,12 @@ export const mundaneItemDetailToCard = (detail: MundaneItemDetail): ItemCard => 
     body: detail.desc,
     footerTags,
     source: "api",
-    apiRef: { system: "open5e", slug: detail.key, ruleset: detail.ruleset },
+    apiRef: {
+      system: "open5e",
+      slug: detail.key,
+      ruleset: detail.ruleset,
+      kind: "mundane-items",
+    },
     createdAt: now,
     updatedAt: now,
   };

--- a/src/api/mappers/spells.test.ts
+++ b/src/api/mappers/spells.test.ts
@@ -10,10 +10,15 @@ describe("spellDetailToCard", () => {
     expect(spellCardSchema.safeParse(card).success).toBe(true);
   });
 
-  test("apiRef carries open5e system, the detail key as slug, and the ruleset", () => {
+  test("apiRef carries open5e system, the detail key as slug, the ruleset, and kind='spells'", () => {
     const detail = spellDetailFactory.build({ key: "srd-2024_fireball" });
     const card = spellDetailToCard(detail);
-    expect(card.apiRef).toEqual({ system: "open5e", slug: "srd-2024_fireball", ruleset: "2024" });
+    expect(card.apiRef).toEqual({
+      system: "open5e",
+      slug: "srd-2024_fireball",
+      ruleset: "2024",
+      kind: "spells",
+    });
   });
 
   test("source is 'api', kind is 'spell', iconKey is left to the heuristic", () => {

--- a/src/api/mappers/spells.ts
+++ b/src/api/mappers/spells.ts
@@ -36,7 +36,12 @@ export const spellDetailToCard = (detail: SpellDetail): SpellCard => {
     body: spellBodyMarkdown(detail.desc, detail.higher_level),
     footerTags,
     source: "api",
-    apiRef: { system: "open5e", slug: detail.key, ruleset: detail.ruleset },
+    apiRef: {
+      system: "open5e",
+      slug: detail.key,
+      ruleset: detail.ruleset,
+      kind: "spells",
+    },
     createdAt: now,
     updatedAt: now,
   };

--- a/src/cards/types.ts
+++ b/src/cards/types.ts
@@ -5,7 +5,12 @@ export type BaseCard = {
   name: string;
   body: string;
   source: "custom" | "api";
-  apiRef?: { system: "open5e"; slug: string; ruleset: "2014" | "2024" };
+  apiRef?: {
+    system: "open5e";
+    slug: string;
+    ruleset: "2014" | "2024";
+    kind: "magic-items" | "mundane-items" | "spells";
+  };
   createdAt: string;
   updatedAt: string;
   iconKey?: string;

--- a/src/decks/schema.test.ts
+++ b/src/decks/schema.test.ts
@@ -31,7 +31,12 @@ describe("itemCardSchema", () => {
       body: "Big bag.",
       footerTags: [],
       source: "api" as const,
-      apiRef: { system: "open5e" as const, slug: "bag-of-holding", ruleset: "2024" as const },
+      apiRef: {
+        system: "open5e" as const,
+        slug: "bag-of-holding",
+        ruleset: "2024" as const,
+        kind: "magic-items" as const,
+      },
       createdAt: "2026-04-19T00:00:00.000Z",
       updatedAt: "2026-04-19T00:00:00.000Z",
     };
@@ -47,7 +52,12 @@ describe("itemCardSchema", () => {
       body: "Big bag.",
       footerTags: [],
       source: "api" as const,
-      apiRef: { system: "open5e" as const, slug: "bag-of-holding", ruleset: "2014" as const },
+      apiRef: {
+        system: "open5e" as const,
+        slug: "bag-of-holding",
+        ruleset: "2014" as const,
+        kind: "magic-items" as const,
+      },
       createdAt: "2026-04-19T00:00:00.000Z",
       updatedAt: "2026-04-19T00:00:00.000Z",
     };
@@ -110,7 +120,22 @@ describe("itemCardSchema", () => {
       headerTags: [],
       body: "",
       source: "api" as const,
-      apiRef: { system: "open5e" as const, slug: "x" },
+      apiRef: { system: "open5e" as const, slug: "x", kind: "magic-items" as const },
+      createdAt: "2026-04-19T00:00:00.000Z",
+      updatedAt: "2026-04-19T00:00:00.000Z",
+    };
+    expect(itemCardSchema.safeParse(card).success).toBe(false);
+  });
+
+  test("rejects an apiRef without a kind", () => {
+    const card = {
+      id: "abc",
+      kind: "item" as const,
+      name: "X",
+      headerTags: [],
+      body: "",
+      source: "api" as const,
+      apiRef: { system: "open5e" as const, slug: "x", ruleset: "2024" as const },
       createdAt: "2026-04-19T00:00:00.000Z",
       updatedAt: "2026-04-19T00:00:00.000Z",
     };

--- a/src/decks/schema.ts
+++ b/src/decks/schema.ts
@@ -4,6 +4,7 @@ const apiRefSchema = z.object({
   system: z.literal("open5e"),
   slug: z.string(),
   ruleset: z.enum(["2014", "2024"]),
+  kind: z.enum(["magic-items", "mundane-items", "spells"]),
 });
 
 const baseCardSchema = z.object({

--- a/supabase/migrations/20260513000000_apiref_add_kind.sql
+++ b/supabase/migrations/20260513000000_apiref_add_kind.sql
@@ -1,3 +1,35 @@
+-- 20260513000000_apiref_add_kind.sql
+-- Add a required `kind` discriminator to apiRef ("magic-items" | "mundane-items" | "spells").
+-- Cards persist `Card.kind` ("item" | "spell" | "ability"), but for items that's
+-- ambiguous between magic and mundane SRD sources. The new `apiRef.kind` is what
+-- the upcoming reference-route / QR-code feature uses to construct
+-- /reference/$kind/$key URLs without a runtime slug-to-kind lookup.
+--
+-- Backfill strategy: NULL OUT apiRef on every existing row instead of inferring
+-- kind from the bundled SRD JSON. At time of writing prod holds ~16 cards
+-- total, so the cost (losing the SRD slug pointer on those cards; QR codes
+-- won't render until they're re-imported) is trivial compared to the
+-- complexity of a slug→kind map embedded in this migration. Re-imports from
+-- the SRD pickers will repopulate apiRef with the new shape automatically.
+--
+-- The embedded JSON Schema below is generated from src/decks/schema.ts via
+-- `npm run gen:schema`. To update it, regenerate the JSON file and write a
+-- NEW migration that follows the same drop-then-add pattern below — never
+-- edit this file in place.
+
+create extension if not exists pg_jsonschema;
+
+alter table public.cards drop constraint if exists cards_payload_valid;
+
+-- Strip apiRef from every existing card. Re-import to repopulate.
+update public.cards
+set payload = payload - 'apiRef'
+where payload ? 'apiRef';
+
+alter table public.cards
+  add constraint cards_payload_valid
+  check (jsonb_matches_schema(
+    $cardpayload$
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "oneOf": [
@@ -273,3 +305,9 @@
     }
   ]
 }
+    $cardpayload$::json,
+    payload
+  ));
+
+comment on constraint cards_payload_valid on public.cards is
+  'JSON Schema validation generated from src/decks/schema.ts via npm run gen:schema. Regen requires a new migration that drops + re-adds this constraint.';


### PR DESCRIPTION
### What are the relevant tickets?

N/A — verbal feature request. Prep for the upcoming QR-code-on-cards feature, which builds on the reference routes added in #77.

### Description (What does it do?)

Adds a required `kind` discriminator to `apiRef` (`"magic-items" | "mundane-items" | "spells"`). `apiRef` itself stays optional; when present, all four fields (`system`, `slug`, `ruleset`, `kind`) are required.

Why: `Card.kind === "item"` doesn't distinguish magic vs mundane SRD items, but the reference routes from #77 do (`/reference/$kind/$key`). The upcoming QR feature needs to build that URL from `apiRef` directly, without a runtime slug-to-kind lookup against the bundled SRD JSON. The new field's vocabulary matches `ReferenceKind` in `src/views/ReferenceView.tsx` and what `referenceRoutePath` consumes — the QR feature can drop straight into `referenceRoutePath(card.apiRef.kind, card.apiRef.slug)`.

Three coordinated pieces:
- **Zod + TS type** — `apiRef.kind` required when apiRef is present. `apiRef` itself remains optional (custom cards still have no apiRef).
- **Mappers** — `magicItems`, `mundaneItems`, `spells` each emit the appropriate kind. Mapper and schema tests updated; one new schema test covers the reject-without-kind path.
- **Supabase migration** (`supabase/migrations/20260513000000_apiref_add_kind.sql`) — drops the `cards_payload_valid` CHECK, strips `apiRef` from every existing row via `payload - 'apiRef'`, re-adds the CHECK with the regenerated JSON Schema heredoc. Same drop-then-add pattern as `20260504113000_swap_apiref_system_to_open5e.sql` and `20260504120000_hoist_tags_to_base.sql`.

**Backfill strategy: null, don't migrate.** Prod holds ~16 cards at time of writing. The cost (losing the SRD slug pointer on those cards until they're re-imported, which repopulates apiRef in the new shape automatically) is trivial compared to the complexity of an embedded slug→kind map in the migration. Verified by grep that nothing in `src/` reads `apiRef` today — the QR feature is the first reader — so nothing visible breaks. The full rationale is in the migration's header comment.

### How can this be tested?

- `npm test` — covers the new schema rejection case (`src/decks/schema.test.ts`) and the updated mapper expectations (each mapper's test now asserts the emitted `apiRef.kind`).
- `npm run gen:schema -- --check` — verifies `supabase/schemas/card-payload.json` matches what the Zod schema currently produces.
- Manual smoke test after applying the migration locally: import any magic item, mundane item, and spell via the API picker; confirm the resulting card has the expected `apiRef.kind` in the deck JSON.
- The CHECK in the new migration is exercised by the same JSON-Schema runtime (`pg_jsonschema`) that the existing migrations use — any payload missing `apiRef.kind` (when apiRef is present) will be rejected at write time.

### Additional Context

**Deploy ordering** — there's a brief window between the migration applying and the client deploy where an old client could try to write an old-shape apiRef and get rejected by the new CHECK. The affected operation is "import a new SRD card via the picker" — recoverable (user retries) but worth being aware of. Apply the migration immediately with (not days before) the client deploy.

**Why null instead of backfill** — the discussion that led to this choice is worth a sentence here: a slug→kind map embedded in the migration as a `VALUES` CTE would have been the durable answer (zero runtime risk forever), but with ~16 prod cards the trade isn't worth the ~50KB migration file. The bundled SRD JSON would be the wrong runtime fallback anyway (collision risk if open5e ever ships the same slug under both kinds), and the migration would silently lose any rows whose slug is no longer present in the current SRD snapshot.

**Pre-merge** — recommend confirming Supabase point-in-time recovery is on (or taking a manual `cards` table export) before applying the migration, since the UPDATE is destructive.

**Follow-up** — the QR-code feature itself is the next piece of work; this PR just creates the schema affordance it needs.