### PR TITLE
chore(attribution): credit Open5e in README, footer, and SRD browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,5 @@ Item and spell bodies render as Markdown (CommonMark + GFM tables) and are sanit
 ## Credits
 
 Spell and magic-item data bundled in this app is derived from the System Reference Document 5.1 and System Reference Document 5.2 by Wizards of the Coast LLC, available at [dndbeyond.com/srd](https://www.dndbeyond.com/srd), licensed under the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
+
+Huge thanks to the [Open5e](https://open5e.com) project — Deckwright's SRD content is sourced from their curated API at [api.open5e.com](https://api.open5e.com). Open5e does the unglamorous work of turning the SRD into clean, queryable JSON; without that, this app would have been a much longer project.

--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ Item and spell bodies render as Markdown (CommonMark + GFM tables) and are sanit
 
 Spell and magic-item data bundled in this app is derived from the System Reference Document 5.1 and System Reference Document 5.2 by Wizards of the Coast LLC, available at [dndbeyond.com/srd](https://www.dndbeyond.com/srd), licensed under the [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
 
-Huge thanks to the [Open5e](https://open5e.com) project — Deckwright's SRD content is sourced from their curated API at [api.open5e.com](https://api.open5e.com). Open5e does the unglamorous work of turning the SRD into clean, queryable JSON; without that, this app would have been a much longer project.
+Huge thanks to the [Open5e](https://open5e.com) project — Deckwright's SRD content is sourced from their curated API at [api.open5e.com](https://api.open5e.com). Their work turning the SRD into clean, queryable JSON is what made this app practical to build.

--- a/src/app/Footer.module.css
+++ b/src/app/Footer.module.css
@@ -27,6 +27,11 @@
   outline-offset: 2px;
 }
 
+.separator {
+  margin: 0 var(--space-1);
+  color: var(--color-text-muted);
+}
+
 @media print {
   .footer {
     display: none;

--- a/src/app/Footer.module.css
+++ b/src/app/Footer.module.css
@@ -1,5 +1,8 @@
 .footer {
-  text-align: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-2);
   padding: var(--space-3) var(--space-5);
   border-top: 1px solid var(--color-border);
   background: var(--color-surface);
@@ -25,11 +28,6 @@
 .link:focus-visible {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
-}
-
-.separator {
-  margin: 0 var(--space-1);
-  color: var(--color-text-muted);
 }
 
 @media print {

--- a/src/app/Footer.test.tsx
+++ b/src/app/Footer.test.tsx
@@ -18,4 +18,15 @@ describe("<Footer>", () => {
     expect(link.getAttribute("rel") ?? "").toMatch(/noopener/);
     expect(link.getAttribute("rel") ?? "").toMatch(/noreferrer/);
   });
+
+  it("credits Open5e with a link to open5e.com", () => {
+    render(<Footer />);
+    const link = within(screen.getByRole("contentinfo")).getByRole("link", {
+      name: /open5e/i,
+    });
+    expect(link).toHaveAttribute("href", "https://open5e.com");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link.getAttribute("rel") ?? "").toMatch(/noopener/);
+    expect(link.getAttribute("rel") ?? "").toMatch(/noreferrer/);
+  });
 });

--- a/src/app/Footer.tsx
+++ b/src/app/Footer.tsx
@@ -11,11 +11,8 @@ export function Footer() {
         <GitHubLogo size={16} />
         <span>View source on GitHub</span>
       </a>
-      <span className={styles.separator} aria-hidden="true">
-        ·
-      </span>
       <a href={OPEN5E_URL} target="_blank" rel="noopener noreferrer" className={styles.link}>
-        SRD data via Open5e
+        Data via Open5e
       </a>
     </footer>
   );

--- a/src/app/Footer.tsx
+++ b/src/app/Footer.tsx
@@ -2,6 +2,7 @@ import { GitHubLogo } from "../lib/ui/icons/GitHubLogo";
 import styles from "./Footer.module.css";
 
 const REPO_URL = "https://github.com/ChristopherChudzicki/deckwright";
+const OPEN5E_URL = "https://open5e.com";
 
 export function Footer() {
   return (
@@ -9,6 +10,12 @@ export function Footer() {
       <a href={REPO_URL} target="_blank" rel="noopener noreferrer" className={styles.link}>
         <GitHubLogo size={16} />
         <span>View source on GitHub</span>
+      </a>
+      <span className={styles.separator} aria-hidden="true">
+        ·
+      </span>
+      <a href={OPEN5E_URL} target="_blank" rel="noopener noreferrer" className={styles.link}>
+        SRD data via Open5e
       </a>
     </footer>
   );

--- a/src/views/BrowseApiModal.tsx
+++ b/src/views/BrowseApiModal.tsx
@@ -133,7 +133,7 @@ export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
             >
               CC BY 4.0
             </Link>
-            . Curated and served by{" "}
+            . Curated by{" "}
             <Link href="https://open5e.com" target="_blank" rel="noopener noreferrer">
               Open5e
             </Link>

--- a/src/views/BrowseApiModal.tsx
+++ b/src/views/BrowseApiModal.tsx
@@ -133,6 +133,10 @@ export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
             >
               CC BY 4.0
             </Link>
+            . Curated and served by{" "}
+            <Link href="https://open5e.com" target="_blank" rel="noopener noreferrer">
+              Open5e
+            </Link>
             .
           </p>
         </div>


### PR DESCRIPTION
### Description (What does it do?)

Adds an Open5e attribution across three surfaces ahead of sharing Deckwright with the Open5e maintainers.

- **README** — new paragraph in the Credits section thanking Open5e and linking their curated API (`api.open5e.com`). Sits alongside the existing WotC/SRD/CC BY 4.0 paragraph.
- **Browse SRD modal** (`src/views/BrowseApiModal.tsx`) — extends the in-modal attribution footer to read "… licensed under CC BY 4.0. Curated by Open5e." This is the most context-relevant surface, since the modal is where users actually see Open5e-sourced content.
- **Global footer** (`src/app/Footer.tsx`) — adds a second link "Data via Open5e" next to the existing "View source on GitHub" link, so the credit is visible on every page. Switched the footer container from centered text to `flex` with `flex-wrap: wrap` + `gap` so the two links wrap cleanly on narrow viewports.

No logo/icon for Open5e — text link only, since there's no brand asset in the repo and recoloring their orange mark to fit the palette felt like an alteration we shouldn't make without asking.

### Screenshots (if appropriate):
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?

- Open any page and check the footer: both "View source on GitHub" and "Data via Open5e" links render, both open in a new tab with `rel="noopener noreferrer"`. Resize narrow to confirm they wrap cleanly (no dangling separator — the previous mid-review draft had this bug).
- Open the deck editor → "Browse SRD" → confirm the attribution line at the bottom of the modal now ends with "Curated by Open5e." with Open5e linked to https://open5e.com.
- New tests cover the Open5e footer link (`src/app/Footer.test.tsx`).

### Additional Context

Wording went through a copy-edit pass — earlier drafts had "Curated and served by Open5e" (sentence fragment + clunky doublet) and a README sentence that centered the author's effort rather than Open5e's contribution. Both were tightened in the second commit on this branch.