### PR TITLE
feat(browse): add All tab to the SRD browse dialog

### DIFF
--- a/docs/superpowers/plans/2026-05-14-browse-all-tab.md
+++ b/docs/superpowers/plans/2026-05-14-browse-all-tab.md
@@ -1,0 +1,572 @@
+# Browse SRD — All tab Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an "All" content type to the SRD browse dialog that merges items and spells into one searchable list and prepends a kind tag (`Item · …` / `Spell · …`) to each row's meta column. Make it the default tab.
+
+**Architecture:** A new `allContentType` composed in `src/api/content-types/all.ts` calls the three existing index hooks (magic items, mundane items, spells), tags each entry with `__source`, and produces `ContentRow`s with a `kindLabel`. `BrowseApiModal` row renderer prepends `kindLabel · ` when `type.id === "all"`. A new `emptyMessage` field on `ContentType` replaces the current `No ${type.label.toLowerCase()} match…` interpolation so the new tab can read "No results match your search." rather than the broken "No all match your search."
+
+**Tech Stack:** React 18 + TypeScript + Vite, TanStack Query, react-aria-components, fuzzysort, vitest + RTL + MSW + Fishery factories.
+
+**Spec:** `docs/superpowers/specs/2026-05-14-browse-all-tab-design.md`
+
+---
+
+## File Structure
+
+Files this plan creates or modifies:
+
+- `src/api/content-types/types.ts` — modify: add `kindLabel?: string` to `ContentRow`; add `emptyMessage: string` to `ContentType`.
+- `src/api/content-types/items.ts` — modify: add `emptyMessage`.
+- `src/api/content-types/spells.ts` — modify: add `emptyMessage`.
+- `src/api/content-types/all.ts` — create: the new `allContentType`.
+- `src/api/content-types/index.ts` — modify: register `allContentType` first.
+- `src/views/BrowseApiModal.tsx` — modify: read `type.emptyMessage`; prepend `row.kindLabel · ` when `type.id === "all"`.
+- `src/views/BrowseApiModal.test.tsx` — modify: update tablist test; add All-tab assertions for kind tag presence/absence and empty-state copy.
+
+`itemsContentType` and `spellsContentType` are otherwise untouched.
+
+---
+
+## Task 1: Add `kindLabel` to `ContentRow`
+
+Pure type-only addition. No runtime behaviour changes. Setting up the surface that Task 2 will populate and Task 3 will read.
+
+**Files:**
+- Modify: `src/api/content-types/types.ts`
+
+- [ ] **Step 1: Add the optional field**
+
+Open `src/api/content-types/types.ts`. The current `ContentRow` is:
+
+```ts
+export type ContentRow = {
+  key: string;
+  name: string;
+  meta: string;
+  toCard: () => Card;
+};
+```
+
+Replace with:
+
+```ts
+export type ContentRow = {
+  key: string;
+  name: string;
+  meta: string;
+  kindLabel?: string;
+  toCard: () => Card;
+};
+```
+
+- [ ] **Step 2: Verify the suite still passes**
+
+Run: `npm test -- --run`
+Expected: 773 tests pass. No new tests yet — this is a structural prep step.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/api/content-types/types.ts
+git commit -m "refactor(content-types): add optional kindLabel to ContentRow"
+```
+
+---
+
+## Task 2: Build `allContentType` and register it first
+
+The merge logic. Tests are written before the implementation. The existing tablist test breaks here and is updated as part of this task because the change is intrinsic to placing All first.
+
+**Files:**
+- Create: `src/api/content-types/all.ts`
+- Modify: `src/api/content-types/index.ts`
+- Modify: `src/views/BrowseApiModal.test.tsx`
+
+- [ ] **Step 1: Write failing tests in `BrowseApiModal.test.tsx`**
+
+Update the existing tablist-order test to expect three tabs in the new order:
+
+```ts
+test("renders the registered types as a vertical tablist in registry order", async () => {
+  const client = makeClient();
+  wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+  const tabs = screen.getAllByRole("tab");
+  expect(tabs.map((t) => t.textContent)).toEqual(["All", "Items", "Spells"]);
+});
+```
+
+Add a new test asserting All is selected by default. Place it directly after the tablist-order test:
+
+```ts
+test("All tab is selected by default", async () => {
+  const client = makeClient();
+  wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+  expect(screen.getByRole("tab", { name: "All" })).toHaveAttribute("aria-selected", "true");
+});
+```
+
+Add a new test asserting items and spells interleave alphabetically on the All tab. Place it after the "All tab is selected by default" test:
+
+```ts
+test("All tab merges items and spells alphabetically", async () => {
+  const item = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
+  const spell = spellIndexEntryFactory.build({ name: "Fireball" });
+  const client = makeClient({
+    items: { "2024": { count: 1, results: [item] } },
+    spells: { "2024": { count: 1, results: [spell] } },
+  });
+
+  wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+  await screen.findByRole("button", { name: /Bag of Holding/ });
+  const rows = screen.getAllByRole("button", { name: /Bag of Holding|Fireball/ });
+  const names = rows.map((b) => b.textContent ?? "");
+  const bagIdx = names.findIndex((n) => /Bag of Holding/.test(n));
+  const fireIdx = names.findIndex((n) => /Fireball/.test(n));
+  expect(bagIdx).toBeGreaterThanOrEqual(0);
+  expect(fireIdx).toBeGreaterThanOrEqual(0);
+  expect(bagIdx).toBeLessThan(fireIdx);
+});
+```
+
+- [ ] **Step 2: Run tests to verify the three new/updated cases fail**
+
+Run: `npm test -- --run src/views/BrowseApiModal.test.tsx`
+
+Expected failures:
+- "renders the registered types as a vertical tablist in registry order" — fails because tablist currently reads `["Items", "Spells"]`.
+- "All tab is selected by default" — fails because no "All" tab exists yet.
+- "All tab merges items and spells alphabetically" — fails (no All tab, only the magic item appears).
+
+- [ ] **Step 3: Create `src/api/content-types/all.ts`**
+
+Write the complete file:
+
+```ts
+import fuzzysort from "fuzzysort";
+import { useMemo } from "react";
+import type { MagicItem, MundaneItem, Spell } from "../../data/srd-schema";
+import { levelLabel } from "../../lib/srd-format/spells";
+import { useMagicItemIndex, useMundaneItemIndex, useSpellIndex } from "../hooks";
+import { magicItemDetailToCard } from "../mappers/magicItems";
+import { mundaneItemDetailToCard } from "../mappers/mundaneItems";
+import { spellDetailToCard } from "../mappers/spells";
+import type { ContentRow, ContentType } from "./types";
+
+type TaggedEntry =
+  | (MagicItem & { __source: "magic" })
+  | (MundaneItem & { __source: "mundane" })
+  | (Spell & { __source: "spell" });
+
+export const allContentType: ContentType = {
+  id: "all",
+  label: "All",
+  searchPlaceholder: "Search SRD…",
+  emptyMessage: "No results match your search.",
+  supportedSources: ["2024", "2014"],
+  useResults: (source, query) => {
+    const magic = useMagicItemIndex(source);
+    const mundane = useMundaneItemIndex(source);
+    const spells = useSpellIndex(source);
+    const rows = useMemo<ContentRow[]>(() => {
+      const q = query.trim();
+      const tagged: TaggedEntry[] = [
+        ...(magic.data?.results ?? []).map(
+          (entry): TaggedEntry => ({ ...entry, __source: "magic" }),
+        ),
+        ...(mundane.data?.results ?? []).map(
+          (entry): TaggedEntry => ({ ...entry, __source: "mundane" }),
+        ),
+        ...(spells.data?.results ?? []).map(
+          (entry): TaggedEntry => ({ ...entry, __source: "spell" }),
+        ),
+      ];
+      const ordered =
+        q === ""
+          ? [...tagged].sort((a, b) => a.name.localeCompare(b.name))
+          : fuzzysort.go(q, tagged, { key: "name" }).map((r) => r.obj);
+      return ordered.map((entry): ContentRow => {
+        if (entry.__source === "magic") {
+          return {
+            key: entry.key,
+            name: entry.name,
+            meta: entry.rarity.name,
+            kindLabel: "Item",
+            toCard: () => magicItemDetailToCard({ ...entry, ruleset: source }),
+          };
+        }
+        if (entry.__source === "mundane") {
+          return {
+            key: entry.key,
+            name: entry.name,
+            meta: entry.category.name,
+            kindLabel: "Item",
+            toCard: () => mundaneItemDetailToCard({ ...entry, ruleset: source }),
+          };
+        }
+        return {
+          key: entry.key,
+          name: entry.name,
+          meta: levelLabel(entry.level, entry.school.name),
+          kindLabel: "Spell",
+          toCard: () => spellDetailToCard({ ...entry, ruleset: source }),
+        };
+      });
+    }, [magic.data, mundane.data, spells.data, query, source]);
+    return {
+      isLoading: magic.isLoading || mundane.isLoading || spells.isLoading,
+      isError: magic.isError || mundane.isError || spells.isError,
+      refetch: () => {
+        magic.refetch();
+        mundane.refetch();
+        spells.refetch();
+      },
+      rows,
+    };
+  },
+};
+```
+
+Note: the file references `ContentType.emptyMessage`, which Task 4 adds to the type. Until Task 4 runs, TypeScript will flag the `emptyMessage:` line. That's expected; the type is added in Task 4 and the runtime suite is what matters for verification between tasks. The line stays in place because removing and re-adding it across two tasks is churn.
+
+If a stricter intermediate state is preferred, alternative: add `emptyMessage` to `ContentType` first (Task 4 swapped to Task 2-and-a-half). The chosen ordering keeps the user-visible "merge rows" change in Task 2 and the "empty state copy" change in Task 4 cleanly separated.
+
+- [ ] **Step 4: Register `allContentType` first in `src/api/content-types/index.ts`**
+
+Replace the file with:
+
+```ts
+import { allContentType } from "./all";
+import { itemsContentType } from "./items";
+import { spellsContentType } from "./spells";
+import type { ContentType } from "./types";
+
+export const CONTENT_TYPES: readonly [ContentType, ...ContentType[]] = [
+  allContentType,
+  itemsContentType,
+  spellsContentType,
+];
+
+export type { ContentRow, ContentType, ContentTypeResults } from "./types";
+```
+
+- [ ] **Step 5: Run the focused test file and confirm the three new/updated cases pass**
+
+Run: `npm test -- --run src/views/BrowseApiModal.test.tsx`
+
+Expected: all tests in this file pass, including the three from Step 1.
+
+- [ ] **Step 6: Run the full suite**
+
+Run: `npm test -- --run`
+
+Expected: all tests pass. Some pre-existing tests now run against the All tab as the default (e.g., the "shows index entries", "search filters", and "switching source" cases pick up the magic items via the All tab instead of the Items tab). The set of assertions in those tests is robust to that — they search by row name only.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/api/content-types/all.ts src/api/content-types/index.ts src/views/BrowseApiModal.test.tsx
+git commit -m "feat(browse): add All content type that merges items and spells"
+```
+
+---
+
+## Task 3: Render the kind tag prefix in All
+
+TDD. Tests assert that meta starts with `Item · ` / `Spell · ` on All and does not on the other tabs.
+
+**Files:**
+- Modify: `src/views/BrowseApiModal.tsx`
+- Modify: `src/views/BrowseApiModal.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+Add the four cases below to `src/views/BrowseApiModal.test.tsx`, after the "All tab merges items and spells alphabetically" test from Task 2:
+
+```ts
+test("All tab prefixes item rows with 'Item · '", async () => {
+  const item = magicItemIndexEntryFactory.build({
+    name: "Bag of Holding",
+    rarity: { name: "Uncommon" },
+  });
+  const client = makeClient({ items: { "2024": { count: 1, results: [item] } } });
+
+  wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+  const row = await screen.findByRole("button", { name: /Bag of Holding/ });
+  expect(row).toHaveTextContent("Item · Uncommon");
+});
+
+test("All tab prefixes spell rows with 'Spell · '", async () => {
+  const spell = spellIndexEntryFactory.build({
+    name: "Fireball",
+    level: 3,
+    school: { name: "evocation" },
+  });
+  const client = makeClient({ spells: { "2024": { count: 1, results: [spell] } } });
+
+  wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+  const row = await screen.findByRole("button", { name: /Fireball/ });
+  expect(row).toHaveTextContent("Spell · 3rd-level evocation");
+});
+
+test("Items tab does not prefix rows with 'Item · '", async () => {
+  const item = magicItemIndexEntryFactory.build({
+    name: "Bag of Holding",
+    rarity: { name: "Uncommon" },
+  });
+  const client = makeClient({ items: { "2024": { count: 1, results: [item] } } });
+
+  wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+  await userEvent.click(screen.getByRole("tab", { name: "Items" }));
+  const row = await screen.findByRole("button", { name: /Bag of Holding/ });
+  expect(row).toHaveTextContent("Uncommon");
+  expect(row).not.toHaveTextContent("Item · ");
+});
+
+test("Spells tab does not prefix rows with 'Spell · '", async () => {
+  const spell = spellIndexEntryFactory.build({
+    name: "Fireball",
+    level: 3,
+    school: { name: "evocation" },
+  });
+  const client = makeClient({ spells: { "2024": { count: 1, results: [spell] } } });
+
+  wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+  await userEvent.click(screen.getByRole("tab", { name: "Spells" }));
+  const row = await screen.findByRole("button", { name: /Fireball/ });
+  expect(row).toHaveTextContent("3rd-level evocation");
+  expect(row).not.toHaveTextContent("Spell · ");
+});
+```
+
+- [ ] **Step 2: Run the focused test file and verify the four new cases fail**
+
+Run: `npm test -- --run src/views/BrowseApiModal.test.tsx`
+
+Expected: the four new tests fail. The two "All tab prefixes…" cases fail because the renderer hasn't been changed yet. The two "does not prefix" cases pass right now (because the prefix doesn't exist anywhere), which is fine — they exist to guard against regressions introduced by Step 3.
+
+Confirm both All-tab tests fail with an assertion mismatch on the prefix text. The other two should pass.
+
+- [ ] **Step 3: Conditionally render the kind prefix**
+
+Edit `src/views/BrowseApiModal.tsx`. Find this block in `TypePanel` (currently lines 258-269):
+
+```tsx
+{results.rows.map((row) => (
+  <button
+    key={row.key}
+    type="button"
+    className={styles.row}
+    onClick={() => onPick(row.key, row.toCard())}
+    disabled={pickingKey !== null}
+  >
+    <span className={styles.rowName}>{row.name}</span>
+    <span className={styles.rowMeta}>{pickingKey === row.key ? "Loading…" : row.meta}</span>
+  </button>
+))}
+```
+
+Replace the `<span className={styles.rowMeta}>…</span>` line with:
+
+```tsx
+    <span className={styles.rowMeta}>
+      {pickingKey === row.key
+        ? "Loading…"
+        : type.id === "all" && row.kindLabel
+          ? `${row.kindLabel} · ${row.meta}`
+          : row.meta}
+    </span>
+```
+
+`TypePanel` already receives the `type` prop, so no signature change is needed.
+
+- [ ] **Step 4: Run the focused test file and verify all four cases pass**
+
+Run: `npm test -- --run src/views/BrowseApiModal.test.tsx`
+
+Expected: all four new tests pass, plus the entire file.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `npm test -- --run`
+
+Expected: 781 tests pass (773 baseline + 3 from Task 2 + 4 from Task 3, with the existing tablist test updated rather than added — net +7). The "mundane-item rows show category in the meta column" test still passes because `toHaveTextContent("Adventuring Gear")` is a substring match and "Item · Adventuring Gear" contains it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/views/BrowseApiModal.tsx src/views/BrowseApiModal.test.tsx
+git commit -m "feat(browse): prefix kind tag on All-tab row meta"
+```
+
+---
+
+## Task 4: Add `emptyMessage` to `ContentType` and use it
+
+Replaces the inline `No ${type.label.toLowerCase()} match your search.` interpolation, which produces broken grammar for the All tab.
+
+**Files:**
+- Modify: `src/api/content-types/types.ts`
+- Modify: `src/api/content-types/items.ts`
+- Modify: `src/api/content-types/spells.ts`
+- Modify: `src/api/content-types/all.ts`
+- Modify: `src/views/BrowseApiModal.tsx`
+- Modify: `src/views/BrowseApiModal.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add the case below to `src/views/BrowseApiModal.test.tsx` after the kind-tag tests from Task 3:
+
+```ts
+test("All tab empty state reads 'No results match your search.'", async () => {
+  const client = makeClient();
+  wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+  await userEvent.type(screen.getByRole("searchbox"), "xyzzy");
+
+  expect(await screen.findByText("No results match your search.")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the focused test file and verify the new case fails**
+
+Run: `npm test -- --run src/views/BrowseApiModal.test.tsx`
+
+Expected: this new test fails. With no `emptyMessage` plumbed yet, the rendered text reads "No all match your search." (or similar) and the new test can't find "No results match your search." on the page.
+
+- [ ] **Step 3: Add the field to `ContentType`**
+
+Edit `src/api/content-types/types.ts`. The current `ContentType` is:
+
+```ts
+export type ContentType = {
+  id: string;
+  label: string;
+  searchPlaceholder: string;
+  supportedSources: readonly [Ruleset, ...Ruleset[]];
+  useResults: (source: Ruleset, query: string) => ContentTypeResults;
+};
+```
+
+Replace with:
+
+```ts
+export type ContentType = {
+  id: string;
+  label: string;
+  searchPlaceholder: string;
+  emptyMessage: string;
+  supportedSources: readonly [Ruleset, ...Ruleset[]];
+  useResults: (source: Ruleset, query: string) => ContentTypeResults;
+};
+```
+
+- [ ] **Step 4: Set `emptyMessage` on each existing content type**
+
+Edit `src/api/content-types/items.ts`. In the `itemsContentType` object, add directly after `searchPlaceholder: "Search items…"`:
+
+```ts
+  emptyMessage: "No items match your search.",
+```
+
+Edit `src/api/content-types/spells.ts`. In the `spellsContentType` object, add directly after `searchPlaceholder: "Search spells…"`:
+
+```ts
+  emptyMessage: "No spells match your search.",
+```
+
+The `allContentType` file (created in Task 2) already includes `emptyMessage: "No results match your search."` — no edit needed here.
+
+- [ ] **Step 5: Replace the inline message in `BrowseApiModal.tsx`**
+
+In `src/views/BrowseApiModal.tsx`, find this line inside `TypePanel` (currently near line 214):
+
+```tsx
+  const emptyMessage = `No ${type.label.toLowerCase()} match your search.`;
+```
+
+Replace with:
+
+```tsx
+  const emptyMessage = type.emptyMessage;
+```
+
+- [ ] **Step 6: Run the focused test file and verify the new case passes**
+
+Run: `npm test -- --run src/views/BrowseApiModal.test.tsx`
+
+Expected: the new empty-state test passes. The entire file still passes.
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `npm test -- --run`
+
+Expected: 782 tests pass.
+
+- [ ] **Step 8: Type-check via build**
+
+Run: `npm run build`
+
+Expected: build succeeds with no TypeScript errors. (Vitest doesn't enforce `noUncheckedIndexedAccess` and similar strict-mode checks; the build does.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/api/content-types/types.ts src/api/content-types/items.ts src/api/content-types/spells.ts src/views/BrowseApiModal.tsx src/views/BrowseApiModal.test.tsx
+git commit -m "feat(browse): per-type empty-state copy on the SRD modal"
+```
+
+---
+
+## Task 5: Manual verification in the dev server
+
+The test suite covers the logic, but the modal is visual; eyeball it once before declaring done.
+
+**Files:** none modified.
+
+- [ ] **Step 1: Start the dev server**
+
+Run: `npm run dev` (background-friendly)
+
+Open the URL it prints in a browser.
+
+- [ ] **Step 2: Walk the golden path**
+
+- Sign in if required, open a deck, click the "Browse SRD" button.
+- Confirm the dialog opens with the **All** tab selected and rows showing a mix of items and spells in alphabetical order.
+- Confirm each row's right-aligned meta starts with `Item · ` or `Spell · `.
+- Type a query (e.g., "fire"); confirm rows narrow down across both kinds and the prefix is still present.
+- Clear the query; type something that matches nothing (e.g., "xyzzy"); confirm the empty state reads "No results match your search."
+- Switch to the **Items** tab; confirm the prefix disappears, the layout is otherwise unchanged from current behaviour, and the empty-state message (when search matches nothing) reads "No items match your search."
+- Switch to the **Spells** tab; confirm the prefix disappears and behaviour is current.
+- Switch the source (2024 ↔ 2014) while on All; confirm rows refresh and the prefix remains.
+- Pick an item from All; confirm a card is added to the deck (this exercises `toCard()` end-to-end).
+- Pick a spell from All; confirm the same.
+- Resize the window narrow (under ~560px container width); confirm the tab list collapses into the **Type** dropdown and "All" appears at the top.
+
+- [ ] **Step 3: Stop the dev server**
+
+Either close the browser tab or interrupt the dev process. No commit needed for this task.
+
+---
+
+## Self-Review (already done)
+
+Spec coverage:
+- "New `allContentType` placed first" → Task 2.
+- "`ContentRow.kindLabel?: string`" → Task 1; populated in Task 2.
+- "`BrowseApiModal` row renderer: when `typeId === "all"` and `row.kindLabel` is defined, display meta as `${kindLabel} · ${meta}`" → Task 3.
+- "`ContentType.emptyMessage`" → Task 4.
+- "Source filter (2024/2014) keeps working" → no code change; verified in Task 5.
+- "Tests: extensions to BrowseApiModal.test.tsx" → Tasks 2, 3, 4.
+- UX section bullets (default tab, search placeholder, narrow-viewport TypeMenu) → covered by Tasks 2 and 5.
+- Behaviour edge cases (alpha sort, fuzzy across merged set, OR-merged loading/error) → covered by `allContentType.useResults` in Task 2 and verified by the existing loading/error tests that already exercise the magic-items hook (which is now a dependency of All too).
+
+No placeholders. Types referenced (`ContentType`, `ContentRow`, `MagicItem`, `MundaneItem`, `Spell`, the three mappers, the three index hooks, `levelLabel`) all exist in the repo at the cited paths.

--- a/docs/superpowers/specs/2026-05-14-browse-all-tab-design.md
+++ b/docs/superpowers/specs/2026-05-14-browse-all-tab-design.md
@@ -23,8 +23,9 @@ In:
 - New `allContentType` placed first in `CONTENT_TYPES` (becomes the default tab).
 - `ContentRow.kindLabel?: string`. Only `all` sets it — `"Item"` for both magic and mundane item entries, `"Spell"` for spells. `itemsContentType` and `spellsContentType` are untouched.
 - `BrowseApiModal` row renderer: when `typeId === "all"` and `row.kindLabel` is defined, display meta as `${kindLabel} · ${meta}`.
+- `ContentType.emptyMessage: string` — new field used by the modal's empty-state UI in place of the current `No ${type.label.toLowerCase()} match your search.` interpolation. Items: `"No items match your search."`, spells: `"No spells match your search."`, all: `"No results match your search."` This avoids the grammatically broken "No all match your search." that the current interpolation would produce for the new tab.
 - Source filter (2024/2014) keeps working — both kinds support both sources.
-- Tests: a `BrowseApiModal` test covering default tab, mixed results, kind tag visibility, and tag hidden in other tabs.
+- Tests: extensions to `BrowseApiModal.test.tsx` covering default tab, mixed results, kind tag visibility in All, and kind tag absence in both Items and Spells tabs.
 
 Out:
 
@@ -50,20 +51,23 @@ Longsword             Item · Martial Melee Weapon
 
 When the user switches to `Items` or `Spells`, the kind tag disappears (because the renderer only adds it for `typeId === "all"`).
 
+On narrow viewports (`<560px` container width), the tab list collapses into the existing `TypeMenu` dropdown. That menu iterates `CONTENT_TYPES`, so "All" appears at the top of the dropdown automatically — no extra code path is needed.
+
 ## Architecture
 
 ```
 src/api/content-types/
   all.ts                   — new: allContentType
-  all.test.ts              — new: unit test for merge/sort/kindLabel
   index.ts                 — place allContentType first in CONTENT_TYPES
-  types.ts                 — add kindLabel?: string to ContentRow
+  types.ts                 — add kindLabel?: string to ContentRow; add emptyMessage: string to ContentType
+  items.ts                 — add emptyMessage: "No items match your search."
+  spells.ts                — add emptyMessage: "No spells match your search."
 src/views/
-  BrowseApiModal.tsx       — when typeId === "all", render `${row.kindLabel} · ${row.meta}`
+  BrowseApiModal.tsx       — read type.emptyMessage instead of inlining the string; when typeId === "all", render `${row.kindLabel} · ${row.meta}`
   BrowseApiModal.test.tsx  — new assertions for All tab + kind tag visibility
 ```
 
-`itemsContentType` and `spellsContentType` are not modified.
+Existing row-building logic in `itemsContentType` and `spellsContentType` is not modified.
 
 ### `allContentType.useResults`
 
@@ -71,7 +75,11 @@ src/views/
 - Builds a tagged union of all three entry types, with `__source: "magic" | "mundane" | "spell"` (extending the pattern in `items.ts`'s `TaggedEntry`).
 - When `query === ""`: alpha-sort by `name`.
 - When `query !== ""`: `fuzzysort.go(q, tagged, { key: "name" })`.
-- Maps each entry to a `ContentRow`, delegating row-shape decisions to the existing detail-to-card mappers (`magicItemDetailToCard`, `mundaneItemDetailToCard`, `spellDetailToCard`). Sets `kindLabel` based on `__source`: `"Item"` for `magic`/`mundane`, `"Spell"` for `spell`. `meta` matches what items/spells tabs already show (rarity, category, level/school).
+- Maps each entry to a `ContentRow`, dispatching on `__source`:
+    - `"magic"` → `meta: entry.rarity.name`, `kindLabel: "Item"`, `toCard: () => magicItemDetailToCard({ ...entry, ruleset: source })`.
+    - `"mundane"` → `meta: entry.category.name`, `kindLabel: "Item"`, `toCard: () => mundaneItemDetailToCard({ ...entry, ruleset: source })`.
+    - `"spell"` → `meta: levelLabel(entry.level, entry.school.name)`, `kindLabel: "Spell"`, `toCard: () => spellDetailToCard({ ...entry, ruleset: source })`.
+  The `{ ...entry, ruleset: source }` wrap matches the call shape `items.ts` and `spells.ts` use today; the mappers expect a detail object with a `ruleset` field.
 - `isLoading`: OR of all three.
 - `isError`: OR of all three (same posture items uses today — bundled JSON makes partial failure rare).
 - `refetch`: fire-and-forget all three.
@@ -85,19 +93,19 @@ src/views/
 
 ## Tests
 
-`src/views/BrowseApiModal.test.tsx` — add cases:
+All test coverage lives in `src/views/BrowseApiModal.test.tsx`. Content-type modules don't carry their own unit tests in this repo (see `src/api/hooks.test.tsx` for the existing hook-test pattern); the modal test exercises `allContentType.useResults` end-to-end via its UI output, which is enough for this feature.
 
-- All tab is selected by default (assert via the selected `Tab` role / data-selected).
-- With empty query, results include both an item and a spell, with the kind tag visible (e.g., "Item · Wondrous item", "Spell · 3rd-level evocation").
-- Typing a known item name in All returns the item row and the kind tag reads "Item".
-- Typing a known spell name in All returns the spell row and the kind tag reads "Spell".
-- Switching to the Items tab hides the kind tag (meta does not start with "Item · ").
+Cases to add:
 
-`src/api/content-types/all.test.ts` — small unit test:
+- All tab is selected by default (assert via the `Tab` with name "All" being `data-selected`).
+- With empty query and both indices loaded, results include both an item and a spell row; their meta text starts with "Item · " and "Spell · " respectively.
+- Typing a known item name in All returns that item row and the meta starts with "Item · ".
+- Typing a known spell name in All returns that spell row and the meta starts with "Spell · ".
+- Switching to the Items tab: rendered rows' meta does NOT start with "Item · " (the kind tag is omitted outside All).
+- Switching to the Spells tab: same — meta does NOT start with "Spell · ".
+- Empty-state copy in All reads "No results match your search." when a query matches nothing.
 
-- Given mocked item + spell indices, the rows array merges and sorts as expected; each row carries the correct `kindLabel`.
-
-No changes to existing tests for `itemsContentType` or `spellsContentType` are expected, because `kindLabel` is additive on rows and consumers of those tabs ignore it.
+No changes to existing tests for `itemsContentType` or `spellsContentType` are expected.
 
 ## Risks
 

--- a/docs/superpowers/specs/2026-05-14-browse-all-tab-design.md
+++ b/docs/superpowers/specs/2026-05-14-browse-all-tab-design.md
@@ -1,0 +1,106 @@
+# Browse SRD — All tab
+
+## Problem
+
+`BrowseApiModal` has separate tabs for Items and Spells, driven by the `CONTENT_TYPES` array in `src/api/content-types/`. A user adding a card has to know in advance which category their target belongs to. Most of the time they just want to type a name (e.g., "fireball", "longsword", "bag of holding") and have the matching SRD entry show up — picking the right tab first is friction.
+
+## Goal
+
+Add a third content type, "All", that searches across items and spells in a single list. Make it the default tab. When the active tab is "All", each row shows a leading meta tag indicating whether the row is an Item or a Spell. Other tabs are visually unchanged.
+
+## Approach
+
+Compose, don't special-case. Add an `allContentType` in `src/api/content-types/all.ts` whose `useResults` internally subscribes to the same React Query hooks that items/spells use today (`useMagicItemIndex`, `useMundaneItemIndex`, `useSpellIndex`), tags each row with a `kindLabel`, merges, and sorts/fuzzy-matches across the combined set.
+
+`ContentRow` gains an optional `kindLabel?: string`. `BrowseApiModal`'s row renderer prepends `kindLabel` to the existing `meta` string with a center-dot separator, but only when the active tab id is `"all"`. Other tabs continue to render `meta` unchanged.
+
+This keeps `BrowseApiModal` generic — it still iterates `CONTENT_TYPES` and renders a `TypePanel` per tab. The only branch is the one bit that decides whether to prepend `kindLabel`.
+
+## Scope
+
+In:
+
+- New `allContentType` placed first in `CONTENT_TYPES` (becomes the default tab).
+- `ContentRow.kindLabel?: string`. Only `all` sets it — `"Item"` for both magic and mundane item entries, `"Spell"` for spells. `itemsContentType` and `spellsContentType` are untouched.
+- `BrowseApiModal` row renderer: when `typeId === "all"` and `row.kindLabel` is defined, display meta as `${kindLabel} · ${meta}`.
+- Source filter (2024/2014) keeps working — both kinds support both sources.
+- Tests: a `BrowseApiModal` test covering default tab, mixed results, kind tag visibility, and tag hidden in other tabs.
+
+Out:
+
+- Three-way kind labeling (Magic item / Mundane item / Spell). Two labels only; magic vs mundane is implicit in the existing meta column (rarity vs category).
+- Persisting the last-selected tab across sessions.
+- Grouping or section headers in All. Flat merged list.
+- Per-kind toggles inside All (e.g., "hide spells"). The All tab is purely additive — granular filtering is what the individual tabs are for.
+- Changes to the source menu, header, or footer.
+
+## UX
+
+When the modal opens:
+
+- "All" is selected by default (the tab list now shows `All`, `Items`, `Spells` in that order).
+- The search field's placeholder for `all` is `"Search SRD…"`.
+- Rows render as today, with the meta column reading `${kindLabel} · ${meta}`. Example:
+
+```
+Fireball              Spell · 3rd-level evocation
+Bag of Holding        Item · Wondrous item
+Longsword             Item · Martial Melee Weapon
+```
+
+When the user switches to `Items` or `Spells`, the kind tag disappears (because the renderer only adds it for `typeId === "all"`).
+
+## Architecture
+
+```
+src/api/content-types/
+  all.ts                   — new: allContentType
+  all.test.ts              — new: unit test for merge/sort/kindLabel
+  index.ts                 — place allContentType first in CONTENT_TYPES
+  types.ts                 — add kindLabel?: string to ContentRow
+src/views/
+  BrowseApiModal.tsx       — when typeId === "all", render `${row.kindLabel} · ${row.meta}`
+  BrowseApiModal.test.tsx  — new assertions for All tab + kind tag visibility
+```
+
+`itemsContentType` and `spellsContentType` are not modified.
+
+### `allContentType.useResults`
+
+- Calls `useMagicItemIndex(source)`, `useMundaneItemIndex(source)`, `useSpellIndex(source)`.
+- Builds a tagged union of all three entry types, with `__source: "magic" | "mundane" | "spell"` (extending the pattern in `items.ts`'s `TaggedEntry`).
+- When `query === ""`: alpha-sort by `name`.
+- When `query !== ""`: `fuzzysort.go(q, tagged, { key: "name" })`.
+- Maps each entry to a `ContentRow`, delegating row-shape decisions to the existing detail-to-card mappers (`magicItemDetailToCard`, `mundaneItemDetailToCard`, `spellDetailToCard`). Sets `kindLabel` based on `__source`: `"Item"` for `magic`/`mundane`, `"Spell"` for `spell`. `meta` matches what items/spells tabs already show (rarity, category, level/school).
+- `isLoading`: OR of all three.
+- `isError`: OR of all three (same posture items uses today — bundled JSON makes partial failure rare).
+- `refetch`: fire-and-forget all three.
+
+## Behaviour edge cases
+
+- **Empty query, both sources loaded**: rows interleave alphabetically by name. A spell named "Aid" sits above an item named "Alchemist's Fire".
+- **Search query**: fuzzy match operates across the merged set; results are ordered by fuzzysort score, not by kind.
+- **One source still loading**: `isLoading` stays true and the modal shows the loading state. We don't render a partial list. Acceptable because both indices come from bundled JSON and complete near-simultaneously.
+- **Source switch (2024 ↔ 2014)** while in All: tab stays on All, query is preserved (today's behaviour), results refresh from the new source.
+
+## Tests
+
+`src/views/BrowseApiModal.test.tsx` — add cases:
+
+- All tab is selected by default (assert via the selected `Tab` role / data-selected).
+- With empty query, results include both an item and a spell, with the kind tag visible (e.g., "Item · Wondrous item", "Spell · 3rd-level evocation").
+- Typing a known item name in All returns the item row and the kind tag reads "Item".
+- Typing a known spell name in All returns the spell row and the kind tag reads "Spell".
+- Switching to the Items tab hides the kind tag (meta does not start with "Item · ").
+
+`src/api/content-types/all.test.ts` — small unit test:
+
+- Given mocked item + spell indices, the rows array merges and sorts as expected; each row carries the correct `kindLabel`.
+
+No changes to existing tests for `itemsContentType` or `spellsContentType` are expected, because `kindLabel` is additive on rows and consumers of those tabs ignore it.
+
+## Risks
+
+- **Default tab shift** — anyone with muscle memory for "Items first" will land on All instead. Low impact; one extra click to reach Items if they want it.
+- **Performance** — All tab pays the cost of three indices loaded simultaneously. Indices are bundled JSON; this is already the case for the Items tab today (magic + mundane).
+- **Visual density** — adding a meta prefix lengthens the meta string. The existing `.rowMeta` column is right-aligned and uses muted text; longer text should still fit within typical row widths. If it overflows on narrow viewports, that's an existing concern, not introduced here.

--- a/src/api/content-types/all.ts
+++ b/src/api/content-types/all.ts
@@ -1,0 +1,82 @@
+import fuzzysort from "fuzzysort";
+import { useMemo } from "react";
+import type { MagicItem, MundaneItem, Spell } from "../../data/srd-schema";
+import { levelLabel } from "../../lib/srd-format/spells";
+import { useMagicItemIndex, useMundaneItemIndex, useSpellIndex } from "../hooks";
+import { magicItemDetailToCard } from "../mappers/magicItems";
+import { mundaneItemDetailToCard } from "../mappers/mundaneItems";
+import { spellDetailToCard } from "../mappers/spells";
+import type { ContentRow, ContentType } from "./types";
+
+type TaggedEntry =
+  | (MagicItem & { __source: "magic" })
+  | (MundaneItem & { __source: "mundane" })
+  | (Spell & { __source: "spell" });
+
+export const allContentType: ContentType = {
+  id: "all",
+  label: "All",
+  searchPlaceholder: "Search SRD…",
+  emptyMessage: "No results match your search.",
+  supportedSources: ["2024", "2014"],
+  useResults: (source, query) => {
+    const magic = useMagicItemIndex(source);
+    const mundane = useMundaneItemIndex(source);
+    const spells = useSpellIndex(source);
+    const rows = useMemo<ContentRow[]>(() => {
+      const q = query.trim();
+      const tagged: TaggedEntry[] = [
+        ...(magic.data?.results ?? []).map(
+          (entry): TaggedEntry => ({ ...entry, __source: "magic" }),
+        ),
+        ...(mundane.data?.results ?? []).map(
+          (entry): TaggedEntry => ({ ...entry, __source: "mundane" }),
+        ),
+        ...(spells.data?.results ?? []).map(
+          (entry): TaggedEntry => ({ ...entry, __source: "spell" }),
+        ),
+      ];
+      const ordered =
+        q === ""
+          ? [...tagged].sort((a, b) => a.name.localeCompare(b.name))
+          : fuzzysort.go(q, tagged, { key: "name" }).map((r) => r.obj);
+      return ordered.map((entry): ContentRow => {
+        if (entry.__source === "magic") {
+          return {
+            key: entry.key,
+            name: entry.name,
+            meta: entry.rarity.name,
+            kindLabel: "Item",
+            toCard: () => magicItemDetailToCard({ ...entry, ruleset: source }),
+          };
+        }
+        if (entry.__source === "mundane") {
+          return {
+            key: entry.key,
+            name: entry.name,
+            meta: entry.category.name,
+            kindLabel: "Item",
+            toCard: () => mundaneItemDetailToCard({ ...entry, ruleset: source }),
+          };
+        }
+        return {
+          key: entry.key,
+          name: entry.name,
+          meta: levelLabel(entry.level, entry.school.name),
+          kindLabel: "Spell",
+          toCard: () => spellDetailToCard({ ...entry, ruleset: source }),
+        };
+      });
+    }, [magic.data, mundane.data, spells.data, query, source]);
+    return {
+      isLoading: magic.isLoading || mundane.isLoading || spells.isLoading,
+      isError: magic.isError || mundane.isError || spells.isError,
+      refetch: () => {
+        magic.refetch();
+        mundane.refetch();
+        spells.refetch();
+      },
+      rows,
+    };
+  },
+};

--- a/src/api/content-types/index.ts
+++ b/src/api/content-types/index.ts
@@ -1,8 +1,10 @@
+import { allContentType } from "./all";
 import { itemsContentType } from "./items";
 import { spellsContentType } from "./spells";
 import type { ContentType } from "./types";
 
 export const CONTENT_TYPES: readonly [ContentType, ...ContentType[]] = [
+  allContentType,
   itemsContentType,
   spellsContentType,
 ];

--- a/src/api/content-types/items.ts
+++ b/src/api/content-types/items.ts
@@ -12,6 +12,7 @@ export const itemsContentType: ContentType = {
   id: "items",
   label: "Items",
   searchPlaceholder: "Search items…",
+  emptyMessage: "No items match your search.",
   supportedSources: ["2024", "2014"],
   useResults: (source, query) => {
     const magic = useMagicItemIndex(source);

--- a/src/api/content-types/spells.ts
+++ b/src/api/content-types/spells.ts
@@ -9,6 +9,7 @@ export const spellsContentType: ContentType = {
   id: "spells",
   label: "Spells",
   searchPlaceholder: "Search spells…",
+  emptyMessage: "No spells match your search.",
   supportedSources: ["2024", "2014"],
   useResults: (source, query) => {
     const idx = useSpellIndex(source);

--- a/src/api/content-types/types.ts
+++ b/src/api/content-types/types.ts
@@ -20,6 +20,7 @@ export type ContentType = {
   id: string;
   label: string;
   searchPlaceholder: string;
+  emptyMessage: string;
   supportedSources: readonly [Ruleset, ...Ruleset[]];
   useResults: (source: Ruleset, query: string) => ContentTypeResults;
 };

--- a/src/api/content-types/types.ts
+++ b/src/api/content-types/types.ts
@@ -5,6 +5,7 @@ export type ContentRow = {
   key: string;
   name: string;
   meta: string;
+  kindLabel?: string;
   toCard: () => Card;
 };
 

--- a/src/views/BrowseApiModal.test.tsx
+++ b/src/views/BrowseApiModal.test.tsx
@@ -83,6 +83,64 @@ describe("<BrowseApiModal>", () => {
     expect(bagIdx).toBeLessThan(fireIdx);
   });
 
+  test("All tab prefixes item rows with 'Item · '", async () => {
+    const item = magicItemIndexEntryFactory.build({
+      name: "Bag of Holding",
+      rarity: { name: "Uncommon" },
+    });
+    const client = makeClient({ items: { "2024": { count: 1, results: [item] } } });
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    const row = await screen.findByRole("button", { name: /Bag of Holding/ });
+    expect(row).toHaveTextContent("Item · Uncommon");
+  });
+
+  test("All tab prefixes spell rows with 'Spell · '", async () => {
+    const spell = spellIndexEntryFactory.build({
+      name: "Fireball",
+      level: 3,
+      school: { name: "evocation" },
+    });
+    const client = makeClient({ spells: { "2024": { count: 1, results: [spell] } } });
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    const row = await screen.findByRole("button", { name: /Fireball/ });
+    expect(row).toHaveTextContent("Spell · 3rd-level evocation");
+  });
+
+  test("Items tab does not prefix rows with 'Item · '", async () => {
+    const item = magicItemIndexEntryFactory.build({
+      name: "Bag of Holding",
+      rarity: { name: "Uncommon" },
+    });
+    const client = makeClient({ items: { "2024": { count: 1, results: [item] } } });
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    await userEvent.click(screen.getByRole("tab", { name: "Items" }));
+    const row = await screen.findByRole("button", { name: /Bag of Holding/ });
+    expect(row).toHaveTextContent("Uncommon");
+    expect(row).not.toHaveTextContent("Item · ");
+  });
+
+  test("Spells tab does not prefix rows with 'Spell · '", async () => {
+    const spell = spellIndexEntryFactory.build({
+      name: "Fireball",
+      level: 3,
+      school: { name: "evocation" },
+    });
+    const client = makeClient({ spells: { "2024": { count: 1, results: [spell] } } });
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    await userEvent.click(screen.getByRole("tab", { name: "Spells" }));
+    const row = await screen.findByRole("button", { name: /Fireball/ });
+    expect(row).toHaveTextContent("3rd-level evocation");
+    expect(row).not.toHaveTextContent("Spell · ");
+  });
+
   test("shows index entries once the items list loads", async () => {
     const entryA = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
     const entryB = magicItemIndexEntryFactory.build({ name: "Cloak of Protection" });

--- a/src/views/BrowseApiModal.test.tsx
+++ b/src/views/BrowseApiModal.test.tsx
@@ -53,7 +53,34 @@ describe("<BrowseApiModal>", () => {
     wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
 
     const tabs = screen.getAllByRole("tab");
-    expect(tabs.map((t) => t.textContent)).toEqual(["Items", "Spells"]);
+    expect(tabs.map((t) => t.textContent)).toEqual(["All", "Items", "Spells"]);
+  });
+
+  test("All tab is selected by default", async () => {
+    const client = makeClient();
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    expect(screen.getByRole("tab", { name: "All" })).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("All tab merges items and spells alphabetically", async () => {
+    const item = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
+    const spell = spellIndexEntryFactory.build({ name: "Fireball" });
+    const client = makeClient({
+      items: { "2024": { count: 1, results: [item] } },
+      spells: { "2024": { count: 1, results: [spell] } },
+    });
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    await screen.findByRole("button", { name: /Bag of Holding/ });
+    const rows = screen.getAllByRole("button", { name: /Bag of Holding|Fireball/ });
+    const names = rows.map((b) => b.textContent ?? "");
+    const bagIdx = names.findIndex((n) => /Bag of Holding/.test(n));
+    const fireIdx = names.findIndex((n) => /Fireball/.test(n));
+    expect(bagIdx).toBeGreaterThanOrEqual(0);
+    expect(fireIdx).toBeGreaterThanOrEqual(0);
+    expect(bagIdx).toBeLessThan(fireIdx);
   });
 
   test("shows index entries once the items list loads", async () => {

--- a/src/views/BrowseApiModal.test.tsx
+++ b/src/views/BrowseApiModal.test.tsx
@@ -262,6 +262,7 @@ describe("<BrowseApiModal>", () => {
 
     wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
 
+    await userEvent.click(screen.getByRole("tab", { name: "Items" }));
     await screen.findByRole("button", { name: /Bag of Holding/ });
     const matched = screen.getAllByRole("button", { name: /Bag of Holding|Battleaxe/ });
     const names = matched.map((b) => b.textContent ?? "");
@@ -309,6 +310,13 @@ describe("<BrowseApiModal>", () => {
     const spellsSearch = await screen.findByRole("searchbox");
     expect(spellsSearch).toHaveValue("");
     expect(spellsSearch).toHaveAttribute("placeholder", "Search spells…");
+  });
+
+  test("All tab search placeholder reads 'Search SRD…'", async () => {
+    const client = makeClient();
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    expect(screen.getByRole("searchbox")).toHaveAttribute("placeholder", "Search SRD…");
   });
 
   test("clicking an item POSTs a card with kind:item", async () => {

--- a/src/views/BrowseApiModal.test.tsx
+++ b/src/views/BrowseApiModal.test.tsx
@@ -141,6 +141,15 @@ describe("<BrowseApiModal>", () => {
     expect(row).not.toHaveTextContent("Spell · ");
   });
 
+  test("All tab empty state reads 'No results match your search.'", async () => {
+    const client = makeClient();
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    await userEvent.type(screen.getByRole("searchbox"), "xyzzy");
+
+    expect(await screen.findByText("No results match your search.")).toBeInTheDocument();
+  });
+
   test("shows index entries once the items list loads", async () => {
     const entryA = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
     const entryB = magicItemIndexEntryFactory.build({ name: "Cloak of Protection" });

--- a/src/views/BrowseApiModal.tsx
+++ b/src/views/BrowseApiModal.tsx
@@ -264,7 +264,13 @@ function TypePanel({
             disabled={pickingKey !== null}
           >
             <span className={styles.rowName}>{row.name}</span>
-            <span className={styles.rowMeta}>{pickingKey === row.key ? "Loading…" : row.meta}</span>
+            <span className={styles.rowMeta}>
+              {pickingKey === row.key
+                ? "Loading…"
+                : type.id === "all" && row.kindLabel
+                  ? `${row.kindLabel} · ${row.meta}`
+                  : row.meta}
+            </span>
           </button>
         ))}
       </div>

--- a/src/views/BrowseApiModal.tsx
+++ b/src/views/BrowseApiModal.tsx
@@ -211,7 +211,7 @@ function TypePanel({
   onPick,
 }: TypePanelProps) {
   const results = type.useResults(source, query);
-  const emptyMessage = `No ${type.label.toLowerCase()} match your search.`;
+  const emptyMessage = type.emptyMessage;
 
   return (
     <>


### PR DESCRIPTION
### What are the relevant tickets?

N/A — verbal feature request.

### Description (What does it do?)

Adds a third content type, **All**, to the SRD browse dialog. It searches across items (magic + mundane) and spells in a single merged list, and is now the default tab. Each row in the All tab shows a leading kind tag (`Item · …` or `Spell · …`) in the meta column; the prefix is hidden on the Items and Spells tabs.

Why: today the user has to know whether their target is an item or a spell before they can search. Most of the time they just want to type a name ("fireball", "longsword", "bag of holding") and pick the result. Pre-selecting the tab is friction.

Architecture (compose, don't special-case):

- New `allContentType` in `src/api/content-types/all.ts` calls the same three React Query hooks the existing tabs use (`useMagicItemIndex`, `useMundaneItemIndex`, `useSpellIndex`), tags each entry with `__source: "magic" | "mundane" | "spell"`, alpha-sorts (empty query) or fuzzy-sorts (with query) across the merged set, and emits `ContentRow`s with `kindLabel: "Item" | "Spell"`. `isLoading`, `isError`, and `refetch` are OR-merges across the three — same posture `itemsContentType` uses today for magic + mundane.
- `ContentRow` gains an optional `kindLabel?: string`; only `allContentType` sets it.
- `BrowseApiModal`'s row renderer prepends `${row.kindLabel} · ` to the meta column when `type.id === "all"`.
- `ContentType` gains a required `emptyMessage: string` field. The previous inline interpolation (`No ${type.label.toLowerCase()} match your search.`) would have produced the grammatically broken "No all match your search." Items now reads "No items match your search.", spells "No spells match your search.", and All reads "No results match your search."

`itemsContentType` and `spellsContentType` are otherwise untouched. The mobile narrow-viewport `TypeMenu` dropdown (< ~560px container width) iterates `CONTENT_TYPES`, so "All" appears at the top of the menu automatically — no extra code path.

### Screenshots (if appropriate):
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?

Run the dev server and walk:

- Open a deck → **Browse SRD**. Confirm **All** is selected by default and the row list interleaves items and spells alphabetically with `Item · …` / `Spell · …` prefixes on the right side of each row.
- Type a query that matches nothing (e.g., `xyzzy`) → empty state reads "No results match your search."
- Type a real query (e.g., `fire`) → results narrow across both kinds; kind prefix remains.
- Switch to **Items** and **Spells** tabs → prefix disappears; layout is otherwise unchanged from current behaviour.
- Switch source 2024 ↔ 2014 while on All → rows refresh; prefix stays.
- Pick an item and a spell from All → both add cards to the deck (the kind tag in the dialog doesn't change anything about the saved card — `toCard()` returns the same shape as picking from the Items/Spells tabs).
- Resize the window narrow (< ~560px container width) → the tab list collapses into the **Type** dropdown with "All" at the top.

Test coverage: `src/views/BrowseApiModal.test.tsx` adds default-tab, merged-rows alphabetical sort, kind-tag presence in All, kind-tag absence in Items and Spells, the All empty-state copy, and the All-tab search placeholder. The existing "Items tab merges magic and mundane sources alphabetically" test now explicitly clicks into Items first (previously it had drifted to running on All by accident). +8 tests, 781 passing.

### Additional Context

**Two parallel-subagent review passes** (one on the spec, one on the implementation) shaped the final shape:

- **Spec round** caught the broken empty-state grammar before code was written, which is why the `emptyMessage` field exists. Also dropped a planned `all.test.ts` after the test agent pointed out the repo's pattern is to test content-type behaviour through the modal's UI rather than as a hook unit (see `src/api/hooks.test.tsx` for the established hook-test style).
- **Code round** flagged a test-naming drift (the existing Items-tab merge test ran against All by accident after the default flipped) and a coverage gap (no assertion for the All-tab placeholder). Both addressed in `86c62b0`.

**Pushed back (with reasons documented in the commits)**:

- "Rows can render alongside an error banner if one of the three indices fails" — this is pre-existing OR-error behaviour in `itemsContentType` for magic + mundane, intentionally chosen because both indices come from bundled JSON. Widening from two to three sources doesn't change the failure characteristic. Out of scope.
- "Cross-kind `key` collisions" — SRD keys are kind-namespaced in the source data (`srd_…` / `srd-2024_…`); `itemsContentType` makes the same assumption today.
- "Loosen the `type.id === "all"` guard to just `row.kindLabel`" — the spec specifies this exact condition; keeping `type.id === "all"` makes intent obvious at the call site.

**Spec and plan** are checked in:

- `docs/superpowers/specs/2026-05-14-browse-all-tab-design.md`
- `docs/superpowers/plans/2026-05-14-browse-all-tab.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)