### PR TITLE
feat(cards): add referenceUrl QR code in card footer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "dompurify": "^3.4.2",
         "fuzzysort": "^3.1.0",
         "marked": "^18.0.3",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.5",
         "react-aria-components": "^1.17.0",
         "react-dom": "^19.2.5",
@@ -4470,6 +4471,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dompurify": "^3.4.2",
     "fuzzysort": "^3.1.0",
     "marked": "^18.0.3",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.5",
     "react-aria-components": "^1.17.0",
     "react-dom": "^19.2.5",

--- a/src/api/mappers/magicItems.test.ts
+++ b/src/api/mappers/magicItems.test.ts
@@ -61,6 +61,14 @@ describe("magicItemDetailToCard", () => {
     });
   });
 
+  test("referenceUrl points at the in-app /reference/magic-items/$key route", () => {
+    const detail = magicItemDetailFactory.build({ key: "srd-2024_bag-of-holding" });
+    const card = magicItemDetailToCard(detail);
+    expect(card.referenceUrl).toBe(
+      `${window.location.origin}/reference/magic-items/srd-2024_bag-of-holding`,
+    );
+  });
+
   test("source is 'api'", () => {
     const detail = magicItemDetailFactory.build();
     const card = magicItemDetailToCard(detail);

--- a/src/api/mappers/magicItems.ts
+++ b/src/api/mappers/magicItems.ts
@@ -2,6 +2,7 @@ import type { ItemCard } from "../../cards/types";
 import { newId } from "../../lib/id";
 import { acFormula, formatWeight } from "../../lib/srd-format/items";
 import { nowIso } from "../../lib/time";
+import { referenceAbsoluteUrl } from "../../views/reference/routeUrl";
 import type { MagicItemDetail } from "../endpoints/magicItems";
 
 export const magicItemDetailToCard = (detail: MagicItemDetail): ItemCard => {
@@ -37,6 +38,7 @@ export const magicItemDetailToCard = (detail: MagicItemDetail): ItemCard => {
       ruleset: detail.ruleset,
       kind: "magic-items",
     },
+    referenceUrl: referenceAbsoluteUrl("magic-items", detail.key),
     createdAt: now,
     updatedAt: now,
   };

--- a/src/api/mappers/mundaneItems.test.ts
+++ b/src/api/mappers/mundaneItems.test.ts
@@ -47,6 +47,14 @@ describe("mundaneItemDetailToCard", () => {
     });
   });
 
+  test("referenceUrl points at the in-app /reference/mundane-items/$key route", () => {
+    const detail = mundaneItemDetailFactory.build({ key: "srd-2024_battleaxe" });
+    const card = mundaneItemDetailToCard(detail);
+    expect(card.referenceUrl).toBe(
+      `${window.location.origin}/reference/mundane-items/srd-2024_battleaxe`,
+    );
+  });
+
   test("source is 'api', kind is 'item'", () => {
     const detail = mundaneItemDetailFactory.build();
     const card = mundaneItemDetailToCard(detail);

--- a/src/api/mappers/mundaneItems.ts
+++ b/src/api/mappers/mundaneItems.ts
@@ -8,6 +8,7 @@ import {
   weaponPropertyLabel,
 } from "../../lib/srd-format/items";
 import { nowIso } from "../../lib/time";
+import { referenceAbsoluteUrl } from "../../views/reference/routeUrl";
 import type { MundaneItemDetail } from "../endpoints/mundaneItems";
 
 const capitalize = (s: string): string => s.charAt(0).toUpperCase() + s.slice(1);
@@ -52,6 +53,7 @@ export const mundaneItemDetailToCard = (detail: MundaneItemDetail): ItemCard => 
       ruleset: detail.ruleset,
       kind: "mundane-items",
     },
+    referenceUrl: referenceAbsoluteUrl("mundane-items", detail.key),
     createdAt: now,
     updatedAt: now,
   };

--- a/src/api/mappers/spells.test.ts
+++ b/src/api/mappers/spells.test.ts
@@ -21,6 +21,12 @@ describe("spellDetailToCard", () => {
     });
   });
 
