### PR TITLE
chore(footer): point repo link at renamed deckwright repo

### DIFF
--- a/src/app/Footer.test.tsx
+++ b/src/app/Footer.test.tsx
@@ -13,7 +13,7 @@ describe("<Footer>", () => {
     const link = within(screen.getByRole("contentinfo")).getByRole("link", {
       name: /view source on github/i,
     });
-    expect(link).toHaveAttribute("href", "https://github.com/ChristopherChudzicki/dnd-cards");
+    expect(link).toHaveAttribute("href", "https://github.com/ChristopherChudzicki/deckwright");
     expect(link).toHaveAttribute("target", "_blank");
     expect(link.getAttribute("rel") ?? "").toMatch(/noopener/);
     expect(link.getAttribute("rel") ?? "").toMatch(/noreferrer/);

--- a/src/app/Footer.tsx
+++ b/src/app/Footer.tsx
@@ -1,7 +1,7 @@
 import { GitHubLogo } from "../lib/ui/icons/GitHubLogo";
 import styles from "./Footer.module.css";
 
-const REPO_URL = "https://github.com/ChristopherChudzicki/dnd-cards";
+const REPO_URL = "https://github.com/ChristopherChudzicki/deckwright";
 
 export function Footer() {
   return (


### PR DESCRIPTION
### What are the relevant tickets?

N/A — follow-up to the GitHub repo rename from `dnd-cards` to `deckwright`.

### Description (What does it do?)

Updates the hardcoded `REPO_URL` in the footer's "View source on GitHub" link (and its test assertion) to point at the new repo name. GitHub's redirect from the old URL still works, but this keeps the user-visible link canonical.

A grep of the rest of the repo turned up only historical specs/plans/handoffs under `docs/superpowers/**` and `feature_work/**` referencing the old URL — left alone since those are frozen documents and the redirect handles them.

### How can this be tested?

Open the app, click the GitHub icon in the footer, confirm it lands on `https://github.com/ChristopherChudzicki/deckwright` (not via redirect).