+  test("referenceUrl points at the in-app /reference/spells/$key route", () => {
+    const detail = spellDetailFactory.build({ key: "srd-2024_fireball" });
+    const card = spellDetailToCard(detail);
+    expect(card.referenceUrl).toBe(`${window.location.origin}/reference/spells/srd-2024_fireball`);
+  });
+
   test("source is 'api', kind is 'spell', iconKey is left to the heuristic", () => {
     const detail = spellDetailFactory.build();
     const card = spellDetailToCard(detail);

--- a/src/api/mappers/spells.ts
+++ b/src/api/mappers/spells.ts
@@ -9,6 +9,7 @@ import {
   spellBodyMarkdown,
 } from "../../lib/srd-format/spells";
 import { nowIso } from "../../lib/time";
+import { referenceAbsoluteUrl } from "../../views/reference/routeUrl";
 import type { SpellDetail } from "../endpoints/spells";
 
 export const spellDetailToCard = (detail: SpellDetail): SpellCard => {
@@ -42,6 +43,7 @@ export const spellDetailToCard = (detail: SpellDetail): SpellCard => {
       ruleset: detail.ruleset,
       kind: "spells",
     },
+    referenceUrl: referenceAbsoluteUrl("spells", detail.key),
     createdAt: now,
     updatedAt: now,
   };

--- a/src/cards/Card.module.css
+++ b/src/cards/Card.module.css
@@ -21,12 +21,29 @@
   --card-base: 17px;
   --card-width: 3.75in;
   --card-height: 5in;
+  /* Expressed in px (via calc) rather than em so the resolved length stays
+     constant across contexts that change font-size (e.g. .body table has
+     font-size: 0.92em, which would otherwise shrink an em-based --qr-size
+     by ~8% relative to its value at .body — enough for the table to overhang
+     the QR float and trip BFC clearing). */
+  --qr-size: calc(3.4 * var(--card-base));
+  /* How much of the QR sits INSIDE the body (vs straddling into the footer).
+     Equals qr-size minus the footer's rendered height. The footer is sized
+     by its own style values (font-size 0.85em, margin-top + padding-top
+     0.5em each, 1px border, default line-height ~1.2): roughly
+     1.92 * card-base + 1px. We undershoot slightly to 1.9 * card-base so
+     the body reserve is a few px taller than strictly needed — small safety
+     buffer that prevents text from crossing into the QR if the footer
+     renders any taller. */
+  --qr-body-overhang: calc(var(--qr-size) - 1.9 * var(--card-base));
 }
 
 .perPage2 {
   --card-base: 24px;
   --card-width: 5in;
   --card-height: 7.5in;
+  --qr-size: calc(3.2 * var(--card-base));
+  --qr-body-overhang: calc(var(--qr-size) - 1.9 * var(--card-base));
 }
 
 .icon {
@@ -107,6 +124,68 @@
   /* Wrapper span — groups tags as a single flex item alongside .footerRight. */
 }
 
+/* When a card has a referenceUrl, the QR overlays the footer's right column.
+   The margin-right pulls the footer's right edge (and its border-top divider)
+   in so there's a visible gap between the divider and the QR. The gap matches
+   the card's own padding (1.15em of card-base) so the QR has the same
+   breathing room from the divider as content has from the card edge.
+   Pagination text keeps its default margin-left:auto (from .footerRight), so
+   it stays right-aligned within the narrowed footer — matching continuation
+   pages. */
+.footerWithQr {
+  margin-right: calc(var(--qr-size) + 1.15 * var(--card-base));
+}
+
+/* QR layout. Three pieces:
+   - .qrPusher: zero-width float at the top of .body. Reserves vertical space
+     on the right column without obstructing block-level children (tables, DLs,
+     etc. — which establish their own BFC and would otherwise be pushed below
+     any nonzero-width float). Its sole purpose is to push the next floated
+     sibling down to the bottom of the body.
+   - .qrReserve: actual float that .qrPusher displaces to the bottom-right.
+     This is what inline text wraps around. A table only conflicts with it if
+     the table extends down into the bottom-right corner — in which case the
+     paginator naturally pushes it to the next page.
+   - .qrCorner: the visible QR, absolutely positioned in the card's
+     bottom-right corner. Overlaps the body's bottom corner AND the right
+     portion of the footer (which is left empty when QR is present, see
+     .footerWithQr).
+*/
+.qrPusher {
+  float: right;
+  width: 0;
+  height: calc(100% - var(--qr-body-overhang));
+}
+
+.qrReserve {
+  float: right;
+  clear: right;
+  width: var(--qr-size);
+  height: var(--qr-body-overhang);
+}
+
+.qrCorner {
+  position: absolute;
+  bottom: 1.15em;
+  right: 1.15em;
+  width: var(--qr-size);
+  height: var(--qr-size);
+  background: var(--print-color-paper);
+}
+
+.qrCorner svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+/* When the QR decoration is present, the first normal-flow markdown element
+   follows .qrReserve in source order. Apply the same margin-top reset the
+   real first child gets (.body > :first-child rule above). */
+.body > .qrReserve + * {
+  margin-top: 0;
+}
+
 .footerTag + .footerTag::before {
   content: " | ";
   white-space: pre;
@@ -167,6 +246,22 @@
 
 .body th {
   font-weight: 600;
+}
+
+/* Tables establish their own Block Formatting Context, and the CSS spec
+   forbids a BFC's border box from overlapping the margin box of any float in
+   the same BFC. Our .body table is width: 100%, which (without this rule)
+   shares its right edge with the QR floats. Browsers conservatively treat
+   edge-sharing as overlap and "clear" the table by placing it below all
+   preceding floats — i.e. below .qrReserve, which sits at the body's bottom
+   right. The result: tables on page 1 get pushed below the body entirely and
+   the paginator slices them onto page 2+.
+   Capping table width gives the table genuine room beside the right-column
+   floats at any vertical position, so it stays in normal flow. Same goes for
+   other BFC-establishing block elements (e.g. <pre>). */
+.body > .qrPusher ~ table,
+.body > .qrPusher ~ pre {
+  max-width: calc(100% - var(--qr-size));
 }
 
 @media print {

--- a/src/cards/Card.module.css
+++ b/src/cards/Card.module.css
@@ -257,10 +257,10 @@
    right. The result: tables on page 1 get pushed below the body entirely and
    the paginator slices them onto page 2+.
    Capping table width gives the table genuine room beside the right-column
-   floats at any vertical position, so it stays in normal flow. Same goes for
-   other BFC-establishing block elements (e.g. <pre>). */
-.body > .qrPusher ~ table,
-.body > .qrPusher ~ pre {
+   floats at any vertical position, so it stays in normal flow. Only <table>
+   appears in renderBody's allowlist today; if other BFC-establishing tags
+   are added (pre, blockquote with overflow, etc.), extend the selector. */
+.body > .qrPusher ~ table {
   max-width: calc(100% - var(--qr-size));
 }
 

--- a/src/cards/Card.test.tsx
+++ b/src/cards/Card.test.tsx
@@ -140,6 +140,38 @@ describe("<Card> with pagination", () => {
   });
 });
 
+describe("<Card> with a referenceUrl (QR code)", () => {
+  test("renders the QR corner when card has a referenceUrl", () => {
+    const card = itemCardFactory.build({ referenceUrl: "https://example.com/x" });
+    render(<Card card={card} cardsPerPage={4} />);
+    expect(screen.getByTestId("card-qr")).toBeInTheDocument();
+  });
+
+  test("omits the QR corner when card has no referenceUrl", () => {
+    const card = itemCardFactory.build();
+    render(<Card card={card} cardsPerPage={4} />);
+    expect(screen.queryByTestId("card-qr")).not.toBeInTheDocument();
+  });
+
+  test("omits the QR corner on continuation pages even when referenceUrl is set", () => {
+    const card = itemCardFactory.build({ referenceUrl: "https://example.com/x" });
+    render(<Card card={card} cardsPerPage={4} pagination={{ page: 2, total: 3 }} />);
+    expect(screen.queryByTestId("card-qr")).not.toBeInTheDocument();
+  });
+
+  test("applies the footerWithQr layout (narrowed divider) when a QR is present", () => {
+    const card = itemCardFactory.build({ referenceUrl: "https://example.com/x" });
+    render(<Card card={card} cardsPerPage={4} pagination={{ page: 1, total: 3 }} />);
+    expect(screen.getByTestId("card-footer").className).toMatch(/footerWithQr/);
+  });
+
+  test("does not switch the footer layout when there is no referenceUrl", () => {
+    const card = itemCardFactory.build();
+    render(<Card card={card} cardsPerPage={4} pagination={{ page: 1, total: 3 }} />);
+    expect(screen.getByTestId("card-footer").className).not.toMatch(/footerWithQr/);
+  });
+});
+
 describe("<Card> with markdown body", () => {
   test("renders bold and italic", () => {
     const card = itemCardFactory.build({ body: "**Curse**. _italic_ text." });

--- a/src/cards/Card.test.tsx
+++ b/src/cards/Card.test.tsx
@@ -170,6 +170,12 @@ describe("<Card> with a referenceUrl (QR code)", () => {
     render(<Card card={card} cardsPerPage={4} pagination={{ page: 1, total: 3 }} />);
     expect(screen.getByTestId("card-footer").className).not.toMatch(/footerWithQr/);
   });
+
+  test("does not apply footerWithQr on continuation pages even when card has a referenceUrl", () => {
+    const card = itemCardFactory.build({ referenceUrl: "https://example.com/x" });
+    render(<Card card={card} cardsPerPage={4} pagination={{ page: 2, total: 3 }} />);
+    expect(screen.getByTestId("card-footer").className).not.toMatch(/footerWithQr/);
+  });
 });
 
 describe("<Card> with markdown body", () => {

--- a/src/cards/Card.tsx
+++ b/src/cards/Card.tsx
@@ -24,10 +24,11 @@ export function Card({ card, cardsPerPage, pagination, bodyHtml }: Props) {
 
   const isFirstPage = !pagination || pagination.page === 1;
   const showQr = isFirstPage && !!card.referenceUrl;
-  // When bodyHtml is provided by an upstream paginator (expandCard), it already
-  // carries the qrFloat prefix on page 1 — the slice naturally drops it on
-  // continuation pages. When rendering without pagination (editor preview), we
-  // build the html here and add the prefix ourselves.
+  // When bodyHtml is provided (every paginated render goes through expandCard,
+  // which prefixes the qrFloat onto page 1 and naturally drops it on
+  // continuation pages via the slice), use it as-is. The fallback below
+  // handles non-paginated render paths (tests and any future direct Card use)
+  // by adding the prefix ourselves so the layout still measures correctly.
   const html = bodyHtml ?? (showQr ? qrFloatHtml() + renderBody(card.body) : renderBody(card.body));
 
   const showFooterTags = isFirstPage && card.footerTags.length > 0;

--- a/src/cards/Card.tsx
+++ b/src/cards/Card.tsx
@@ -1,6 +1,8 @@
+import { QRCodeSVG } from "qrcode.react";
 import styles from "./Card.module.css";
 import { FramedIcon } from "./FramedIcon";
 import { pickIconKey } from "./iconRules";
+import { qrFloatHtml } from "./qrFloat";
 import { renderBody } from "./renderBody";
 import type { RenderableCard } from "./types";
 
@@ -21,9 +23,16 @@ export function Card({ card, cardsPerPage, pagination, bodyHtml }: Props) {
   const iconKey = card.iconKey ?? pickIconKey(card);
 
   const isFirstPage = !pagination || pagination.page === 1;
-  const html = bodyHtml ?? renderBody(card.body);
+  const showQr = isFirstPage && !!card.referenceUrl;
+  // When bodyHtml is provided by an upstream paginator (expandCard), it already
+  // carries the qrFloat prefix on page 1 — the slice naturally drops it on
+  // continuation pages. When rendering without pagination (editor preview), we
+  // build the html here and add the prefix ourselves.
+  const html = bodyHtml ?? (showQr ? qrFloatHtml() + renderBody(card.body) : renderBody(card.body));
+
   const showFooterTags = isFirstPage && card.footerTags.length > 0;
   const showFooter = showFooterTags || pagination !== undefined;
+  const footerClass = showQr ? `${styles.footer} ${styles.footerWithQr}` : styles.footer;
 
   return (
     <div className={`${styles.card} ${layoutClass}`} data-role="card-root">
@@ -55,7 +64,7 @@ export function Card({ card, cardsPerPage, pagination, bodyHtml }: Props) {
         dangerouslySetInnerHTML={{ __html: html }}
       />
       {showFooter && (
-        <div className={styles.footer} data-testid="card-footer">
+        <div className={footerClass} data-testid="card-footer">
           {showFooterTags && (
             <span className={styles.footerTags}>
               {card.footerTags.map((tag) => (
@@ -70,6 +79,11 @@ export function Card({ card, cardsPerPage, pagination, bodyHtml }: Props) {
               Card {pagination.page} of {pagination.total}
             </span>
           )}
+        </div>
+      )}
+      {showQr && card.referenceUrl && (
+        <div className={styles.qrCorner} data-testid="card-qr" aria-hidden="true">
+          <QRCodeSVG value={card.referenceUrl} size={96} />
         </div>
       )}
     </div>

--- a/src/cards/CardEditor.module.css
+++ b/src/cards/CardEditor.module.css
@@ -39,3 +39,26 @@
   flex: 1;
   min-width: 0;
 }
+
+/* Inline action styled as a link, used inside .help text for the
+   Reset-to-SRD-link and Disconnect-from-SRD affordances. Matches the Link
+   primitive's accent + underline, but renders as a <button> because these
+   are actions, not navigation. */
+.linkButton {
+  background: none;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  color: var(--color-accent);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.linkButton:hover {
+  color: var(--color-accent-hover);
+}
+
+.linkButton:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}

--- a/src/cards/CardEditor.test.tsx
+++ b/src/cards/CardEditor.test.tsx
@@ -152,6 +152,32 @@ describe("<CardEditor>", () => {
     expect(screen.getByText(/suggested order: rarity, cost, weight/i)).toBeInTheDocument();
   });
 
+  test("Reference link field reflects card.referenceUrl", () => {
+    const card = itemCardFactory.build({ referenceUrl: "https://example.com/r" });
+    render(<Harness initial={card} />);
+    expect(screen.getByLabelText(/reference link/i)).toHaveValue("https://example.com/r");
+  });
+
+  test("typing in the Reference link field updates card.referenceUrl", async () => {
+    const card = itemCardFactory.build();
+    const seen: RenderableCard[] = [];
+    render(<Harness initial={card} onEach={(c) => seen.push(c)} />);
+
+    await userEvent.type(screen.getByLabelText(/reference link/i), "https://x");
+
+    expect(seen[seen.length - 1]?.referenceUrl).toBe("https://x");
+  });
+
+  test("clearing the Reference link field sets referenceUrl to undefined", async () => {
+    const card = itemCardFactory.build({ referenceUrl: "https://example.com/r" });
+    const seen: RenderableCard[] = [];
+    render(<Harness initial={card} onEach={(c) => seen.push(c)} />);
+
+    await userEvent.clear(screen.getByLabelText(/reference link/i));
+
+    expect(seen[seen.length - 1]?.referenceUrl).toBeUndefined();
+  });
+
   test("switching Type from Item to Spell updates kind without losing other fields", async () => {
     const card = itemCardFactory.build();
     const seen: RenderableCard[] = [];

--- a/src/cards/CardEditor.test.tsx
+++ b/src/cards/CardEditor.test.tsx
@@ -186,56 +186,62 @@ describe("<CardEditor>", () => {
   };
   const srdUrlBag = `${window.location.origin}/reference/magic-items/srd-2024_bag-of-holding`;
 
-  test("'Use reference page' action is hidden when card has no apiRef", () => {
+  test("'Restore original link' action is hidden when card has no apiRef", () => {
     const card = itemCardFactory.build();
     render(<Harness initial={card} />);
-    expect(screen.queryByRole("button", { name: /use reference page/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /restore original link/i }),
+    ).not.toBeInTheDocument();
   });
 
-  test("'Use reference page' action is hidden when referenceUrl already matches the SRD-derived URL", () => {
+  test("'Restore original link' action is hidden when referenceUrl already matches the SRD-derived URL", () => {
     const card = itemCardFactory.build({ apiRef: apiRefBag, referenceUrl: srdUrlBag });
     render(<Harness initial={card} />);
-    expect(screen.queryByRole("button", { name: /use reference page/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /restore original link/i }),
+    ).not.toBeInTheDocument();
   });
 
-  test("'Use reference page' action is shown when apiRef exists and referenceUrl is empty", () => {
+  test("'Restore original link' action is shown when apiRef exists and referenceUrl is empty", () => {
     const card = itemCardFactory.build({ apiRef: apiRefBag, referenceUrl: undefined });
     render(<Harness initial={card} />);
-    expect(screen.getByRole("button", { name: /use reference page/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /restore original link/i })).toBeInTheDocument();
   });
 
-  test("'Use reference page' action is shown when referenceUrl differs from the SRD-derived URL", () => {
+  test("'Restore original link' action is shown when referenceUrl differs from the SRD-derived URL", () => {
     const card = itemCardFactory.build({
       apiRef: apiRefBag,
       referenceUrl: "https://elsewhere.example/x",
     });
     render(<Harness initial={card} />);
-    expect(screen.getByRole("button", { name: /use reference page/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /restore original link/i })).toBeInTheDocument();
   });
 
-  test("clicking 'Use reference page' sets referenceUrl to the apiRef-derived URL", async () => {
+  test("clicking 'Restore original link' sets referenceUrl to the apiRef-derived URL", async () => {
     const card = itemCardFactory.build({ apiRef: apiRefBag, referenceUrl: undefined });
     const seen: RenderableCard[] = [];
     render(<Harness initial={card} onEach={(c) => seen.push(c)} />);
 
-    await userEvent.click(screen.getByRole("button", { name: /use reference page/i }));
+    await userEvent.click(screen.getByRole("button", { name: /restore original link/i }));
 
     expect(seen[seen.length - 1]?.referenceUrl).toBe(srdUrlBag);
   });
 
-  test("'permanently clear' action is hidden when card has no apiRef", () => {
+  test("'permanently disconnect' action is hidden when card has no apiRef", () => {
     const card = itemCardFactory.build();
     render(<Harness initial={card} />);
-    expect(screen.queryByRole("button", { name: /permanently clear/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /permanently disconnect/i }),
+    ).not.toBeInTheDocument();
   });
 
-  test("'permanently clear' action is shown whenever apiRef exists", () => {
+  test("'permanently disconnect' action is shown whenever apiRef exists", () => {
     const card = itemCardFactory.build({ apiRef: apiRefBag, referenceUrl: srdUrlBag });
     render(<Harness initial={card} />);
-    expect(screen.getByRole("button", { name: /permanently clear/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /permanently disconnect/i })).toBeInTheDocument();
   });
 
-  test("clicking 'permanently clear' clears apiRef but leaves referenceUrl unchanged", async () => {
+  test("clicking 'permanently disconnect' clears apiRef but leaves referenceUrl unchanged", async () => {
     const card = itemCardFactory.build({
       apiRef: apiRefBag,
       referenceUrl: "https://example.com/keepme",
@@ -243,7 +249,7 @@ describe("<CardEditor>", () => {
     const seen: RenderableCard[] = [];
     render(<Harness initial={card} onEach={(c) => seen.push(c)} />);
 
-    await userEvent.click(screen.getByRole("button", { name: /permanently clear/i }));
+    await userEvent.click(screen.getByRole("button", { name: /permanently disconnect/i }));
 
     const last = seen[seen.length - 1];
     expect(last?.apiRef).toBeUndefined();

--- a/src/cards/CardEditor.test.tsx
+++ b/src/cards/CardEditor.test.tsx
@@ -178,6 +178,78 @@ describe("<CardEditor>", () => {
     expect(seen[seen.length - 1]?.referenceUrl).toBeUndefined();
   });
 
+  const apiRefBag = {
+    system: "open5e" as const,
+    slug: "srd-2024_bag-of-holding",
+    ruleset: "2024" as const,
+    kind: "magic-items" as const,
+  };
+  const srdUrlBag = `${window.location.origin}/reference/magic-items/srd-2024_bag-of-holding`;
+
+  test("'Use reference page' action is hidden when card has no apiRef", () => {
+    const card = itemCardFactory.build();
+    render(<Harness initial={card} />);
+    expect(screen.queryByRole("button", { name: /use reference page/i })).not.toBeInTheDocument();
+  });
+
+  test("'Use reference page' action is hidden when referenceUrl already matches the SRD-derived URL", () => {
+    const card = itemCardFactory.build({ apiRef: apiRefBag, referenceUrl: srdUrlBag });
+    render(<Harness initial={card} />);
+    expect(screen.queryByRole("button", { name: /use reference page/i })).not.toBeInTheDocument();
+  });
+
+  test("'Use reference page' action is shown when apiRef exists and referenceUrl is empty", () => {
+    const card = itemCardFactory.build({ apiRef: apiRefBag, referenceUrl: undefined });
+    render(<Harness initial={card} />);
+    expect(screen.getByRole("button", { name: /use reference page/i })).toBeInTheDocument();
+  });
+
+  test("'Use reference page' action is shown when referenceUrl differs from the SRD-derived URL", () => {
+    const card = itemCardFactory.build({
+      apiRef: apiRefBag,
+      referenceUrl: "https://elsewhere.example/x",
+    });
+    render(<Harness initial={card} />);
+    expect(screen.getByRole("button", { name: /use reference page/i })).toBeInTheDocument();
+  });
+
+  test("clicking 'Use reference page' sets referenceUrl to the apiRef-derived URL", async () => {
+    const card = itemCardFactory.build({ apiRef: apiRefBag, referenceUrl: undefined });
+    const seen: RenderableCard[] = [];
+    render(<Harness initial={card} onEach={(c) => seen.push(c)} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /use reference page/i }));
+
+    expect(seen[seen.length - 1]?.referenceUrl).toBe(srdUrlBag);
+  });
+
+  test("'permanently clear' action is hidden when card has no apiRef", () => {
+    const card = itemCardFactory.build();
+    render(<Harness initial={card} />);
+    expect(screen.queryByRole("button", { name: /permanently clear/i })).not.toBeInTheDocument();
+  });
+
+  test("'permanently clear' action is shown whenever apiRef exists", () => {
+    const card = itemCardFactory.build({ apiRef: apiRefBag, referenceUrl: srdUrlBag });
+    render(<Harness initial={card} />);
+    expect(screen.getByRole("button", { name: /permanently clear/i })).toBeInTheDocument();
+  });
+
+  test("clicking 'permanently clear' clears apiRef but leaves referenceUrl unchanged", async () => {
+    const card = itemCardFactory.build({
+      apiRef: apiRefBag,
+      referenceUrl: "https://example.com/keepme",
+    });
+    const seen: RenderableCard[] = [];
+    render(<Harness initial={card} onEach={(c) => seen.push(c)} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /permanently clear/i }));
+
+    const last = seen[seen.length - 1];
+    expect(last?.apiRef).toBeUndefined();
+    expect(last?.referenceUrl).toBe("https://example.com/keepme");
+  });
+
   test("switching Type from Item to Spell updates kind without losing other fields", async () => {
     const card = itemCardFactory.build();
     const seen: RenderableCard[] = [];

--- a/src/cards/CardEditor.tsx
+++ b/src/cards/CardEditor.tsx
@@ -231,10 +231,9 @@ export function CardEditor({ card, onChange }: Props) {
                   >
                     Restore original link
                   </button>
-                  .
                 </>
               )}{" "}
-              {canResetReferenceUrl ? "Or " : ""}
+              {canResetReferenceUrl ? "or " : ""}
               <button type="button" className={styles.linkButton} onClick={handleDisconnectApiRef}>
                 {canResetReferenceUrl ? "permanently disconnect" : "Permanently disconnect"}
               </button>

--- a/src/cards/CardEditor.tsx
+++ b/src/cards/CardEditor.tsx
@@ -38,6 +38,15 @@ export function CardEditor({ card, onChange }: Props) {
     onChange({ ...card, footerTags: next, updatedAt: nowIso() });
   };
 
+  const handleReferenceUrlChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    onChange({
+      ...card,
+      referenceUrl: value === "" ? undefined : value,
+      updatedAt: nowIso(),
+    });
+  };
+
   const handleKindChange = (next: "item" | "spell") => {
     if (next === card.kind) return;
     onChange({ ...card, kind: next, updatedAt: nowIso() } as RenderableCard);
@@ -61,6 +70,8 @@ export function CardEditor({ card, onChange }: Props) {
     footerTags: `${idBase}-footerTags`,
     footerTagsLabel: `${idBase}-footerTagsLabel`,
     footerTagsHelp: `${idBase}-footerTagsHelp`,
+    referenceUrl: `${idBase}-referenceUrl`,
+    referenceUrlHelp: `${idBase}-referenceUrlHelp`,
     typeLabel: `${idBase}-typeLabel`,
   };
 
@@ -179,6 +190,20 @@ export function CardEditor({ card, onChange }: Props) {
           Suggested order: rarity, cost, weight.
         </span>
       </div>
+      <label className={styles.field} htmlFor={ids.referenceUrl}>
+        <span className={styles.label}>Reference link</span>
+        <Input
+          id={ids.referenceUrl}
+          aria-describedby={ids.referenceUrlHelp}
+          value={card.referenceUrl ?? ""}
+          onChange={handleReferenceUrlChange}
+          placeholder="https://…"
+        />
+        <span id={ids.referenceUrlHelp} className={styles.help}>
+          Rendered as a QR code in the card’s bottom-right corner. Leave blank to omit. SRD-imported
+          cards prefill with the in-app reference page.
+        </span>
+      </label>
     </form>
   );
 }

--- a/src/cards/CardEditor.tsx
+++ b/src/cards/CardEditor.tsx
@@ -229,16 +229,16 @@ export function CardEditor({ card, onChange }: Props) {
                     className={styles.linkButton}
                     onClick={handleResetReferenceUrl}
                   >
-                    Use reference page
+                    Restore original link
                   </button>
                   .
                 </>
               )}{" "}
               {canResetReferenceUrl ? "Or " : ""}
               <button type="button" className={styles.linkButton} onClick={handleDisconnectApiRef}>
-                {canResetReferenceUrl ? "permanently clear" : "Permanently clear"}
-              </button>{" "}
-              link to reference.
+                {canResetReferenceUrl ? "permanently disconnect" : "Permanently disconnect"}
+              </button>
+              .
             </>
           )}
         </span>

--- a/src/cards/CardEditor.tsx
+++ b/src/cards/CardEditor.tsx
@@ -8,6 +8,7 @@ import { TagInput } from "../lib/ui/TagInput";
 import { Textarea } from "../lib/ui/Textarea";
 import { ToggleButton } from "../lib/ui/ToggleButton";
 import { ToggleButtonGroup } from "../lib/ui/ToggleButtonGroup";
+import { referenceAbsoluteUrl } from "../views/reference/routeUrl";
 import styles from "./CardEditor.module.css";
 import { FALLBACK_ICON_KEY, pickIconKey } from "./iconRules";
 import { MarkdownToolbar } from "./MarkdownToolbar";
@@ -45,6 +46,21 @@ export function CardEditor({ card, onChange }: Props) {
       referenceUrl: value === "" ? undefined : value,
       updatedAt: nowIso(),
     });
+  };
+
+  const srdReferenceUrl = card.apiRef
+    ? referenceAbsoluteUrl(card.apiRef.kind, card.apiRef.slug)
+    : undefined;
+  const canResetReferenceUrl =
+    srdReferenceUrl !== undefined && card.referenceUrl !== srdReferenceUrl;
+
+  const handleResetReferenceUrl = () => {
+    if (!srdReferenceUrl) return;
+    onChange({ ...card, referenceUrl: srdReferenceUrl, updatedAt: nowIso() });
+  };
+
+  const handleDisconnectApiRef = () => {
+    onChange({ ...card, apiRef: undefined, updatedAt: nowIso() });
   };
 
   const handleKindChange = (next: "item" | "spell") => {
@@ -200,8 +216,31 @@ export function CardEditor({ card, onChange }: Props) {
           placeholder="https://…"
         />
         <span id={ids.referenceUrlHelp} className={styles.help}>
-          Rendered as a QR code in the card’s bottom-right corner. Leave blank to omit. SRD-imported
-          cards prefill with the in-app reference page.
+          Rendered as a QR code in the card’s bottom-right corner. Leave blank to omit.
+          {card.apiRef && (
+            <>
+              {" "}
+              This item was imported.
+              {canResetReferenceUrl && (
+                <>
+                  {" "}
+                  <button
+                    type="button"
+                    className={styles.linkButton}
+                    onClick={handleResetReferenceUrl}
+                  >
+                    Use reference page
+                  </button>
+                  .
+                </>
+              )}{" "}
+              {canResetReferenceUrl ? "Or " : ""}
+              <button type="button" className={styles.linkButton} onClick={handleDisconnectApiRef}>
+                {canResetReferenceUrl ? "permanently clear" : "Permanently clear"}
+              </button>{" "}
+              link to reference.
+            </>
+          )}
         </span>
       </label>
     </form>

--- a/src/cards/CardEditor.tsx
+++ b/src/cards/CardEditor.tsx
@@ -238,7 +238,7 @@ export function CardEditor({ card, onChange }: Props) {
               <button type="button" className={styles.linkButton} onClick={handleDisconnectApiRef}>
                 {canResetReferenceUrl ? "permanently disconnect" : "Permanently disconnect"}
               </button>
-              .
+              {canResetReferenceUrl ? " from import to remove this option." : " from import."}
             </>
           )}
         </span>

--- a/src/cards/breakCandidates.ts
+++ b/src/cards/breakCandidates.ts
@@ -31,6 +31,10 @@ export function collectBreakCandidates(
     // appear as candidate split points — their getBoundingClientRect would
     // otherwise emit a y at body-bottom and steer the paginator into an
     // empty-chunk loop.
+    // Shallow by design: this check runs only at the top-level loop, not
+    // inside handleChild's recursion. Today's only skip-targets (the QR
+    // floats) are direct children of .body; nested decorations would need
+    // their own opt-out path.
     if ((child as HTMLElement).dataset.paginationSkip === "true") continue;
     handleChild(child as HTMLElement, root, originY, lineBoxes, out);
   }

--- a/src/cards/breakCandidates.ts
+++ b/src/cards/breakCandidates.ts
@@ -26,6 +26,12 @@ export function collectBreakCandidates(
   const lineBoxes = opts.lineBoxes ?? defaultLineBoxes;
 
   for (const child of Array.from(root.children)) {
+    // Floated decorations (e.g. the QR-corner reserve in Card.tsx) carry
+    // data-pagination-skip="true". They are out of normal flow and must not
+    // appear as candidate split points — their getBoundingClientRect would
+    // otherwise emit a y at body-bottom and steer the paginator into an
+    // empty-chunk loop.
+    if ((child as HTMLElement).dataset.paginationSkip === "true") continue;
     handleChild(child as HTMLElement, root, originY, lineBoxes, out);
   }
 

--- a/src/cards/expandCard.ts
+++ b/src/cards/expandCard.ts
@@ -1,6 +1,7 @@
 import type { CardPagination } from "./Card";
 import { layoutPaginate } from "./layoutPaginator";
 import type { CardMeasurer } from "./measurer";
+import { qrFloatHtml } from "./qrFloat";
 import { renderBody } from "./renderBody";
 import type { RenderableCard } from "./types";
 
@@ -12,7 +13,15 @@ export type PhysicalCard = {
 
 export function expandCard(card: RenderableCard, measurer: CardMeasurer): PhysicalCard[] {
   const dims = measurer.getBodyDimensions(card);
-  const bodyHtml = renderBody(card.body);
+  // When the card has a referenceUrl, the printed card renders a QR-reserve
+  // float in .body's bottom-right corner. Prefixing the bodyHtml here lets
+  // layoutPaginate measure body capacity with the float (and its shape-outside
+  // wrap exclusion) in place — so pagination splits content earlier when the
+  // QR steals real estate. The slice naturally keeps the float in chunk 1 and
+  // drops it from continuation chunks, matching Card.tsx's "QR on page 1 only"
+  // render rule.
+  const renderedBody = renderBody(card.body);
+  const bodyHtml = card.referenceUrl ? qrFloatHtml() + renderedBody : renderedBody;
   const chunks = layoutPaginate({
     bodyHtml,
     width: dims.width,

--- a/src/cards/qrFloat.ts
+++ b/src/cards/qrFloat.ts
@@ -1,0 +1,23 @@
+import styles from "./Card.module.css";
+
+/**
+ * HTML for the invisible float pair that carves out a bottom-right wrap
+ * exclusion inside `.body` (matched by the absolute-positioned `.qrCorner`).
+ * Used by Card.tsx (when rendering without pagination) and by expandCard.ts
+ * (so layoutPaginate measures body capacity *with* the exclusion in place).
+ *
+ * Two elements rather than one: a zero-width pusher reserves vertical space
+ * on the right column so the subsequent floated reserve drops to the bottom.
+ * The zero-width pusher means block-level children (tables, DLs) are not
+ * pushed below the float — see Card.module.css for the full rationale.
+ *
+ * `data-pagination-skip="true"` is honored by `collectBreakCandidates` — the
+ * floated decorations are out of normal flow and must not appear as candidate
+ * split points.
+ */
+export function qrFloatHtml(): string {
+  return (
+    `<div class="${styles.qrPusher}" data-pagination-skip="true" aria-hidden="true"></div>` +
+    `<div class="${styles.qrReserve}" data-pagination-skip="true" aria-hidden="true"></div>`
+  );
+}

--- a/src/cards/types.ts
+++ b/src/cards/types.ts
@@ -11,6 +11,7 @@ export type BaseCard = {
     ruleset: "2014" | "2024";
     kind: "magic-items" | "mundane-items" | "spells";
   };
+  referenceUrl?: string;
   createdAt: string;
   updatedAt: string;
   iconKey?: string;

--- a/src/decks/schema.test.ts
+++ b/src/decks/schema.test.ts
@@ -141,4 +141,20 @@ describe("itemCardSchema", () => {
     };
     expect(itemCardSchema.safeParse(card).success).toBe(false);
   });
+
+  test("accepts an item card with a referenceUrl", () => {
+    const card = {
+      id: "abc",
+      kind: "item" as const,
+      name: "Bag of Holding",
+      headerTags: [],
+      body: "Big bag.",
+      footerTags: [],
+      source: "custom" as const,
+      referenceUrl: "https://example.com/reference/magic-items/srd-2024_bag-of-holding",
+      createdAt: "2026-05-14T00:00:00.000Z",
+      updatedAt: "2026-05-14T00:00:00.000Z",
+    };
+    expect(itemCardSchema.safeParse(card).success).toBe(true);
+  });
 });

--- a/src/decks/schema.ts
+++ b/src/decks/schema.ts
@@ -13,6 +13,7 @@ const baseCardSchema = z.object({
   body: z.string(),
   source: z.enum(["custom", "api"]),
   apiRef: apiRefSchema.optional(),
+  referenceUrl: z.string().optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
   iconKey: z.string().optional(),

--- a/src/views/ReferenceView.module.css
+++ b/src/views/ReferenceView.module.css
@@ -29,11 +29,13 @@
   max-width: 100%;
   border-collapse: collapse;
   margin: 0 0 var(--space-4);
-  /* Lea Verou scroll-shadow technique — fades hide themselves when not scrolled. */
+  /* Lea Verou scroll-shadow technique — fades hide themselves when not
+     scrolled. The mask color must match the actual surrounding background
+     (--color-bg), not --color-surface, or the masked edge shows as a
+     visibly lighter strip against the page. */
   background:
-    linear-gradient(to right, var(--color-surface), var(--color-surface)) left center / 16px 100%
-    no-repeat,
-    linear-gradient(to right, transparent, var(--color-surface)) right center / 16px 100% no-repeat,
+    linear-gradient(to right, var(--color-bg), var(--color-bg)) left center / 16px 100% no-repeat,
+    linear-gradient(to right, transparent, var(--color-bg)) right center / 16px 100% no-repeat,
     radial-gradient(farthest-side at 0 50%, rgba(0, 0, 0, 0.18), transparent) left center / 12px
     100% no-repeat,
     radial-gradient(farthest-side at 100% 50%, rgba(0, 0, 0, 0.18), transparent) right center / 12px

--- a/src/views/reference/routeUrl.ts
+++ b/src/views/reference/routeUrl.ts
@@ -2,8 +2,8 @@ import type { ReferenceKind } from "../ReferenceView";
 
 /**
  * Build the in-app path for a reference page. Use for SPA links via
- * TanStack Router's `<Link>`, OR concatenate with `window.location.origin`
- * for an absolute URL suitable for encoding in a QR code.
+ * TanStack Router's `<Link>`, OR see `referenceAbsoluteUrl` below for an
+ * origin-prefixed URL suitable for encoding in a QR code.
  *
  * Example: `referenceRoutePath("magic-items", "srd-2024_wand-of-wonder")` →
  * `"/reference/magic-items/srd-2024_wand-of-wonder"`.
@@ -15,4 +15,17 @@ import type { ReferenceKind } from "../ReferenceView";
  */
 export function referenceRoutePath(kind: ReferenceKind, key: string): string {
   return `/reference/${kind}/${encodeURIComponent(key)}`;
+}
+
+/**
+ * Build the absolute URL for a reference page using the current
+ * `window.location.origin`. Used by the SRD import mappers to seed
+ * `Card.referenceUrl`, which the print layout encodes as a QR code.
+ *
+ * The origin is captured at import time. If the deploy domain changes, prior
+ * imports retain the old origin until re-imported — acceptable for this app's
+ * scope.
+ */
+export function referenceAbsoluteUrl(kind: ReferenceKind, key: string): string {
+  return `${window.location.origin}${referenceRoutePath(kind, key)}`;
 }

--- a/supabase/migrations/20260514000000_add_reference_url.sql
+++ b/supabase/migrations/20260514000000_add_reference_url.sql
@@ -1,3 +1,26 @@
+-- 20260514000000_add_reference_url.sql
+-- Add an optional `referenceUrl` string to every card-payload variant. The QR
+-- code feature renders a code in the card footer/body corner that encodes this
+-- URL. For SRD-imported cards the mappers auto-fill it with the in-app
+-- /reference/$kind/$key absolute URL; users can override (paste a dndbeyond
+-- link, etc.) or clear it to disable the QR.
+--
+-- No data backfill: existing rows without `referenceUrl` simply have no QR.
+-- The prior migration (20260513000000_apiref_add_kind) already nulled out
+-- every existing apiRef on prod, so we have nothing to derive referenceUrl
+-- from anyway. Users re-import from the SRD pickers to get QR codes.
+--
+-- The embedded JSON Schema below is generated from src/decks/schema.ts via
+-- `npm run gen:schema`. To update it, regenerate the JSON file and write a
+-- NEW migration that follows the same drop-then-add pattern below — never
+-- edit this file in place.
+
+alter table public.cards drop constraint if exists cards_payload_valid;
+
+alter table public.cards
+  add constraint cards_payload_valid
+  check (jsonb_matches_schema(
+    $cardpayload$
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "oneOf": [
@@ -282,3 +305,6 @@
     }
   ]
 }
+$cardpayload$::json,
+    payload
+  ));


### PR DESCRIPTION
### Description (What does it do?)

Adds an optional `referenceUrl` string to every card. When set, it renders as a QR code in the bottom-right corner of the printed card (page 1 only).

- **SRD-imported cards** are auto-seeded with the in-app `/reference/$kind/$key` absolute URL via a new `referenceAbsoluteUrl` helper that composes `window.location.origin` with the existing `referenceRoutePath`.
- **Users can override** with any URL (e.g. dndbeyond, a custom share link) or leave the field blank to omit the QR.
- **Editor recovery affordances** — when a card has `apiRef`, inline link-styled actions in the Reference link field's help text let the user *Restore original link* (re-fill the URL with the auto-seeded value) or *permanently disconnect from import* (clear `apiRef`, leaving the URL alone).

### Layout work

The QR straddles the body/footer boundary in the bottom-right corner. Making body prose flow around it while keeping page-1 tables intact required a few non-obvious CSS moves, all documented inline:

- **Two-float decoration** in `.body` (`qrPusher` zero-width + `qrReserve` sized to QR's body footprint). The 0-width pusher lets BFC elements like tables coexist on the right column without being cleared below the floats.
- **`.body table` max-width cap** when the QR floats are present. Tables share their right edge with `qrPusher` otherwise, and browsers conservatively treat the edge-share as overlap and push the table off page 1.
- **`--qr-size` as `calc(N * card-base)` px** rather than em — the table context has `font-size: 0.92em`, which would otherwise shrink an em-based size enough to break the table-fit math.
- **`.footerWithQr`** pulls the footer in with `margin-right: calc(var(--qr-size) + 1.15 * var(--card-base))` so its `border-top` divider stops short of the QR with the same gap the card's outer padding gives its content.
- **`--qr-body-overhang`** sizes the body reserve to match only the QR's body footprint (not the full QR), so body text wraps right up to the QR's top edge.

### Migration

`supabase/migrations/20260514000000_add_reference_url.sql` updates the `cards_payload_valid` CHECK constraint to allow the new optional field. **No data backfill** — prior cards have `apiRef` already nulled by #78, so there's nothing to derive `referenceUrl` from. Existing imported cards on prod will need re-import to gain a QR; net cost is small given prod has ~16 cards.

### How can this be tested?

- [ ] Import a card from the SRD picker → QR appears in the printed card preview, encoding `${origin}/reference/$kind/$key`.
- [ ] Scan the QR with a phone — confirm scannable at 4-up scale (~0.6") and 2-up (~0.8").
- [ ] Edit the URL → QR updates; clear the URL → QR disappears; paste an external URL → QR encodes that.
- [ ] Custom card (no URL) → no QR, no other visual change.
- [ ] Multi-page card with a `referenceUrl`: page 1 shows QR + narrowed footer divider + right-aligned pagination; page 2+ shows full-width divider, no QR.
- [ ] Card body with a small table: table renders on page 1 alongside the QR; longer tables split across pages.
- [ ] Editor help text under "Reference link":
  - Custom card → base help only.
  - Imported card, URL matches seed → "This item was imported. Permanently disconnect from import."
  - Imported card, URL empty or custom → "This item was imported. Restore original link or permanently disconnect from import to remove this option."
  - Click *Restore original link* → URL fills with the in-app reference page.
  - Click *permanently disconnect* → `apiRef` clears; the imported-help text and both actions disappear; the URL stays as the user left it.
- [ ] Reference page (`/reference/...`) table styling: left edge no longer shows a lighter strip (`--color-bg` mask).

Tests cover schema parsing, mapper output (including the absolute URL), Card render (QR shown only on page 1 with referenceUrl, footerWithQr applied + dropped correctly), and editor state for the four Reset/Disconnect combinations. 773 tests pass; `npm run build` is clean.

### Additional Context

- The layout went through a few visible iterations during development (single shape-outside float → two-float pusher+reserve, when shape-outside turned out not to apply to BFC elements). The current CSS is heavily commented at the load-bearing spots — the comments are designed to encode the *why* so the next person debugging a regression has the constraints in hand.
- `referenceAbsoluteUrl` captures `window.location.origin` at import time. If the deploy domain ever changes, prior imports retain the stale origin until re-imported. Acceptable at this app's scope; noted in the helper's doc comment.
- A pre-existing unrelated CSS regression on the reference page's tables (a scroll-shadow mask using `--color-surface` instead of `--color-bg` produced a visibly lighter strip on the left edge) was fixed alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)