### PR TITLE
feat(print): print a subset of a deck

### DIFF
--- a/docs/superpowers/plans/2026-05-22-print-subset.md
+++ b/docs/superpowers/plans/2026-05-22-print-subset.md
@@ -1,0 +1,1532 @@
+# Print a Subset of a Deck — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users print an arbitrary subset of a deck's renderable cards via a sidebar count + a modal picker, instead of always printing the whole deck.
+
+**Architecture:** `PrintView` gains an ephemeral `Set<CardId>` of selected cards (defaults to all renderable cards, owned by a `usePrintSelection` hook). The sidebar shows a live count + a "Choose cards…" button + a "Select all" link. A new `PrintSelectionModal` owns a draft selection edited via a Kind filter, name search, recency/name sort, per-row checkboxes, and a tri-state header checkbox; on Apply it commits the draft back to `PrintView`, which filters cards before they enter the existing print pipeline.
+
+**Tech Stack:** React 18 + TypeScript, `react-aria-components` (Checkbox, RadioGroup, Dialog via the repo's `DialogShell`), CSS modules, Vitest + React Testing Library + `@testing-library/user-event`, MSW for the deck-cards query.
+
+**Spec:** `docs/superpowers/specs/2026-05-19-print-subset-design.md`
+
+---
+
+## File structure
+
+**New files:**
+- `src/views/usePrintSelection.ts` — hook owning the selection `Set` + init-once-per-deck logic + `selectAll`.
+- `src/views/usePrintSelection.test.tsx` — hook unit tests.
+- `src/views/printSelectionLabel.ts` — pure `selectionCountLabel(selected, total)` helper for the sidebar count phrasing.
+- `src/views/printSelectionLabel.test.ts` — helper unit tests.
+- `src/lib/relativeTime.ts` — `relativeTime(iso, now?)` → "2 hours ago".
+- `src/lib/relativeTime.test.ts` — helper unit tests.
+- `src/lib/ui/Checkbox.tsx` — RAC `Checkbox` wrapper supporting `isIndeterminate`.
+- `src/lib/ui/Checkbox.module.css` — checkbox styles.
+- `src/lib/ui/Checkbox.test.tsx` — primitive tests.
+- `src/views/PrintSelectionModal.tsx` — the picker modal.
+- `src/views/PrintSelectionModal.module.css` — picker layout.
+- `src/views/PrintSelectionModal.test.tsx` — modal behavior tests.
+
+**Modified files:**
+- `src/views/PrintView.tsx` — selection state wiring, sidebar additions, filtered pipeline, modal mount.
+- `src/views/PrintView.module.css` — sidebar count / link styles, empty-selection message.
+- `src/views/PrintView.test.tsx` — integration tests for narrowing/empty/select-all.
+- `src/lib/ui/README.md` — add `Checkbox` to the catalog.
+
+**Reused as-is (do not re-derive):**
+- `src/decks/deckListing.ts` — `deckListing(cards, { kind, sort })` does Kind filtering + recency/name sort with stable tie-breakers. `DeckKindFilter` = `"all" | "item" | "spell"`, `DeckSort` = `"updated" | "name"`.
+- `src/cards/types.ts` — `RenderableCard`, `CardId`, `isRenderableCard`.
+- `src/lib/ui/DialogShell.tsx` (string `aria-label` only), `Button`, `Input`.
+
+---
+
+## Stage 1 — Selection plumbing + sidebar
+
+Shippable on its own. The "Choose cards…" button opens a placeholder until Stage 3. Logic lives in two tested pure/near-pure units; the cross-cutting narrow/empty integration tests arrive in Stage 3 once the modal can drive those states.
+
+### Task 1: `usePrintSelection` hook
+
+**Files:**
+- Create: `src/views/usePrintSelection.ts`
+- Test: `src/views/usePrintSelection.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { usePrintSelection } from "./usePrintSelection";
+
+describe("usePrintSelection", () => {
+  test("initializes to all renderable ids once data is ready", () => {
+    const { result } = renderHook(
+      ({ ids, ready }) => usePrintSelection("d1", ids, ready),
+      { initialProps: { ids: ["a", "b", "c"], ready: true } },
+    );
+    expect([...result.current.selected].sort()).toEqual(["a", "b", "c"]);
+  });
+
+  test("does not initialize until ready is true", () => {
+    const { result, rerender } = renderHook(
+      ({ ids, ready }) => usePrintSelection("d1", ids, ready),
+      { initialProps: { ids: [] as string[], ready: false } },
+    );
+    expect(result.current.selected.size).toBe(0);
+    rerender({ ids: ["a", "b"], ready: true });
+    expect([...result.current.selected].sort()).toEqual(["a", "b"]);
+  });
+
+  test("a refetch of the same deck does not reset a narrowed selection", () => {
+    const { result, rerender } = renderHook(
+      ({ ids, ready }) => usePrintSelection("d1", ids, ready),
+      { initialProps: { ids: ["a", "b", "c"], ready: true } },
+    );
+    act(() => result.current.setSelected(new Set(["a"])));
+    expect([...result.current.selected]).toEqual(["a"]);
+    // Same deckId, new array identity (simulated background refetch).
+    rerender({ ids: ["a", "b", "c"], ready: true });
+    expect([...result.current.selected]).toEqual(["a"]);
+  });
+
+  test("switching deckId re-initializes to all", () => {
+    const { result, rerender } = renderHook(
+      ({ deckId, ids }) => usePrintSelection(deckId, ids, true),
+      { initialProps: { deckId: "d1", ids: ["a", "b"] } },
+    );
+    act(() => result.current.setSelected(new Set(["a"])));
+    rerender({ deckId: "d2", ids: ["x", "y", "z"] });
+    expect([...result.current.selected].sort()).toEqual(["x", "y", "z"]);
+  });
+
+  test("selectAll restores the full renderable set", () => {
+    const { result } = renderHook(() => usePrintSelection("d1", ["a", "b", "c"], true));
+    act(() => result.current.setSelected(new Set(["a"])));
+    act(() => result.current.selectAll());
+    expect([...result.current.selected].sort()).toEqual(["a", "b", "c"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/views/usePrintSelection.test.tsx`
+Expected: FAIL — `usePrintSelection` is not defined / module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+import { useEffect, useRef, useState } from "react";
+import type { CardId } from "../cards/types";
+
+export type PrintSelection = {
+  selected: Set<CardId>;
+  setSelected: (next: Set<CardId>) => void;
+  selectAll: () => void;
+};
+
+/**
+ * Owns the print selection as a Set of card ids. Initializes to "all
+ * renderable" exactly once per deckId (when `ready` first turns true),
+ * so a background refetch — which hands us a new `renderableIds` array
+ * identity — does not silently wipe a narrowed selection. Switching to a
+ * different deckId re-initializes.
+ */
+export function usePrintSelection(
+  deckId: string,
+  renderableIds: CardId[],
+  ready: boolean,
+): PrintSelection {
+  const [selected, setSelected] = useState<Set<CardId>>(() => new Set());
+  const initializedFor = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (ready && initializedFor.current !== deckId) {
+      initializedFor.current = deckId;
+      setSelected(new Set(renderableIds));
+    }
+  }, [ready, deckId, renderableIds]);
+
+  return {
+    selected,
+    setSelected,
+    selectAll: () => setSelected(new Set(renderableIds)),
+  };
+}
+```
+
+The `initializedFor` ref makes the effect idempotent: it runs on every render (because `renderableIds` identity changes), but only re-initializes when the deck actually changes.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/views/usePrintSelection.test.tsx`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/views/usePrintSelection.ts src/views/usePrintSelection.test.tsx
+git commit -m "feat(print): add usePrintSelection hook for subset selection state"
+```
+
+---
+
+### Task 2: `selectionCountLabel` helper
+
+**Files:**
+- Create: `src/views/printSelectionLabel.ts`
+- Test: `src/views/printSelectionLabel.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, test } from "vitest";
+import { selectionCountLabel } from "./printSelectionLabel";
+
+describe("selectionCountLabel", () => {
+  test("all selected reads 'All N cards'", () => {
+    expect(selectionCountLabel(15, 15)).toBe("All 15 cards");
+  });
+
+  test("narrowed reads 'X of N cards'", () => {
+    expect(selectionCountLabel(7, 15)).toBe("7 of 15 cards");
+  });
+
+  test("zero selected reads '0 of N cards'", () => {
+    expect(selectionCountLabel(0, 15)).toBe("0 of 15 cards");
+  });
+
+  test("singular total pluralizes correctly", () => {
+    expect(selectionCountLabel(1, 1)).toBe("All 1 card");
+    expect(selectionCountLabel(0, 1)).toBe("0 of 1 card");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/views/printSelectionLabel.test.ts`
+Expected: FAIL — `selectionCountLabel` is not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+const cardWord = (n: number) => (n === 1 ? "card" : "cards");
+
+/** Sidebar count phrasing. `total` is the renderable-card count. */
+export function selectionCountLabel(selected: number, total: number): string {
+  if (selected === total) return `All ${total} ${cardWord(total)}`;
+  return `${selected} of ${total} ${cardWord(total)}`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/views/printSelectionLabel.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/views/printSelectionLabel.ts src/views/printSelectionLabel.test.ts
+git commit -m "feat(print): add selection count label helper"
+```
+
+---
+
+### Task 3: Wire selection into PrintView + sidebar
+
+**Files:**
+- Modify: `src/views/PrintView.tsx`
+- Modify: `src/views/PrintView.module.css`
+- Test: `src/views/PrintView.test.tsx`
+
+Context — current `PrintView.tsx` (lines 36–52) builds `printable` and feeds it to `useExpandedCards`:
+
+```tsx
+const cards = cardsQuery.data ?? [];
+const printable = cards.filter(isRenderableCard);
+const { physicalCards } = useExpandedCards(printable, perPage);
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/views/PrintView.test.tsx` (inside the existing `describe`):
+
+```tsx
+test("opens with all renderable cards selected and shows 'All N cards'", async () => {
+  const cards = makeCardRow.buildList(3);
+  server.use(
+    http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+  );
+  render(wrap(<PrintView deckId="d1" />));
+  await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
+  expect(screen.getByText("All 3 cards")).toBeInTheDocument();
+});
+
+test("the 'Select all' link is hidden when all cards are selected", async () => {
+  const cards = makeCardRow.buildList(3);
+  server.use(
+    http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+  );
+  render(wrap(<PrintView deckId="d1" />));
+  await waitFor(() => expect(screen.getByText("All 3 cards")).toBeInTheDocument());
+  expect(screen.queryByRole("button", { name: /select all/i })).not.toBeInTheDocument();
+});
+
+test("exposes a 'Choose cards' button", async () => {
+  const cards = makeCardRow.buildList(2);
+  server.use(
+    http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+  );
+  render(wrap(<PrintView deckId="d1" />));
+  await waitFor(() => expect(screen.getByText("All 2 cards")).toBeInTheDocument());
+  expect(screen.getByRole("button", { name: /choose cards/i })).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/views/PrintView.test.tsx`
+Expected: FAIL — no "All 3 cards" text / no "Choose cards" button.
+
+- [ ] **Step 3: Implement the wiring in `PrintView.tsx`**
+
+Add imports near the top:
+
+```tsx
+import { useMemo, useState } from "react"; // extend existing react import as needed
+import { isRenderableCard } from "../cards/types";
+import { usePrintSelection } from "./usePrintSelection";
+import { selectionCountLabel } from "./printSelectionLabel";
+```
+
+(`useId`, `Fragment`, etc. that already exist stay. `useMemo` is new.)
+
+Inside `PrintView`, replace the data/derivation block:
+
+```tsx
+const cards = cardsQuery.data ?? [];
+const printable = useMemo(() => cards.filter(isRenderableCard), [cards]);
+const renderableIds = useMemo(() => printable.map((c) => c.id), [printable]);
+
+const { selected, setSelected, selectAll } = usePrintSelection(
+  deckId,
+  renderableIds,
+  cardsQuery.isSuccess,
+);
+const [isPickerOpen, setIsPickerOpen] = useState(false);
+
+const selectedPrintable = printable.filter((c) => selected.has(c.id));
+const { physicalCards } = useExpandedCards(selectedPrintable, perPage);
+```
+
+Note: `physicalCards` now derives from `selectedPrintable`, not `printable`. `pairSlots`/`pages` downstream are unchanged.
+
+Update the empty/disabled logic. Replace the `isDisabled={printable.length === 0}` on the Print button and the `printable.length === 0` empty message:
+
+```tsx
+const isEmptySelection = printable.length > 0 && selectedPrintable.length === 0;
+const isNarrowed = selected.size > 0 && selected.size < printable.length;
+```
+
+Add the selection block at the **top** of the sidebar (before the "Cards per page" `.field`):
+
+```tsx
+{printable.length > 0 && (
+  <div className={styles.selectionBlock}>
+    <p className={styles.selectionCount} data-empty={isEmptySelection || undefined}>
+      {selectionCountLabel(selectedPrintable.length, printable.length)}
+    </p>
+    <Button variant="secondary" size="sm" onPress={() => setIsPickerOpen(true)}>
+      Choose cards…
+    </Button>
+    {isNarrowed && (
+      <button type="button" className={styles.selectAllLink} onClick={selectAll}>
+        Select all
+      </button>
+    )}
+  </div>
+)}
+<hr className={styles.divider} />
+```
+
+Update the Print button. Per the spec's a11y note, use `aria-disabled`
+(not `isDisabled`/`disabled`) so the button stays focusable and a
+screen reader can announce the `aria-describedby` hint explaining *why*
+it's disabled; guard `onPress` so it's inert when nothing is selected:
+
+```tsx
+const noneSelected = selectedPrintable.length === 0;
+
+<Button
+  className={styles.printButton}
+  variant="primary"
+  size="lg"
+  aria-disabled={noneSelected || undefined}
+  aria-describedby={isEmptySelection ? emptyHintId : undefined}
+  onPress={() => {
+    if (noneSelected) return;
+    window.print();
+  }}
+>
+  Print
+</Button>
+{isEmptySelection && (
+  <p id={emptyHintId} className={styles.tip}>
+    Select at least 1 card to print.
+  </p>
+)}
+```
+
+This replaces the button's previous `isDisabled={printable.length === 0}`
+— `noneSelected` is true whenever the deck has no renderable cards *or*
+the user cleared the selection, covering both cases.
+
+Add `const emptyHintId = useId();` alongside the existing `useId()` usage.
+
+Update the sheet empty message (currently `{printable.length === 0 && <p>No printable cards...</p>}`):
+
+```tsx
+{printable.length === 0 && <p>No printable cards in this deck yet.</p>}
+{isEmptySelection && (
+  <p>No cards selected — use Choose cards to pick what to print.</p>
+)}
+```
+
+Add the modal mount at the end of the root (placeholder for Stage 1 — replaced in Task 9):
+
+```tsx
+{isPickerOpen && (
+  <div role="dialog" aria-label="Choose cards to print">
+    {/* Placeholder — replaced by PrintSelectionModal in Stage 3. */}
+    <button type="button" onClick={() => setIsPickerOpen(false)}>
+      Close
+    </button>
+  </div>
+)}
+```
+
+- [ ] **Step 4: Add CSS in `PrintView.module.css`**
+
+Add near the other sidebar rules:
+
+```css
+.selectionBlock {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  align-items: flex-start;
+}
+
+.selectionCount {
+  margin: 0;
+  font-weight: 500;
+}
+
+.selectionCount[data-empty] {
+  color: var(--color-warning-fg, var(--color-danger-fg));
+}
+
+.selectAllLink {
+  border: 0;
+  background: none;
+  padding: 0;
+  font: inherit;
+  color: var(--color-accent);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.selectAllLink:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+```
+
+If `--color-warning-fg` does not exist in `src/index.css`, the fallback to `--color-danger-fg` applies; verify one of them resolves (grep `src/index.css`). If neither exists, add `--color-warning-fg` to `src/index.css` as a sibling of the other `--color-*-fg` tokens using the existing warning/amber hue.
+
+- [ ] **Step 5: Run tests**
+
+Run: `npm test -- src/views/PrintView.test.tsx`
+Expected: PASS — the three new tests plus all pre-existing PrintView tests (the pipeline still renders all cards because the default selection is "all").
+
+- [ ] **Step 6: Typecheck + build**
+
+Run: `npm run build`
+Expected: no TypeScript errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/views/PrintView.tsx src/views/PrintView.module.css src/views/PrintView.test.tsx src/index.css
+git commit -m "feat(print): selection state + sidebar count/choose-cards/select-all"
+```
+
+---
+
+## Stage 2 — Net-new primitives
+
+Isolated, individually tested. No dependency on Stage 1.
+
+### Task 4: `relativeTime` helper
+
+**Files:**
+- Create: `src/lib/relativeTime.ts`
+- Test: `src/lib/relativeTime.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, test } from "vitest";
+import { relativeTime } from "./relativeTime";
+
+const now = new Date("2026-05-22T12:00:00Z");
+
+describe("relativeTime", () => {
+  test("minutes ago", () => {
+    expect(relativeTime("2026-05-22T11:30:00Z", now)).toBe("30 minutes ago");
+  });
+
+  test("hours ago", () => {
+    expect(relativeTime("2026-05-22T10:00:00Z", now)).toBe("2 hours ago");
+  });
+
+  test("days ago", () => {
+    expect(relativeTime("2026-05-19T12:00:00Z", now)).toBe("3 days ago");
+  });
+
+  test("seconds ago uses 'now' bucket", () => {
+    // numeric: "auto" renders < 1 minute as "now".
+    expect(relativeTime("2026-05-22T11:59:50Z", now)).toBe("now");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/lib/relativeTime.test.ts`
+Expected: FAIL — `relativeTime` is not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+
+const DIVISIONS: { amount: number; unit: Intl.RelativeTimeFormatUnit }[] = [
+  { amount: 60, unit: "second" },
+  { amount: 60, unit: "minute" },
+  { amount: 24, unit: "hour" },
+  { amount: 7, unit: "day" },
+  { amount: 4.34524, unit: "week" },
+  { amount: 12, unit: "month" },
+  { amount: Number.POSITIVE_INFINITY, unit: "year" },
+];
+
+/** "2 hours ago", "3 days ago", "now". Past values produce "… ago". */
+export function relativeTime(iso: string, now: Date = new Date()): string {
+  let duration = (new Date(iso).getTime() - now.getTime()) / 1000;
+  for (const division of DIVISIONS) {
+    if (Math.abs(duration) < division.amount) {
+      return rtf.format(Math.round(duration), division.unit);
+    }
+    duration /= division.amount;
+  }
+  return rtf.format(Math.round(duration), "year");
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/lib/relativeTime.test.ts`
+Expected: PASS (4 tests).
+
+If "30 minutes ago" / "2 hours ago" come back with different exact wording in the CI locale, pin the locale by changing `new Intl.RelativeTimeFormat(undefined, …)` to `new Intl.RelativeTimeFormat("en", …)`. The repo's `Intl.Collator` in `deckListing.ts` uses default locale, but RelativeTimeFormat wording is locale-sensitive, so `"en"` keeps tests deterministic.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/relativeTime.ts src/lib/relativeTime.test.ts
+git commit -m "feat(lib): add relativeTime formatter"
+```
+
+---
+
+### Task 5: `Checkbox` primitive
+
+**Files:**
+- Create: `src/lib/ui/Checkbox.tsx`
+- Create: `src/lib/ui/Checkbox.module.css`
+- Test: `src/lib/ui/Checkbox.test.tsx`
+- Modify: `src/lib/ui/README.md`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, test } from "vitest";
+import { render, screen } from "../../test/render";
+import { Checkbox } from "./Checkbox";
+
+function Harness() {
+  const [selected, setSelected] = useState(false);
+  return (
+    <Checkbox isSelected={selected} onChange={setSelected}>
+      Accept
+    </Checkbox>
+  );
+}
+
+describe("Checkbox", () => {
+  test("renders a checkbox with its label as the accessible name", () => {
+    render(<Checkbox isSelected={false} onChange={() => {}}>Accept</Checkbox>);
+    expect(screen.getByRole("checkbox", { name: "Accept" })).toBeInTheDocument();
+  });
+
+  test("toggles on click", async () => {
+    render(<Harness />);
+    const box = screen.getByRole("checkbox", { name: "Accept" });
+    expect(box).not.toBeChecked();
+    await userEvent.click(box);
+    expect(box).toBeChecked();
+  });
+
+  test("indeterminate renders aria-checked=mixed", () => {
+    render(
+      <Checkbox isSelected={false} isIndeterminate onChange={() => {}} aria-label="Select all">
+        {null}
+      </Checkbox>,
+    );
+    expect(screen.getByRole("checkbox", { name: "Select all" })).toHaveAttribute(
+      "aria-checked",
+      "mixed",
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/lib/ui/Checkbox.test.tsx`
+Expected: FAIL — `Checkbox` not defined.
+
+- [ ] **Step 3: Write the primitive**
+
+`src/lib/ui/Checkbox.tsx`:
+
+```tsx
+import type { ReactNode } from "react";
+import { Checkbox as RACCheckbox, type CheckboxProps as RACCheckboxProps } from "react-aria-components";
+import styles from "./Checkbox.module.css";
+
+export type CheckboxProps = Omit<RACCheckboxProps, "className" | "children"> & {
+  className?: string;
+  children?: ReactNode;
+};
+
+export function Checkbox({ className, children, ...rest }: CheckboxProps) {
+  return (
+    <RACCheckbox {...rest} className={[styles.checkbox, className].filter(Boolean).join(" ")}>
+      <span className={styles.box} aria-hidden="true" />
+      {children}
+    </RACCheckbox>
+  );
+}
+```
+
+`children` is optional: the tri-state header checkbox is labelled via `aria-label` and renders no visible label text.
+
+`src/lib/ui/Checkbox.module.css`:
+
+```css
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+}
+
+.box {
+  width: 1.1rem;
+  height: 1.1rem;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  display: inline-flex;
+  flex: none;
+}
+
+.checkbox[data-selected] .box,
+.checkbox[data-indeterminate] .box {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+.checkbox[data-focus-visible] .box {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+```
+
+RAC sets `data-selected` / `data-indeterminate` / `data-focus-visible` on the label element automatically; no render-function needed. (A checkmark/dash glyph is optional polish; the background-fill states above are sufficient and accessible. If you add glyphs, use a `::after` on `.box` keyed off the same data-attributes.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/lib/ui/Checkbox.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Document the primitive**
+
+Add a row to the catalog table in `src/lib/ui/README.md` (after the `Switch` row):
+
+```markdown
+| `Checkbox` | A checkbox. Supports `isIndeterminate` for tri-state (renders `aria-checked="mixed"`). Children are the label; omit them and pass `aria-label` for a label-less control. |
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/ui/Checkbox.tsx src/lib/ui/Checkbox.module.css src/lib/ui/Checkbox.test.tsx src/lib/ui/README.md
+git commit -m "feat(ui): add Checkbox primitive with indeterminate support"
+```
+
+---
+
+## Stage 3 — Assemble `PrintSelectionModal` + integration
+
+### Task 6: Modal scaffold — list, sort, row checkboxes, Apply/Cancel
+
+**Files:**
+- Create: `src/views/PrintSelectionModal.tsx`
+- Create: `src/views/PrintSelectionModal.module.css`
+- Test: `src/views/PrintSelectionModal.test.tsx`
+
+The modal is self-contained and tested directly (rendered without `PrintView`), so its tests don't need MSW. Build cards with the card factories.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, test, vi } from "vitest";
+import { itemCardFactory, spellCardFactory } from "../cards/factories";
+import type { CardId, RenderableCard } from "../cards/types";
+import { render, screen } from "../test/render";
+import { PrintSelectionModal } from "./PrintSelectionModal";
+
+function open(cards: RenderableCard[], initial: Set<CardId>, onApply = vi.fn()) {
+  function Harness() {
+    const [closed, setClosed] = useState(false);
+    if (closed) return <p>closed</p>;
+    return (
+      <PrintSelectionModal
+        cards={cards}
+        initialSelection={initial}
+        onApply={onApply}
+        onClose={() => setClosed(true)}
+      />
+    );
+  }
+  render(<Harness />);
+  return { onApply };
+}
+
+const allIds = (cards: RenderableCard[]) => new Set(cards.map((c) => c.id));
+
+describe("<PrintSelectionModal>", () => {
+  test("lists every renderable card with a checkbox, recency-sorted (newest first)", () => {
+    const older = itemCardFactory.build({ name: "Older", updatedAt: "2026-05-01T00:00:00Z" });
+    const newer = itemCardFactory.build({ name: "Newer", updatedAt: "2026-05-20T00:00:00Z" });
+    const cards = [older, newer];
+    open(cards, allIds(cards));
+    const checkboxes = screen.getAllByRole("checkbox");
+    // First checkbox is the header tri-state; rows follow. Newest row first.
+    const rowNames = screen.getAllByRole("checkbox", { name: /Older|Newer/ }).map((el) => el.getAttribute("aria-label") ?? el.textContent);
+    expect(rowNames[0]).toMatch(/Newer/);
+    expect(rowNames[1]).toMatch(/Older/);
+    expect(checkboxes.length).toBeGreaterThanOrEqual(3); // header + 2 rows
+  });
+
+  test("focus lands on the name search input on open", () => {
+    const cards = itemCardFactory.buildList(2);
+    open(cards, allIds(cards));
+    expect(screen.getByRole("searchbox", { name: /search cards/i })).toHaveFocus();
+  });
+
+  test("Apply commits the current draft and closes", async () => {
+    const cards = itemCardFactory.buildList(2);
+    const { onApply } = open(cards, allIds(cards));
+    await userEvent.click(screen.getByRole("button", { name: /apply/i }));
+    expect(onApply).toHaveBeenCalledTimes(1);
+    const committed = onApply.mock.calls[0][0] as Set<string>;
+    expect([...committed].sort()).toEqual([...allIds(cards)].sort());
+    expect(screen.getByText("closed")).toBeInTheDocument();
+  });
+
+  test("Cancel discards the draft (onApply not called) and closes", async () => {
+    const cards = itemCardFactory.buildList(2);
+    const { onApply } = open(cards, allIds(cards));
+    const [first] = cards;
+    await userEvent.click(screen.getByRole("checkbox", { name: first.name }));
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onApply).not.toHaveBeenCalled();
+    expect(screen.getByText("closed")).toBeInTheDocument();
+  });
+
+  test("toggling a row updates the Apply total", async () => {
+    const cards = itemCardFactory.buildList(3);
+    open(cards, allIds(cards));
+    expect(screen.getByRole("button", { name: "Apply (3 cards)" })).toBeInTheDocument();
+    const [first] = cards;
+    await userEvent.click(screen.getByRole("checkbox", { name: first.name }));
+    expect(screen.getByRole("button", { name: "Apply (2 cards)" })).toBeInTheDocument();
+  });
+
+  test("a spell and an item both appear when present", () => {
+    const item = itemCardFactory.build({ name: "Cloak" });
+    const spell = spellCardFactory.build({ name: "Bless" });
+    const cards = [item, spell];
+    open(cards, allIds(cards));
+    expect(screen.getByRole("checkbox", { name: "Cloak" })).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "Bless" })).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/views/PrintSelectionModal.test.tsx`
+Expected: FAIL — `PrintSelectionModal` not defined.
+
+- [ ] **Step 3: Write the scaffold**
+
+`src/views/PrintSelectionModal.tsx`:
+
+```tsx
+import { useMemo, useState } from "react";
+import { TextField } from "react-aria-components";
+import { relativeTime } from "../lib/relativeTime";
+import { deckListing, type DeckSort } from "../decks/deckListing";
+import type { CardId, RenderableCard } from "../cards/types";
+import { Button } from "../lib/ui/Button";
+import { Checkbox } from "../lib/ui/Checkbox";
+import { DialogShell } from "../lib/ui/DialogShell";
+import { Input } from "../lib/ui/Input";
+import styles from "./PrintSelectionModal.module.css";
+
+type Props = {
+  cards: RenderableCard[];
+  initialSelection: Set<CardId>;
+  onApply: (next: Set<CardId>) => void;
+  onClose: () => void;
+};
+
+const cardWord = (n: number) => (n === 1 ? "card" : "cards");
+
+export function PrintSelectionModal({ cards, initialSelection, onApply, onClose }: Props) {
+  const [draft, setDraft] = useState<Set<CardId>>(() => new Set(initialSelection));
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<DeckSort>("updated");
+
+  const visible = useMemo(() => {
+    const { cards: sorted } = deckListing(cards, { kind: "all", sort });
+    const q = search.trim().toLowerCase();
+    return q ? sorted.filter((c) => c.name.toLowerCase().includes(q)) : sorted;
+  }, [cards, sort, search]);
+
+  const toggle = (id: CardId) => {
+    const next = new Set(draft);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    setDraft(next);
+  };
+
+  const total = draft.size;
+
+  return (
+    <DialogShell
+      isOpen
+      onOpenChange={(o) => {
+        if (!o) onClose();
+      }}
+      aria-label="Choose cards to print"
+      size="lg"
+      height={{ fixed: "min(70vh, 640px)" }}
+      bleed
+    >
+      {() => (
+        <div className={styles.modal}>
+          <div className={styles.filterRow}>
+            <TextField aria-label="Search cards" className={styles.searchField}>
+              <Input
+                type="search"
+                placeholder="Search cards…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                autoFocus
+              />
+            </TextField>
+            <label className={styles.sortLabel}>
+              <span>Sort</span>
+              <select
+                className={styles.sortSelect}
+                value={sort}
+                onChange={(e) => setSort(e.target.value as DeckSort)}
+              >
+                <option value="updated">Recently edited</option>
+                <option value="name">Name A→Z</option>
+              </select>
+            </label>
+          </div>
+
+          <ul className={styles.list}>
+            {visible.map((c) => (
+              <li key={c.id} className={styles.row}>
+                <Checkbox isSelected={draft.has(c.id)} onChange={() => toggle(c.id)}>
+                  {c.name}
+                </Checkbox>
+                <span className={styles.rowKind} aria-hidden="true">
+                  {c.kind}
+                </span>
+                <time className={styles.rowTime} dateTime={c.updatedAt}>
+                  {relativeTime(c.updatedAt)}
+                </time>
+              </li>
+            ))}
+          </ul>
+
+          <div className={styles.footer}>
+            <div className={styles.footerActions}>
+              <Button variant="secondary" onPress={onClose}>
+                Cancel
+              </Button>
+              <Button variant="primary" onPress={() => onApply(draft)}>
+                {`Apply (${total} ${cardWord(total)})`}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </DialogShell>
+  );
+}
+```
+
+`src/views/PrintSelectionModal.module.css`:
+
+```css
+.modal {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  gap: var(--space-3);
+  padding: var(--space-4);
+}
+
+.filterRow {
+  display: flex;
+  gap: var(--space-3);
+  align-items: end;
+  flex-wrap: wrap;
+}
+
+.searchField {
+  flex: 1 1 12rem;
+}
+
+.sortLabel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  font-size: var(--fs-sm);
+}
+
+.sortSelect {
+  font: inherit;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-1);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.rowKind {
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+  text-transform: capitalize;
+}
+
+.rowTime {
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+}
+
+.footer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--space-3);
+}
+
+.footerActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3);
+}
+
+.bulkRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-1);
+  border-bottom: 1px solid var(--color-border-strong);
+}
+
+.shownCount {
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+}
+
+.hiddenLine {
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+```
+
+(The `.bulkRow`, `.shownCount`, `.hiddenLine`, `.srOnly` classes are used in Tasks 7–8; defining them now avoids a second CSS edit.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm test -- src/views/PrintSelectionModal.test.tsx`
+Expected: PASS (6 tests). The header tri-state checkbox doesn't exist yet, so the "checkboxes.length >= 3" assertion counts 2 rows; adjust the first test's `>= 3` to `>= 2` if it fails here, then restore to `>= 3` after Task 7. (Cleaner: keep `>= 2` now; Task 7 adds its own header assertions.)
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npm run build`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/views/PrintSelectionModal.tsx src/views/PrintSelectionModal.module.css src/views/PrintSelectionModal.test.tsx
+git commit -m "feat(print): PrintSelectionModal scaffold — list, sort, row checkboxes, apply/cancel"
+```
+
+---
+
+### Task 7: Tri-state header checkbox
+
+**Files:**
+- Modify: `src/views/PrintSelectionModal.tsx`
+- Test: `src/views/PrintSelectionModal.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `PrintSelectionModal.test.tsx`:
+
+```tsx
+test("header checkbox clears all visible when all are checked", async () => {
+  const cards = itemCardFactory.buildList(3);
+  open(cards, allIds(cards));
+  const header = screen.getByRole("checkbox", { name: /select all shown cards/i });
+  expect(header).toBeChecked();
+  await userEvent.click(header);
+  expect(screen.getByRole("button", { name: "Apply (0 cards)" })).toBeInTheDocument();
+});
+
+test("header checkbox selects all visible when none are checked", async () => {
+  const cards = itemCardFactory.buildList(3);
+  open(cards, new Set()); // start empty
+  const header = screen.getByRole("checkbox", { name: /select all shown cards/i });
+  expect(header).not.toBeChecked();
+  await userEvent.click(header);
+  expect(screen.getByRole("button", { name: "Apply (3 cards)" })).toBeInTheDocument();
+});
+
+test("header checkbox is indeterminate (mixed) when some visible are checked", async () => {
+  const cards = itemCardFactory.buildList(3);
+  open(cards, allIds(cards));
+  const [first] = cards;
+  await userEvent.click(screen.getByRole("checkbox", { name: first.name }));
+  const header = screen.getByRole("checkbox", { name: /select all shown cards/i });
+  expect(header).toHaveAttribute("aria-checked", "mixed");
+});
+
+test("clicking an indeterminate header clears all visible", async () => {
+  const cards = itemCardFactory.buildList(3);
+  open(cards, allIds(cards));
+  const [first] = cards;
+  await userEvent.click(screen.getByRole("checkbox", { name: first.name })); // now 2 of 3
+  const header = screen.getByRole("checkbox", { name: /select all shown cards/i });
+  await userEvent.click(header);
+  expect(screen.getByRole("button", { name: "Apply (0 cards)" })).toBeInTheDocument();
+});
+
+test("header shows 'X of Y shown' status", () => {
+  const cards = itemCardFactory.buildList(3);
+  open(cards, allIds(cards));
+  expect(screen.getByText("3 of 3 shown")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/views/PrintSelectionModal.test.tsx`
+Expected: FAIL — no "select all shown cards" checkbox.
+
+- [ ] **Step 3: Implement the header**
+
+In `PrintSelectionModal.tsx`, add derived values after `visible`:
+
+```tsx
+const visibleIds = useMemo(() => visible.map((c) => c.id), [visible]);
+const visibleCheckedCount = useMemo(
+  () => visibleIds.filter((id) => draft.has(id)).length,
+  [visibleIds, draft],
+);
+const allVisibleChecked = visible.length > 0 && visibleCheckedCount === visible.length;
+const noneVisibleChecked = visibleCheckedCount === 0;
+const headerIndeterminate = !allVisibleChecked && !noneVisibleChecked;
+
+const onHeaderToggle = () => {
+  const next = new Set(draft);
+  if (visibleCheckedCount > 0) {
+    // any visible checked (checked or indeterminate) → clear all visible
+    for (const id of visibleIds) next.delete(id);
+  } else {
+    for (const id of visibleIds) next.add(id);
+  }
+  setDraft(next);
+};
+```
+
+Insert the bulk-select row immediately before `<ul className={styles.list}>`:
+
+```tsx
+<div className={styles.bulkRow}>
+  <Checkbox
+    aria-label="Select all shown cards"
+    isSelected={allVisibleChecked}
+    isIndeterminate={headerIndeterminate}
+    onChange={onHeaderToggle}
+  />
+  <span className={styles.shownCount}>
+    {visibleCheckedCount} of {visible.length} shown
+  </span>
+</div>
+```
+
+**Critical:** `onHeaderToggle` ignores the boolean RAC passes to `onChange` and derives the action from `visibleCheckedCount`. RAC's Checkbox fires `onChange(true)` when clicked from the indeterminate state, which would *select all* — the opposite of the required "any checked → clear" rule. Deriving the action ourselves is what makes the indeterminate case correct.
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm test -- src/views/PrintSelectionModal.test.tsx`
+Expected: PASS (all, including the 5 new header tests). If the Task 6 "checkboxes.length >= 2" assertion was left at `>= 2`, bump it to `>= 3` now (header + 2 rows).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/views/PrintSelectionModal.tsx src/views/PrintSelectionModal.test.tsx
+git commit -m "feat(print): tri-state header checkbox for bulk select/clear of visible cards"
+```
+
+---
+
+### Task 8: Kind filter, name search, hidden-checked line, live region
+
+**Files:**
+- Modify: `src/views/PrintSelectionModal.tsx`
+- Test: `src/views/PrintSelectionModal.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `PrintSelectionModal.test.tsx`:
+
+```tsx
+test("Kind filter hides the other kind without unchecking it", async () => {
+  const item = itemCardFactory.build({ name: "Cloak" });
+  const spell = spellCardFactory.build({ name: "Bless" });
+  const cards = [item, spell];
+  open(cards, allIds(cards));
+  await userEvent.click(screen.getByRole("radio", { name: /items/i }));
+  expect(screen.queryByRole("checkbox", { name: "Bless" })).not.toBeInTheDocument();
+  expect(screen.getByRole("checkbox", { name: "Cloak" })).toBeInTheDocument();
+  // Switching back to All shows Bless still checked.
+  await userEvent.click(screen.getByRole("radio", { name: /all/i }));
+  expect(screen.getByRole("checkbox", { name: "Bless" })).toBeChecked();
+});
+
+test("name search narrows the list case-insensitively", async () => {
+  const a = itemCardFactory.build({ name: "Acid Arrow" });
+  const b = itemCardFactory.build({ name: "Bless" });
+  open([a, b], allIds([a, b]));
+  await userEvent.type(screen.getByRole("searchbox", { name: /search cards/i }), "acid");
+  expect(screen.getByRole("checkbox", { name: "Acid Arrow" })).toBeInTheDocument();
+  expect(screen.queryByRole("checkbox", { name: "Bless" })).not.toBeInTheDocument();
+});
+
+test("hidden-checked line appears when a filter hides a selected card", async () => {
+  const item = itemCardFactory.build({ name: "Cloak" });
+  const spell = spellCardFactory.build({ name: "Bless" });
+  const cards = [item, spell];
+  open(cards, allIds(cards));
+  await userEvent.click(screen.getByRole("radio", { name: /items/i }));
+  expect(
+    screen.getByText(/1 selected card is hidden by filters/i),
+  ).toBeInTheDocument();
+});
+
+test("Clear filters link restores the full list and removes the hidden-checked line", async () => {
+  const item = itemCardFactory.build({ name: "Cloak" });
+  const spell = spellCardFactory.build({ name: "Bless" });
+  const cards = [item, spell];
+  open(cards, allIds(cards));
+  await userEvent.click(screen.getByRole("radio", { name: /items/i }));
+  await userEvent.click(screen.getByRole("button", { name: /clear filters/i }));
+  expect(screen.getByRole("checkbox", { name: "Bless" })).toBeInTheDocument();
+  expect(screen.queryByText(/hidden by filters/i)).not.toBeInTheDocument();
+});
+
+test("exposes a polite live region announcing the selected total", () => {
+  const cards = itemCardFactory.buildList(3);
+  open(cards, allIds(cards));
+  const live = screen.getByText(/3 cards selected/i);
+  expect(live).toHaveAttribute("aria-live", "polite");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/views/PrintSelectionModal.test.tsx`
+Expected: FAIL — no Kind radios, no hidden line, no live region.
+
+- [ ] **Step 3: Implement filters + hidden line + live region**
+
+Edit the two existing import lines in place (do **not** add duplicate
+import statements). After editing they should read:
+
+```tsx
+import { Radio, RadioGroup, TextField } from "react-aria-components";
+import { deckListing, type DeckKindFilter, type DeckSort } from "../decks/deckListing";
+```
+
+(Task 6 imported `TextField` and `{ deckListing, type DeckSort }`; this
+step adds `Radio`, `RadioGroup`, and `DeckKindFilter` to those same
+lines.)
+
+Add `kind` state and thread it into `visible`:
+
+```tsx
+const [kind, setKind] = useState<DeckKindFilter>("all");
+
+const visible = useMemo(() => {
+  const { cards: sorted } = deckListing(cards, { kind, sort });
+  const q = search.trim().toLowerCase();
+  return q ? sorted.filter((c) => c.name.toLowerCase().includes(q)) : sorted;
+}, [cards, kind, sort, search]);
+```
+
+Compute the hidden-checked count (selected cards not currently visible):
+
+```tsx
+const hiddenSelectedCount = useMemo(() => {
+  const visibleIdSet = new Set(visibleIds);
+  return cards.filter((c) => draft.has(c.id) && !visibleIdSet.has(c.id)).length;
+}, [cards, draft, visibleIds]);
+
+const clearFilters = () => {
+  setKind("all");
+  setSearch("");
+};
+```
+
+Add the Kind RadioGroup into the `.filterRow` (before the search `TextField`):
+
+```tsx
+<RadioGroup
+  className={styles.kindGroup}
+  aria-label="Filter by card kind"
+  value={kind}
+  onChange={(v) => setKind(v as DeckKindFilter)}
+>
+  <Radio value="all" className={styles.chip}>All</Radio>
+  <Radio value="item" className={styles.chip}>Items</Radio>
+  <Radio value="spell" className={styles.chip}>Spells</Radio>
+</RadioGroup>
+```
+
+Add the hidden-checked line + live region into the footer (above `.footerActions`):
+
+```tsx
+{hiddenSelectedCount > 0 && (
+  <p className={styles.hiddenLine}>
+    {`${hiddenSelectedCount} selected ${cardWord(hiddenSelectedCount)} ${
+      hiddenSelectedCount === 1 ? "is" : "are"
+    } hidden by filters — still included when you Apply.`}{" "}
+    <button type="button" className={styles.clearFiltersLink} onClick={clearFilters}>
+      Clear filters
+    </button>
+  </p>
+)}
+<span className={styles.srOnly} aria-live="polite">
+  {`${total} ${cardWord(total)} selected`}
+</span>
+```
+
+Add chip + link styles to `PrintSelectionModal.module.css`:
+
+```css
+.kindGroup {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.chip {
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-pill, 999px);
+  cursor: pointer;
+  font-size: var(--fs-sm);
+}
+
+.chip[data-selected] {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-on-accent, #fff);
+}
+
+.chip[data-focus-visible] {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.clearFiltersLink {
+  border: 0;
+  background: none;
+  padding: 0;
+  font: inherit;
+  color: var(--color-accent);
+  text-decoration: underline;
+  cursor: pointer;
+}
+```
+
+If `--color-on-accent` / `--radius-pill` don't exist, substitute `#fff` and `999px` literals (component-internal geometry, allowed per the design-system note).
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm test -- src/views/PrintSelectionModal.test.tsx`
+Expected: PASS (all). The "is/are" wording test asserts "1 selected card is hidden".
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npm run build`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/views/PrintSelectionModal.tsx src/views/PrintSelectionModal.module.css src/views/PrintSelectionModal.test.tsx
+git commit -m "feat(print): kind filter, name search, hidden-checked line, live region"
+```
+
+---
+
+### Task 9: Wire the modal into PrintView + integration tests
+
+**Files:**
+- Modify: `src/views/PrintView.tsx`
+- Test: `src/views/PrintView.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `PrintView.test.tsx`. These drive the narrow/empty/select-all states end-to-end. Build named/typed cards via payload factories so the modal rows are addressable:
+
+```tsx
+import { makeSpellPayload, makeAbilityPayload } from "../test/factories";
+
+function rowWithPayload(payload: ReturnType<typeof makeItemPayload.build>) {
+  return makeCardRow.build({ payload });
+}
+
+test("narrowing via the modal updates the count and the printed set", async () => {
+  const keep = rowWithPayload(makeItemPayload.build({ name: "Keep" }));
+  const drop = rowWithPayload(makeItemPayload.build({ name: "Drop" }));
+  server.use(
+    http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json([keep, drop])),
+  );
+  render(wrap(<PrintView deckId="d1" />));
+  await waitFor(() => expect(screen.getByText("All 2 cards")).toBeInTheDocument());
+
+  await userEvent.click(screen.getByRole("button", { name: /choose cards/i }));
+  await userEvent.click(screen.getByRole("checkbox", { name: "Drop" }));
+  await userEvent.click(screen.getByRole("button", { name: /apply/i }));
+
+  expect(screen.getByText("1 of 2 cards")).toBeInTheDocument();
+  // Only the kept card is on the sheet.
+  expect(screen.getByText("Keep")).toBeInTheDocument();
+  expect(screen.queryByText("Drop")).not.toBeInTheDocument();
+});
+
+test("Cancel preserves the previous selection", async () => {
+  const cards = makeCardRow.buildList(2);
+  server.use(
+    http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+  );
+  render(wrap(<PrintView deckId="d1" />));
+  await waitFor(() => expect(screen.getByText("All 2 cards")).toBeInTheDocument());
+  await userEvent.click(screen.getByRole("button", { name: /choose cards/i }));
+  await userEvent.click(screen.getByRole("checkbox", { name: /select all shown cards/i })); // clears
+  await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+  expect(screen.getByText("All 2 cards")).toBeInTheDocument();
+});
+
+test("empty selection disables Print and shows the empty message", async () => {
+  const cards = makeCardRow.buildList(2);
+  server.use(
+    http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+  );
+  render(wrap(<PrintView deckId="d1" />));
+  await waitFor(() => expect(screen.getByText("All 2 cards")).toBeInTheDocument());
+  await userEvent.click(screen.getByRole("button", { name: /choose cards/i }));
+  await userEvent.click(screen.getByRole("checkbox", { name: /select all shown cards/i })); // clears
+  await userEvent.click(screen.getByRole("button", { name: /apply/i }));
+  expect(screen.getByText("0 of 2 cards")).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /^print$/i })).toHaveAttribute(
+    "aria-disabled",
+    "true",
+  );
+  expect(screen.getByText(/no cards selected/i)).toBeInTheDocument();
+});
+
+test("Select all link restores the full selection after narrowing", async () => {
+  const cards = makeCardRow.buildList(2);
+  server.use(
+    http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+  );
+  render(wrap(<PrintView deckId="d1" />));
+  await waitFor(() => expect(screen.getByText("All 2 cards")).toBeInTheDocument());
+  await userEvent.click(screen.getByRole("button", { name: /choose cards/i }));
+  const [first] = cards;
+  await userEvent.click(
+    screen.getByRole("checkbox", { name: first.payload.name }),
+  );
+  await userEvent.click(screen.getByRole("button", { name: /apply/i }));
+  expect(screen.getByText("1 of 2 cards")).toBeInTheDocument();
+  await userEvent.click(screen.getByRole("button", { name: /select all/i }));
+  expect(screen.getByText("All 2 cards")).toBeInTheDocument();
+});
+
+test("ability (non-renderable) cards never reach the picker", async () => {
+  const item = rowWithPayload(makeItemPayload.build({ name: "Cloak" }));
+  const ability = makeCardRow.build({ payload: makeAbilityPayload.build({ name: "Rage" }) });
+  server.use(
+    http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () =>
+      HttpResponse.json([item, ability]),
+    ),
+  );
+  render(wrap(<PrintView deckId="d1" />));
+  await waitFor(() => expect(screen.getByText("All 1 card")).toBeInTheDocument());
+  await userEvent.click(screen.getByRole("button", { name: /choose cards/i }));
+  expect(screen.getByRole("checkbox", { name: "Cloak" })).toBeInTheDocument();
+  expect(screen.queryByRole("checkbox", { name: "Rage" })).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/views/PrintView.test.tsx`
+Expected: FAIL — the placeholder modal has no checkboxes / Apply button.
+
+- [ ] **Step 3: Replace the placeholder with the real modal**
+
+In `PrintView.tsx`, add the import:
+
+```tsx
+import { PrintSelectionModal } from "./PrintSelectionModal";
+```
+
+Replace the placeholder block from Task 3 with:
+
+```tsx
+{isPickerOpen && (
+  <PrintSelectionModal
+    cards={printable}
+    initialSelection={selected}
+    onApply={(next) => {
+      setSelected(next);
+      setIsPickerOpen(false);
+    }}
+    onClose={() => setIsPickerOpen(false)}
+  />
+)}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm test -- src/views/PrintView.test.tsx`
+Expected: PASS (all PrintView tests). Note: the "ability cards never reach the picker" test relies on `printable` already filtering via `isRenderableCard` (Task 3) — the modal receives only renderable cards.
+
+- [ ] **Step 5: Full suite + build**
+
+Run: `npm test`
+Expected: PASS (entire suite).
+
+Run: `npm run build`
+Expected: no TypeScript errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/views/PrintView.tsx src/views/PrintView.test.tsx
+git commit -m "feat(print): wire PrintSelectionModal into PrintView with full subset flow"
+```
+
+---
+
+## Self-review checklist (run after implementation)
+
+- [ ] **Spec coverage:** Every spec behavior maps to a task — initial selection (Task 1), count phrasing (Task 2), sidebar/Print-disable/empty message (Task 3), relative time (Task 4), Checkbox/`mixed` (Task 5), modal list+sort+apply/cancel (Task 6), tri-state header (Task 7), kind filter + search + hidden line + live region (Task 8), narrow/empty/select-all/ability integration (Task 9).
+- [ ] **Sort default** is `updated` (recency) — verify the modal's initial `sort` state and the first row order test.
+- [ ] **Re-open resets view, keeps selection:** the modal re-mounts each open (`isPickerOpen` gates rendering), so `useState` initializers re-run — `kind`/`search`/`sort` reset to defaults and `draft` re-seeds from the current `selected`. This satisfies the spec's "filters/sort reset, selection persists" requirement for free; add a quick manual check.
+- [ ] **`aria-label` on modal** is the chosen accessibility path (DialogShell takes a string `aria-label`); `aria-labelledby` widening was deferred per spec.
+- [ ] **Manual smoke:** `npm run dev`, open a deck's print view, edit two cards, reprint just those two via the friction-case walkthrough. Confirm the sidebar count, the tri-state clear, and the printed sheet.
+
+## Deferred (documented, not in scope)
+
+- Virtualization of the picker list (spec tripwire ~150 rows).
+- Announcing the hidden-checked line on appear/disappear — the single polite live region announces the total, which carries the critical info; the line itself is plain text to honor the spec's "avoid announcement flood" priority.
+- Extracting the picker into a generic `src/lib/ui/` primitive (gated on a second consumer).

--- a/docs/superpowers/specs/2026-05-19-print-subset-design.md
+++ b/docs/superpowers/specs/2026-05-19-print-subset-design.md
@@ -20,11 +20,11 @@ printing, without complicating the default "print the whole deck" path.
   renderable card, so a user who never touches the selection UI gets
   today's behavior.
 - Choosing a subset is fast for the friction case ("I just edited two
-  cards") — those cards should be easy to find and check, without
-  scrolling through a long list.
+  cards") — those cards should be easy to find, and the picker should
+  make it cheap to reduce a full selection down to a small one.
 - The print sidebar stays compact. It tells the user how many cards are
   going to print and offers one button to change that. All filtering,
-  sorting, and checkbox work lives in a modal.
+  sorting, search, and checkbox work lives in a modal.
 
 ## Non-goals
 
@@ -51,37 +51,83 @@ selected for printing, as a set of card IDs. The set defaults to "every
 renderable card in the deck" once the deck loads, and is plain component
 state — ephemeral, lost on refresh.
 
-The sidebar grows one block above its existing controls:
+The sidebar grows one new block, sitting **above** the existing controls
+(what gets printed comes before how it's printed):
 
-- A live count: **"Printing 7 of 15 cards"** (or "Printing all 15 cards"
-  when the selection is the full deck).
-- A button: **"Customize selection…"** that opens a modal.
-- When the selection is narrowed, a small "Reset" affordance that returns
-  to all-cards.
+- A live count line: **"All 15 cards"**, **"7 of 15 cards"**, or
+  **"0 of 15 cards"** depending on selection state.
+- A button: **"Customize selection…"** that opens the picker modal.
+- A **"Select all"** link, shown only when the selection is narrowed
+  (`0 < selection.size < renderable.length`). Hidden at all-selected and
+  at zero-selected, since neither case has a useful target for the link.
+
+The full new sidebar order: count → Customize button → Select all link →
+divider → Cards per page → Print backs (with sub-option) → Print button →
+margins tip.
 
 The Print button is disabled when the selection is empty (in addition to
 its existing disabled state when the deck has no renderable cards).
 
 The modal — `PrintSelectionModal` — is where the work happens:
 
-- A filter row at the top: **kind** (All / Items / Spells) and
-  **updated-since** (Any time / Last 24h / Last 7 days / Last 30 days).
-- A card list, sorted by `updatedAt` descending by default. Each row shows
-  a checkbox, the card name, a small kind indicator, and a relative
-  "updated" timestamp ("2 hours ago", "3 days ago").
-- Bulk actions on the currently filtered view: **Select all visible** and
-  **Clear visible**.
-- A footer with the running count ("X cards selected"), **Cancel**, and
-  **Apply**.
+- A **filter row** at the top:
+  - **Kind**: chip group (All / Items / Spells), default All.
+  - **Updated since**: dropdown (Any time / Last 24 hours / Last 7 days /
+    Last 30 days), default Any time. Filters by `updatedAt` against the
+    time the modal opened.
+  - **Name search**: small text input matching by substring against card
+    name. Empty by default.
+- A **header bulk-select**: a tri-state checkbox immediately above the
+  list (the standard Gmail/GitHub pattern). Its state reflects only the
+  *currently visible* (post-filter) cards:
+  - All visible checked → checkbox is checked. Click clears all visible.
+  - None visible checked → unchecked. Click selects all visible.
+  - Some visible checked → indeterminate. Click selects all visible.
+  - Label next to it: **"X of Y shown selected"** (live).
+- A **card list**, sorted by `updatedAt` descending by default. Each row:
+  - Checkbox
+  - Card name
+  - Small kind indicator
+  - Relative "updated" timestamp ("2 hours ago", "3 days ago")
+  - A small **"new"** badge if `createdAt === updatedAt` and the card was
+    created within the last 7 days — disambiguates recent creations from
+    recent edits, since both sort to the top.
+- A small **sort selector** (defaults to "Recently edited"; alternative
+  "Name A→Z").
+- A **footer** with:
+  - Running total: **"X cards selected"** — counts the full draft, not
+    the visible subset.
+  - When filters are active and at least one *hidden* card is selected,
+    a second line: **"N selected card(s) hidden by filters."** with a
+    "Clear filters" link. This is the central mitigation for the
+    filter↔selection coupling risk: it makes invisible state visible.
+  - **Cancel** and **Apply** buttons. Apply is labelled
+    **"Apply (X cards)"** so the committed total is visible at the click
+    moment.
 
-Filters apply only to what's *shown* in the modal — they're a way to find
-cards faster, not a saved query. Checkbox state survives filter changes:
-checking a card under "Items only", then switching to "All", keeps it
-checked.
+Filters apply only to what's *shown* in the modal — they're a way to
+find cards faster, not a saved query. Checkbox state survives filter
+changes: checking a card under "Items only", then switching to "All",
+keeps it checked. The hidden-checked footer line is the safety net for
+users who expect filters to be scoping.
 
-The friction case is now: open print view → click "Customize selection…"
-→ the two recently-edited cards are at the top of the list → check them
-→ Apply → Print. Three to four clicks beyond today's default.
+### The friction-case walkthrough
+
+The friction case is: "I just edited two cards in a 15-card deck, I want
+to reprint just those two." Realistic flow:
+
+1. Open print view → modal opens with **all 15 cards checked**.
+2. Click "Customize selection…".
+3. Click the **header tri-state checkbox** once → clears all 15.
+   (Equivalent to "Clear" — a single click, not 15 unchecks.)
+4. The two recently-edited cards are at the top of the list (default
+   sort). Check them.
+5. Footer reads **"Apply (2 cards)"**. Click it.
+6. Sidebar reads **"2 of 15 cards"**. Click Print.
+
+Five clicks beyond today's default, with no hunting and no ambiguity
+about what's selected. The header tri-state is the linchpin: it
+collapses "uncheck 13 cards" into one click.
 
 ## Behavior details
 
@@ -101,23 +147,27 @@ so missing cards simply aren't there.
 
 If a card is added to the deck while the print view is open, the new
 card is **not** auto-added to the selection. The user opens the modal to
-include it. This is the predictable behavior: a narrowed selection stays
-narrowed until the user changes it.
+include it. The only signal is the sidebar's denominator changing
+(`7 of 15` → `7 of 16`). This is accepted as low-frequency and not
+worth a dedicated UI hint.
 
 ### Empty selection
 
 If the user clears every card and clicks Apply, the sidebar shows
-"Printing 0 of 15 cards" and the Print button is disabled with a small
-hint ("Select at least 1 card to print"). The sheet preview area shows
-a new empty-selection message ("No cards selected — click Customize
-selection to choose what to print"), distinct from today's "No
-printable cards in this deck yet" message (which still fires only when
-the deck itself is empty of renderable cards).
+"0 of 15 cards" in a warning treatment and the Print button is disabled
+with a small hint ("Select at least 1 card to print"). The sheet preview
+area shows a new empty-selection message ("No cards selected — click
+Customize selection to choose what to print"), distinct from today's
+"No printable cards in this deck yet" message (which still fires only
+when the deck itself is empty of renderable cards).
 
-### Reset to all
+### Select all (from the sidebar)
 
-A "Reset" link next to the count returns the selection to the full
-renderable set. The modal is closed; no dialog needed.
+The "Select all" link returns the selection to the full renderable set
+without opening the modal. It's hidden when the selection is already
+the full set or empty. Naming choice: "Select all" rather than "Reset",
+because "Reset" implies clearing all print settings (per-page, backs,
+etc.) — which is misleading.
 
 ### Modal close behavior
 
@@ -127,104 +177,150 @@ renderable set. The modal is closed; no dialog needed.
   selection is preserved.
 - **Escape / overlay click**: same as Cancel.
 
-The modal owns its own draft state (filter chips, sort, draft checkbox
-set). It receives the current selection as a prop and only commits via an
-`onApply` callback.
+The modal owns its own draft state (filter chips, sort, search input,
+draft checkbox set). It receives the current selection as a prop on open
+and only commits via an `onApply` callback.
+
+### Re-opening the modal
+
+When the modal opens a second time on a narrowed selection, the draft
+starts from the current narrowed checkbox state. Filters reset to
+defaults (All / Any time / empty search) and sort resets to "Recently
+edited". This gives the user a predictable starting position each open
+without losing their committed selection.
 
 ### Filters
 
-- **Kind**: a single-select chip group. Default "All". "Items only" hides
-  spell cards from the list; "Spells only" hides item cards. Hidden cards
-  retain their checkbox state.
-- **Updated since**: a single-select dropdown. Default "Any time". Other
-  options: "Last 24 hours", "Last 7 days", "Last 30 days". Filters by
-  `updatedAt` against the current time at modal open.
+- **Kind**: single-select chip group, default "All". "Items only" hides
+  spell cards from the list; "Spells only" hides item cards. Hidden
+  cards retain their checkbox state.
+- **Updated since**: single-select dropdown, default "Any time". Filters
+  by `updatedAt` against the time the modal opened (not "now" on every
+  render — that would shift the cutoff while the user works).
+- **Name search**: substring match against card name, case-insensitive.
+  Empty matches everything.
+
+All three filters compose with `AND`.
 
 ### Sort
 
-Default sort is `updatedAt` descending — most-recently-edited cards at
-the top. This is the central UX choice that makes the friction case
-trivial. A small sort selector lets the user switch to name-ascending if
-they prefer alphabetical.
-
-### Bulk actions
-
-- **Select all visible**: checks every card currently visible under the
-  active filters.
-- **Clear visible**: unchecks every card currently visible under the
-  active filters.
-
-Both operate on the *visible* subset, not the full deck, so the user can
-say "all items, plus those two specific spells" by combining filter +
-bulk action + individual checks.
+Default sort is **`updatedAt` descending** ("Recently edited") — this is
+the central UX choice that makes the friction case trivial. The
+alternative offered is **name A→Z**. Two options keep the selector
+small.
 
 ### Sidebar count phrasing
 
-- 0 selected: "Printing 0 of 15 cards" (red/warning treatment)
-- All selected: "Printing all 15 cards"
-- Narrowed: "Printing 7 of 15 cards"
+- 0 selected: **"0 of 15 cards"** (warning treatment — uses
+  `--color-warning-fg` or equivalent semantic token)
+- All selected: **"All 15 cards"**
+- Narrowed: **"7 of 15 cards"**
 
-The phrasing emphasizes the *narrowed* state — when the user has changed
-something from the default, the count reads differently enough that they
-notice.
+The phrasing drops the redundant "Printing" prefix (the surrounding
+Print button context carries that). When the user has changed something
+from the default, the count reads differently enough — the word "All"
+disappears, a "of" appears — that they notice without needing color
+alone.
+
+## Accessibility
+
+- The modal is labelled by its visible heading ("Customize print
+  selection" or equivalent), using `aria-labelledby`.
+- Focus moves to the **name search input** when the modal opens. On
+  close, focus returns to the **"Customize selection…"** button.
+- The footer running total (`"X cards selected"`) and the hidden-checked
+  line both live inside an `aria-live="polite"` region so screen-reader
+  users hear the counts update as they check/uncheck.
+- Kind chips are implemented as a `radiogroup` (one checked at a time)
+  with proper `aria-label` (e.g., "Filter by card kind").
+- The header tri-state checkbox uses the standard `aria-checked="mixed"`
+  state when indeterminate.
+- The card list is keyboard-navigable: Tab into the list, arrow keys
+  move between rows, Space toggles the focused checkbox.
+- All filter inputs have visible labels (not placeholder-only).
+
+## Responsive behavior
+
+PrintView's existing 16rem sticky sidebar collapses to a full-width strip
+above the sheet at the existing `max-width: 1399px` breakpoint. With the
+new count + Customize button + Select all link sitting above the
+existing controls, the collapsed layout should still read top-to-bottom
+in the same order. No new breakpoint is introduced.
+
+The modal is mobile-tolerant by virtue of using the same
+react-aria-components Modal/Dialog primitives as `BrowseApiModal`, which
+already handles narrow viewports. The filter row may wrap at very narrow
+widths; that's acceptable.
 
 ## Components
 
-- **`PrintView.tsx`** — gains selection state, the sidebar count + button
-  + reset, and a feed of the filtered cards into the existing pipeline.
+- **`PrintView.tsx`** — gains selection state, the sidebar count +
+  button + select-all link, and a feed of the filtered cards into the
+  existing pipeline.
 - **`PrintSelectionModal.tsx`** (new, sibling to `BrowseApiModal`) —
   owns the picker UI. Uses the same `react-aria-components` Modal /
   Dialog primitives as `BrowseApiModal`.
 - **`PrintSelectionModal.module.css`** (new) — picker layout.
 
-The selection state could live inline in `PrintView` or be extracted to a
-`usePrintSelection(deckId)` hook. The implementation plan can decide; the
-behavior is the same either way.
+The selection state could live inline in `PrintView` or be extracted to
+a `usePrintSelection(deckId)` hook. The implementation plan can decide;
+the behavior is the same either way.
 
 ## Tests
 
 Behavior tests, written against accessible roles per project convention:
 
 - Print view opens with all renderable cards selected and shows
-  "Printing all N cards".
-- Clicking "Customize selection…" opens a modal listing all renderable
-  cards.
+  "All N cards".
+- Clicking "Customize selection…" opens the modal listing all
+  renderable cards.
+- Focus lands on the name search input on open.
 - The card list defaults to `updatedAt` descending — recently-updated
   cards appear first.
 - Unchecking one card, clicking Apply, narrows the print to the
-  remaining cards. The sidebar count updates. The sheet preview shows
-  only the remaining cards.
+  remaining cards. The sidebar count updates to "N-1 of N cards". The
+  sheet preview shows only the remaining cards.
 - Cancel discards changes; the previous selection is preserved.
+- The header tri-state checkbox: clears all when fully selected;
+  selects all visible when partially or none selected; reflects
+  `aria-checked="mixed"` in the indeterminate case.
 - Filtering by kind hides the other kind from the list but does not
   uncheck them. Switching back to "All" shows them re-checked.
 - "Updated in last 7 days" hides older cards.
-- "Select all visible" + "Clear visible" operate on the filtered subset.
+- Name search narrows the list by substring on card name,
+  case-insensitive.
+- When filters are active and a selected card is hidden, the
+  "N selected card(s) hidden by filters" line appears with a working
+  "Clear filters" link.
+- Apply button text reflects the running total: "Apply (3 cards)".
 - Empty selection disables the Print button.
-- Reset link returns the selection to all cards.
+- The sidebar "Select all" link is hidden at all-selected and at zero;
+  visible only when narrowed; clicking it restores the full selection.
 - An ability card (non-renderable kind) does not appear in the picker.
+- The count line in the sidebar updates without losing screen-reader
+  focus (sanity check on `aria-live`).
 
 ## Risks
 
-- **Selection vs. deck mutation.** The "new cards aren't auto-added"
-  rule is the predictable behavior, but a user who edits in another tab
-  could be confused. The sidebar count showing "Printing 7 of 16 cards"
-  (note 16, not 15) is the only signal. Acceptable: most users won't
-  edit while the print view is open, and the count change is visible.
 - **Long decks in the picker.** A deck with 100+ cards is rare today
   but possible. The picker is a flat scrollable list, not virtualized.
-  If decks grow much larger, this becomes a performance concern.
-  Punt; revisit when actual deck sizes warrant it.
-- **Filter state confusion.** The filter row helps find cards but
-  doesn't *commit* anything. A user could plausibly check a few cards
-  under "Items only", then hit Apply without realizing all the
-  invisible cards are still selected. The footer count ("X cards
-  selected" — counts the full draft, not the visible subset) is the
-  mitigation, but worth watching in UX review.
+  Around ~150 rows, scroll performance and DOM size start to bite —
+  that's the tripwire for adding virtualization. Acceptable for now;
+  revisit when actual deck sizes warrant it.
+- **Filter↔selection coupling.** Even with the hidden-checked footer
+  hint and the Apply-button count, the conceptual model "filters
+  narrow the *list*, not the *selection*" requires one moment of
+  learning. The hint catches the failure case, but users may still be
+  briefly surprised on first encounter. Worth watching in real use.
+- **The tri-state header checkbox is the most novel control.** This
+  codebase doesn't currently use one. The behavior is the standard
+  Gmail/GitHub one, but it deserves a careful implementation and a
+  test confirming the `mixed` state.
 
 ## Forward compatibility
 
 If a "print a subset" pattern shows up elsewhere — e.g., picking which
 decks to export to PDF in bulk — the picker's filter + sortable list +
-bulk action pattern could extract into a generic primitive in
+tri-state-header pattern could extract into a generic primitive in
 `src/lib/ui/`. One consumer is not a pattern; revisit when there's a
 second.

--- a/docs/superpowers/specs/2026-05-19-print-subset-design.md
+++ b/docs/superpowers/specs/2026-05-19-print-subset-design.md
@@ -71,39 +71,39 @@ its existing disabled state when the deck has no renderable cards).
 The modal — `PrintSelectionModal` — is where the work happens:
 
 - A **filter row** at the top:
-  - **Kind**: chip group (All / Items / Spells), default All.
-  - **Updated since**: dropdown (Any time / Last 24 hours / Last 7 days /
-    Last 30 days), default Any time. Filters by `updatedAt` against the
-    time the modal opened.
+  - **Kind**: single-select chip group (All / Items / Spells), default
+    All.
   - **Name search**: small text input matching by substring against card
-    name. Empty by default.
+    name, case-insensitive. Empty by default.
 - A **header bulk-select**: a tri-state checkbox immediately above the
-  list (the standard Gmail/GitHub pattern). Its state reflects only the
-  *currently visible* (post-filter) cards:
-  - All visible checked → checkbox is checked. Click clears all visible.
-  - None visible checked → unchecked. Click selects all visible.
-  - Some visible checked → indeterminate. Click selects all visible.
-  - Label next to it: **"X of Y shown selected"** (live).
+  list (the standard Gmail/GitHub pattern), acting only on the
+  *currently visible* (post-filter) cards. It follows the conventional
+  two-outcome rule:
+  - If any visible card is checked (checkbox shows checked or
+    indeterminate) → clicking it clears all visible cards.
+  - If no visible card is checked (unchecked) → clicking it selects all
+    visible cards.
+  - Adjacent live text reads **"X of Y shown"** — a status label, not the
+    checkbox's accessible name (see Accessibility).
 - A **card list**, sorted by `updatedAt` descending by default. Each row:
   - Checkbox
   - Card name
   - Small kind indicator
-  - Relative "updated" timestamp ("2 hours ago", "3 days ago")
-  - A small **"new"** badge if `createdAt === updatedAt` and the card was
-    created within the last 7 days — disambiguates recent creations from
-    recent edits, since both sort to the top.
+  - Relative "updated" timestamp ("2 hours ago", "3 days ago"), rendered
+    in a `<time datetime>` element so the absolute value is available.
 - A small **sort selector** (defaults to "Recently edited"; alternative
   "Name A→Z").
 - A **footer** with:
-  - Running total: **"X cards selected"** — counts the full draft, not
-    the visible subset.
-  - When filters are active and at least one *hidden* card is selected,
-    a second line: **"N selected card(s) hidden by filters."** with a
-    "Clear filters" link. This is the central mitigation for the
-    filter↔selection coupling risk: it makes invisible state visible.
-  - **Cancel** and **Apply** buttons. Apply is labelled
-    **"Apply (X cards)"** so the committed total is visible at the click
-    moment.
+  - When filters or search hide at least one *selected* card, a line:
+    **"N selected card(s) hidden by filters — Apply prints all N."** with
+    a "Clear filters" link. This is the central mitigation for the
+    filter↔selection coupling risk: it names the invisible state and says
+    what Apply will do with it.
+  - **Cancel** and **Apply** buttons. Apply is labelled **"Apply (X
+    cards)"** — the single source of the full-draft total at the commit
+    moment. (The header's "X of Y shown" is a visible-subset status; Apply
+    is the full total. They differ by design and sit in clearly different
+    contexts.)
 
 Filters apply only to what's *shown* in the modal — they're a way to
 find cards faster, not a saved query. Checkbox state survives filter
@@ -116,18 +116,21 @@ users who expect filters to be scoping.
 The friction case is: "I just edited two cards in a 15-card deck, I want
 to reprint just those two." Realistic flow:
 
-1. Open print view → modal opens with **all 15 cards checked**.
-2. Click "Customize selection…".
-3. Click the **header tri-state checkbox** once → clears all 15.
-   (Equivalent to "Clear" — a single click, not 15 unchecks.)
+1. Open print view → sidebar reads **"All 15 cards"**.
+2. Click "Customize selection…" → modal opens with all 15 checked and no
+   filter active, so all 15 are "shown".
+3. Click the **header checkbox** once → since all visible are checked, it
+   clears all 15. (One click, not 15 unchecks — this is what the header
+   buys.)
 4. The two recently-edited cards are at the top of the list (default
-   sort). Check them.
-5. Footer reads **"Apply (2 cards)"**. Click it.
+   recency sort). Check them — two clicks.
+5. Apply reads **"Apply (2 cards)"**. Click it.
 6. Sidebar reads **"2 of 15 cards"**. Click Print.
 
-Five clicks beyond today's default, with no hunting and no ambiguity
-about what's selected. The header tri-state is the linchpin: it
-collapses "uncheck 13 cards" into one click.
+Six interactions beyond today's default — two of them the actual card
+checks — with no hunting and no ambiguity. The header checkbox is the
+linchpin: it collapses "uncheck 13 cards" into one click. Note the path
+never engages a filter — recency sort alone surfaces the edited cards.
 
 ## Behavior details
 
@@ -185,22 +188,23 @@ and only commits via an `onApply` callback.
 
 When the modal opens a second time on a narrowed selection, the draft
 starts from the current narrowed checkbox state. Filters reset to
-defaults (All / Any time / empty search) and sort resets to "Recently
-edited". This gives the user a predictable starting position each open
-without losing their committed selection.
+defaults (All kind / empty search) and sort resets to "Recently edited".
+This gives the user a predictable starting position each open without
+losing their committed selection.
 
 ### Filters
 
 - **Kind**: single-select chip group, default "All". "Items only" hides
   spell cards from the list; "Spells only" hides item cards. Hidden
   cards retain their checkbox state.
-- **Updated since**: single-select dropdown, default "Any time". Filters
-  by `updatedAt` against the time the modal opened (not "now" on every
-  render — that would shift the cutoff while the user works).
 - **Name search**: substring match against card name, case-insensitive.
   Empty matches everything.
 
-All three filters compose with `AND`.
+The two filters compose with `AND`. Neither alters checkbox state — they
+only change which rows are shown. (The "Updated since" date filter from
+an earlier draft was cut: the default recency sort already floats edited
+cards to the top, making a date filter redundant and adding coupling
+surface for no gain.)
 
 ### Sort
 
@@ -224,19 +228,33 @@ alone.
 
 ## Accessibility
 
-- The modal is labelled by its visible heading ("Customize print
-  selection" or equivalent), using `aria-labelledby`.
-- Focus moves to the **name search input** when the modal opens. On
-  close, focus returns to the **"Customize selection…"** button.
-- The footer running total (`"X cards selected"`) and the hidden-checked
-  line both live inside an `aria-live="polite"` region so screen-reader
-  users hear the counts update as they check/uncheck.
-- Kind chips are implemented as a `radiogroup` (one checked at a time)
-  with proper `aria-label` (e.g., "Filter by card kind").
-- The header tri-state checkbox uses the standard `aria-checked="mixed"`
-  state when indeterminate.
-- The card list is keyboard-navigable: Tab into the list, arrow keys
-  move between rows, Space toggles the focused checkbox.
+- The modal is labelled by its visible heading, using `aria-labelledby`.
+- Focus moves to the **name search input** when the modal opens (matching
+  the existing `BrowseApiModal` search idiom). On close, focus returns to
+  the **"Customize selection…"** button.
+- **One** polite live region announces the full-draft total as it
+  changes. The Apply button label carries the same number but is *not* a
+  live region — buttons announce their label on focus, so a live region
+  would only duplicate. The hidden-checked line announces when it appears
+  or disappears, not on every toggle, to avoid an announcement flood.
+- The **Kind filter is single-select**, implemented with a RAC
+  `RadioGroup` styled as chips (`aria-label` "Filter by card kind").
+  Note: the repo's existing `ToggleButtonGroup` renders toolbar/group
+  semantics, not `radiogroup`, so it is **not** reused here. The plan
+  should confirm this choice.
+- The **header checkbox** uses `aria-checked="mixed"` when indeterminate.
+  Its accessible name is a stable action verb ("Select all shown cards");
+  the "X of Y shown" count is adjacent status text (associated via
+  `aria-describedby` if needed), never folded into the checkbox's name.
+- The card list uses **plain checkboxes**: Tab moves between them, Space
+  toggles the focused one. No custom arrow-key roving model — a flat
+  checkbox list doesn't expect one, and hand-rolling it fights the
+  primitive.
+- The disabled-state Print button uses `aria-disabled` (so it stays
+  focusable) with `aria-describedby` pointing at the "Select at least 1
+  card to print" hint, so screen-reader users hear *why* it's disabled.
+- The warning treatment on "0 of 15 cards" is not color-only — the
+  wording ("0 of") plus the Print hint carry the meaning.
 - All filter inputs have visible labels (not placeholder-only).
 
 ## Responsive behavior
@@ -281,18 +299,17 @@ Behavior tests, written against accessible roles per project convention:
   remaining cards. The sidebar count updates to "N-1 of N cards". The
   sheet preview shows only the remaining cards.
 - Cancel discards changes; the previous selection is preserved.
-- The header tri-state checkbox: clears all when fully selected;
-  selects all visible when partially or none selected; reflects
-  `aria-checked="mixed"` in the indeterminate case.
+- The header checkbox: when any visible card is checked, clicking it
+  clears all visible; when none are checked, clicking it selects all
+  visible; reflects `aria-checked="mixed"` in the indeterminate case.
 - Filtering by kind hides the other kind from the list but does not
   uncheck them. Switching back to "All" shows them re-checked.
-- "Updated in last 7 days" hides older cards.
 - Name search narrows the list by substring on card name,
   case-insensitive.
-- When filters are active and a selected card is hidden, the
-  "N selected card(s) hidden by filters" line appears with a working
-  "Clear filters" link.
-- Apply button text reflects the running total: "Apply (3 cards)".
+- When a filter or search hides a selected card, the "N selected
+  card(s) hidden by filters — Apply prints all N" line appears with a
+  working "Clear filters" link.
+- Apply button text reflects the full-draft total: "Apply (3 cards)".
 - Empty selection disables the Print button.
 - The sidebar "Select all" link is hidden at all-selected and at zero;
   visible only when narrowed; clicking it restores the full selection.

--- a/docs/superpowers/specs/2026-05-19-print-subset-design.md
+++ b/docs/superpowers/specs/2026-05-19-print-subset-design.md
@@ -56,12 +56,12 @@ The sidebar grows one new block, sitting **above** the existing controls
 
 - A live count line: **"All 15 cards"**, **"7 of 15 cards"**, or
   **"0 of 15 cards"** depending on selection state.
-- A button: **"Customize selection…"** that opens the picker modal.
+- A button: **"Choose cards…"** that opens the picker modal.
 - A **"Select all"** link, shown only when the selection is narrowed
   (`0 < selection.size < renderable.length`). Hidden at all-selected and
   at zero-selected, since neither case has a useful target for the link.
 
-The full new sidebar order: count → Customize button → Select all link →
+The full new sidebar order: count → Choose cards button → Select all link →
 divider → Cards per page → Print backs (with sub-option) → Print button →
 margins tip.
 
@@ -95,10 +95,12 @@ The modal — `PrintSelectionModal` — is where the work happens:
   "Name A→Z").
 - A **footer** with:
   - When filters or search hide at least one *selected* card, a line:
-    **"N selected card(s) hidden by filters — Apply prints all N."** with
-    a "Clear filters" link. This is the central mitigation for the
-    filter↔selection coupling risk: it names the invisible state and says
-    what Apply will do with it.
+    **"N selected card(s) are hidden by filters — still included when you
+    Apply."** with a "Clear filters" link. This is the central mitigation
+    for the filter↔selection coupling risk: it names the invisible state
+    and confirms those cards still print. (The line counts the *hidden
+    selected* cards; the Apply button always shows the full total, which
+    may be larger when visible cards are also checked.)
   - **Cancel** and **Apply** buttons. Apply is labelled **"Apply (X
     cards)"** — the single source of the full-draft total at the commit
     moment. (The header's "X of Y shown" is a visible-subset status; Apply
@@ -117,7 +119,7 @@ The friction case is: "I just edited two cards in a 15-card deck, I want
 to reprint just those two." Realistic flow:
 
 1. Open print view → sidebar reads **"All 15 cards"**.
-2. Click "Customize selection…" → modal opens with all 15 checked and no
+2. Click "Choose cards…" → modal opens with all 15 checked and no
    filter active, so all 15 are "shown".
 3. Click the **header checkbox** once → since all visible are checked, it
    clears all 15. (One click, not 15 unchecks — this is what the header
@@ -137,8 +139,13 @@ never engages a filter — recency sort alone surfaces the edited cards.
 ### Initial selection
 
 When `useDeckCards` resolves, the selection is initialized to
-`new Set(renderable.map(c => c.id))`. This happens once per deck load.
-Subsequent re-renders don't reset the selection.
+`new Set(renderable.map(c => c.id))`. The trigger must be pinned so a
+background refetch (which changes the query data's identity) doesn't
+silently reset a narrowed selection: initialize keyed on `deckId` (e.g.
+re-run only when `deckId` changes, not when `cardsQuery.data` changes
+identity). Switching decks re-initializes to all; a refetch of the same
+deck does not. This is what makes the added/removed-card behavior below
+hold.
 
 ### Selection state through deck mutations
 
@@ -159,8 +166,8 @@ worth a dedicated UI hint.
 If the user clears every card and clicks Apply, the sidebar shows
 "0 of 15 cards" in a warning treatment and the Print button is disabled
 with a small hint ("Select at least 1 card to print"). The sheet preview
-area shows a new empty-selection message ("No cards selected — click
-Customize selection to choose what to print"), distinct from today's
+area shows a new empty-selection message ("No cards selected — use
+Choose cards to pick what to print"), distinct from today's
 "No printable cards in this deck yet" message (which still fires only
 when the deck itself is empty of renderable cards).
 
@@ -190,7 +197,9 @@ When the modal opens a second time on a narrowed selection, the draft
 starts from the current narrowed checkbox state. Filters reset to
 defaults (All kind / empty search) and sort resets to "Recently edited".
 This gives the user a predictable starting position each open without
-losing their committed selection.
+losing their committed selection. The trade-off is deliberate: a user
+who sorted by name last time gets recency sort again on re-open. The
+committed *selection* persists; the *view* (filters, sort) does not.
 
 ### Filters
 
@@ -228,10 +237,15 @@ alone.
 
 ## Accessibility
 
-- The modal is labelled by its visible heading, using `aria-labelledby`.
+- The modal has an accessible name via `aria-label` (e.g. "Choose cards
+  to print"), matching the existing `BrowseApiModal` idiom. Note: the
+  repo's `DialogShell` only accepts a string `aria-label`, not
+  `aria-labelledby` pointing at the visible heading — the plan can either
+  use `aria-label` as-is or widen `DialogShell` to support
+  `aria-labelledby`.
 - Focus moves to the **name search input** when the modal opens (matching
   the existing `BrowseApiModal` search idiom). On close, focus returns to
-  the **"Customize selection…"** button.
+  the **"Choose cards…"** button.
 - **One** polite live region announces the full-draft total as it
   changes. The Apply button label carries the same number but is *not* a
   live region — buttons announce their label on focus, so a live region
@@ -261,7 +275,7 @@ alone.
 
 PrintView's existing 16rem sticky sidebar collapses to a full-width strip
 above the sheet at the existing `max-width: 1399px` breakpoint. With the
-new count + Customize button + Select all link sitting above the
+new count + Choose cards button + Select all link sitting above the
 existing controls, the collapsed layout should still read top-to-bottom
 in the same order. No new breakpoint is introduced.
 
@@ -282,7 +296,47 @@ widths; that's acceptable.
 
 The selection state could live inline in `PrintView` or be extracted to
 a `usePrintSelection(deckId)` hook. The implementation plan can decide;
-the behavior is the same either way.
+the behavior is the same either way (but the init trigger above must be
+honored regardless).
+
+### Reuse and net-new pieces
+
+- **Filter + sort logic already exists.** `src/decks/deckListing.ts`
+  implements kind filtering ("all" / "item" / "spell") and "updated" /
+  "name" sorting with stable tie-breakers — directly reusable for the
+  modal list. Substring name search is a small addition on top. Don't
+  re-derive this.
+- **Three primitives are net-new, not reuse.** `src/lib/ui/` has no
+  `Checkbox` and no `RadioGroup` today. The tri-state header checkbox
+  (with `mixed` state), the per-row checkboxes, and the single-select
+  Kind chip group all have to be built from raw `react-aria-components`.
+  This is the bulk of the work and the riskiest part — treat it as such
+  in the plan. The earlier note about `ToggleButtonGroup` not fitting
+  stands: it's a toolbar/group role, not a `radiogroup`.
+- **A relative-time helper is net-new.** "2 hours ago" needs a small
+  `Intl.RelativeTimeFormat`-based helper (no new dependency) with its own
+  unit test and defined bucketing thresholds (e.g. seconds → minutes →
+  hours → days). The repo has no date library and no existing formatter.
+- **Live region.** The repo has a global `Announcement` singleton
+  (`useSetNextAnnouncement`). The plan should decide between reusing it
+  and adding a local `aria-live="polite"` node inside the modal; a local
+  node is likely cleaner for a count that updates frequently.
+
+### Implementation sequencing
+
+Stage the work so the feature isn't blocked on the novel primitives:
+
+1. **Selection plumbing + sidebar.** Selection state + init trigger, the
+   sidebar count / Choose-cards button / Select-all link, Print-button
+   disable, and the empty-selection message — plus their tests. Shippable
+   on its own with no new primitives (the modal can be stubbed).
+2. **Net-new primitives.** Build the `Checkbox` (incl. indeterminate /
+   `mixed`), the Kind chip `RadioGroup`, and the relative-time helper,
+   each with focused tests. This is the riskiest stage; isolating it
+   keeps risk off the critical path.
+3. **Assemble `PrintSelectionModal`.** Wire the filter row, list (reusing
+   `deckListing.ts`), header checkbox, footer, and `onApply`; add the
+   modal behavior tests.
 
 ## Tests
 
@@ -290,7 +344,7 @@ Behavior tests, written against accessible roles per project convention:
 
 - Print view opens with all renderable cards selected and shows
   "All N cards".
-- Clicking "Customize selection…" opens the modal listing all
+- Clicking "Choose cards…" opens the modal listing all
   renderable cards.
 - Focus lands on the name search input on open.
 - The card list defaults to `updatedAt` descending — recently-updated
@@ -307,8 +361,8 @@ Behavior tests, written against accessible roles per project convention:
 - Name search narrows the list by substring on card name,
   case-insensitive.
 - When a filter or search hides a selected card, the "N selected
-  card(s) hidden by filters — Apply prints all N" line appears with a
-  working "Clear filters" link.
+  card(s) are hidden by filters — still included when you Apply" line
+  appears with a working "Clear filters" link.
 - Apply button text reflects the full-draft total: "Apply (3 cards)".
 - Empty selection disables the Print button.
 - The sidebar "Select all" link is hidden at all-selected and at zero;

--- a/docs/superpowers/specs/2026-05-19-print-subset-design.md
+++ b/docs/superpowers/specs/2026-05-19-print-subset-design.md
@@ -1,0 +1,230 @@
+# Print a subset of a deck
+
+## Problem
+
+When a deck has been printed once and the user edits one or two cards, the
+print view forces them to reprint the entire deck. The current `PrintView`
+renders every renderable card in the deck — there's no way to narrow which
+cards make it onto the sheet. Users either reprint a full deck to refresh
+two cards or skip reprinting and live with an out-of-date physical deck.
+
+The friction is real for the common case: small edits to a deck someone has
+already printed. The fix is to let the user choose a subset before
+printing, without complicating the default "print the whole deck" path.
+
+## Goals
+
+- The user can narrow what gets printed to an arbitrary subset of the
+  deck's renderable cards.
+- The default is unchanged: opening the print view selects every
+  renderable card, so a user who never touches the selection UI gets
+  today's behavior.
+- Choosing a subset is fast for the friction case ("I just edited two
+  cards") — those cards should be easy to find and check, without
+  scrolling through a long list.
+- The print sidebar stays compact. It tells the user how many cards are
+  going to print and offers one button to change that. All filtering,
+  sorting, and checkbox work lives in a modal.
+
+## Non-goals
+
+- **No tracking of "last printed at" per card.** Considered and rejected:
+  there's no reliable browser signal that distinguishes a real print from a
+  cancelled print dialog, and an explicit "Mark as printed" button adds a
+  step users will forget. The reliable substitute — sorting by `updatedAt`
+  in the picker — gives the same workflow without a second source of
+  truth.
+- **No URL persistence of the selection.** Sharing a print is done by PDF,
+  not by URL. Selection lives in component state for the duration of the
+  print view; refreshing resets to "all cards".
+- **No cross-device persistence.** Selection is per-tab, per-visit.
+- **No new card-listing primitive.** The picker reuses existing list/row
+  patterns; it doesn't introduce a virtualized table or new sort framework.
+- **No changes to print output, page layout, back imposition, or the
+  `Card` component.** The pipeline downstream of card filtering is
+  untouched — it just receives a shorter array.
+
+## Approach
+
+`PrintView` gains a single new piece of state: which renderable cards are
+selected for printing, as a set of card IDs. The set defaults to "every
+renderable card in the deck" once the deck loads, and is plain component
+state — ephemeral, lost on refresh.
+
+The sidebar grows one block above its existing controls:
+
+- A live count: **"Printing 7 of 15 cards"** (or "Printing all 15 cards"
+  when the selection is the full deck).
+- A button: **"Customize selection…"** that opens a modal.
+- When the selection is narrowed, a small "Reset" affordance that returns
+  to all-cards.
+
+The Print button is disabled when the selection is empty (in addition to
+its existing disabled state when the deck has no renderable cards).
+
+The modal — `PrintSelectionModal` — is where the work happens:
+
+- A filter row at the top: **kind** (All / Items / Spells) and
+  **updated-since** (Any time / Last 24h / Last 7 days / Last 30 days).
+- A card list, sorted by `updatedAt` descending by default. Each row shows
+  a checkbox, the card name, a small kind indicator, and a relative
+  "updated" timestamp ("2 hours ago", "3 days ago").
+- Bulk actions on the currently filtered view: **Select all visible** and
+  **Clear visible**.
+- A footer with the running count ("X cards selected"), **Cancel**, and
+  **Apply**.
+
+Filters apply only to what's *shown* in the modal — they're a way to find
+cards faster, not a saved query. Checkbox state survives filter changes:
+checking a card under "Items only", then switching to "All", keeps it
+checked.
+
+The friction case is now: open print view → click "Customize selection…"
+→ the two recently-edited cards are at the top of the list → check them
+→ Apply → Print. Three to four clicks beyond today's default.
+
+## Behavior details
+
+### Initial selection
+
+When `useDeckCards` resolves, the selection is initialized to
+`new Set(renderable.map(c => c.id))`. This happens once per deck load.
+Subsequent re-renders don't reset the selection.
+
+### Selection state through deck mutations
+
+If a card is removed from the deck while the print view is open
+(unlikely, but possible if the user has the deck editor open in another
+tab), its ID drops out of the selection automatically — the print
+pipeline filters by `selection.has(card.id)` on the current cards list,
+so missing cards simply aren't there.
+
+If a card is added to the deck while the print view is open, the new
+card is **not** auto-added to the selection. The user opens the modal to
+include it. This is the predictable behavior: a narrowed selection stays
+narrowed until the user changes it.
+
+### Empty selection
+
+If the user clears every card and clicks Apply, the sidebar shows
+"Printing 0 of 15 cards" and the Print button is disabled with a small
+hint ("Select at least 1 card to print"). The sheet preview area shows
+a new empty-selection message ("No cards selected — click Customize
+selection to choose what to print"), distinct from today's "No
+printable cards in this deck yet" message (which still fires only when
+the deck itself is empty of renderable cards).
+
+### Reset to all
+
+A "Reset" link next to the count returns the selection to the full
+renderable set. The modal is closed; no dialog needed.
+
+### Modal close behavior
+
+- **Apply**: commits the modal's draft selection to `PrintView`. Closes
+  the modal.
+- **Cancel**: discards the draft. Closes the modal. The previous
+  selection is preserved.
+- **Escape / overlay click**: same as Cancel.
+
+The modal owns its own draft state (filter chips, sort, draft checkbox
+set). It receives the current selection as a prop and only commits via an
+`onApply` callback.
+
+### Filters
+
+- **Kind**: a single-select chip group. Default "All". "Items only" hides
+  spell cards from the list; "Spells only" hides item cards. Hidden cards
+  retain their checkbox state.
+- **Updated since**: a single-select dropdown. Default "Any time". Other
+  options: "Last 24 hours", "Last 7 days", "Last 30 days". Filters by
+  `updatedAt` against the current time at modal open.
+
+### Sort
+
+Default sort is `updatedAt` descending — most-recently-edited cards at
+the top. This is the central UX choice that makes the friction case
+trivial. A small sort selector lets the user switch to name-ascending if
+they prefer alphabetical.
+
+### Bulk actions
+
+- **Select all visible**: checks every card currently visible under the
+  active filters.
+- **Clear visible**: unchecks every card currently visible under the
+  active filters.
+
+Both operate on the *visible* subset, not the full deck, so the user can
+say "all items, plus those two specific spells" by combining filter +
+bulk action + individual checks.
+
+### Sidebar count phrasing
+
+- 0 selected: "Printing 0 of 15 cards" (red/warning treatment)
+- All selected: "Printing all 15 cards"
+- Narrowed: "Printing 7 of 15 cards"
+
+The phrasing emphasizes the *narrowed* state — when the user has changed
+something from the default, the count reads differently enough that they
+notice.
+
+## Components
+
+- **`PrintView.tsx`** — gains selection state, the sidebar count + button
+  + reset, and a feed of the filtered cards into the existing pipeline.
+- **`PrintSelectionModal.tsx`** (new, sibling to `BrowseApiModal`) —
+  owns the picker UI. Uses the same `react-aria-components` Modal /
+  Dialog primitives as `BrowseApiModal`.
+- **`PrintSelectionModal.module.css`** (new) — picker layout.
+
+The selection state could live inline in `PrintView` or be extracted to a
+`usePrintSelection(deckId)` hook. The implementation plan can decide; the
+behavior is the same either way.
+
+## Tests
+
+Behavior tests, written against accessible roles per project convention:
+
+- Print view opens with all renderable cards selected and shows
+  "Printing all N cards".
+- Clicking "Customize selection…" opens a modal listing all renderable
+  cards.
+- The card list defaults to `updatedAt` descending — recently-updated
+  cards appear first.
+- Unchecking one card, clicking Apply, narrows the print to the
+  remaining cards. The sidebar count updates. The sheet preview shows
+  only the remaining cards.
+- Cancel discards changes; the previous selection is preserved.
+- Filtering by kind hides the other kind from the list but does not
+  uncheck them. Switching back to "All" shows them re-checked.
+- "Updated in last 7 days" hides older cards.
+- "Select all visible" + "Clear visible" operate on the filtered subset.
+- Empty selection disables the Print button.
+- Reset link returns the selection to all cards.
+- An ability card (non-renderable kind) does not appear in the picker.
+
+## Risks
+
+- **Selection vs. deck mutation.** The "new cards aren't auto-added"
+  rule is the predictable behavior, but a user who edits in another tab
+  could be confused. The sidebar count showing "Printing 7 of 16 cards"
+  (note 16, not 15) is the only signal. Acceptable: most users won't
+  edit while the print view is open, and the count change is visible.
+- **Long decks in the picker.** A deck with 100+ cards is rare today
+  but possible. The picker is a flat scrollable list, not virtualized.
+  If decks grow much larger, this becomes a performance concern.
+  Punt; revisit when actual deck sizes warrant it.
+- **Filter state confusion.** The filter row helps find cards but
+  doesn't *commit* anything. A user could plausibly check a few cards
+  under "Items only", then hit Apply without realizing all the
+  invisible cards are still selected. The footer count ("X cards
+  selected" — counts the full draft, not the visible subset) is the
+  mitigation, but worth watching in UX review.
+
+## Forward compatibility
+
+If a "print a subset" pattern shows up elsewhere — e.g., picking which
+decks to export to PDF in bulk — the picker's filter + sortable list +
+bulk action pattern could extract into a generic primitive in
+`src/lib/ui/`. One consumer is not a pattern; revisit when there's a
+second.

--- a/docs/superpowers/specs/2026-05-19-print-subset-design.md
+++ b/docs/superpowers/specs/2026-05-19-print-subset-design.md
@@ -101,11 +101,14 @@ The modal — `PrintSelectionModal` — is where the work happens:
     and confirms those cards still print. (The line counts the *hidden
     selected* cards; the Apply button always shows the full total, which
     may be larger when visible cards are also checked.)
-  - **Cancel** and **Apply** buttons. Apply is labelled **"Apply (X
-    cards)"** — the single source of the full-draft total at the commit
-    moment. (The header's "X of Y shown" is a visible-subset status; Apply
-    is the full total. They differ by design and sit in clearly different
-    contexts.)
+  - **Cancel** and **Apply** buttons. Apply is labelled **"Apply (T
+    cards)"** where T is the full-draft total — the single source of that
+    total at the commit moment. (Notation, to keep the three readouts
+    straight: the header shows **X of Y shown** — X = checked-and-visible,
+    Y = visible; the hidden line shows **N** = checked-and-hidden; and
+    **T = X + N**. The header and Apply differ precisely when N > 0 — which
+    is exactly when the hidden line appears, so the two numbers never
+    diverge silently.)
 
 Filters apply only to what's *shown* in the modal — they're a way to
 find cards faster, not a saved query. Checkbox state survives filter
@@ -129,10 +132,12 @@ to reprint just those two." Realistic flow:
 5. Apply reads **"Apply (2 cards)"**. Click it.
 6. Sidebar reads **"2 of 15 cards"**. Click Print.
 
-Six interactions beyond today's default — two of them the actual card
-checks — with no hunting and no ambiguity. The header checkbox is the
-linchpin: it collapses "uncheck 13 cards" into one click. Note the path
-never engages a filter — recency sort alone surfaces the edited cards.
+Five interactions beyond today's default — Choose cards, the header
+clear, two card checks, and Apply (Print is in today's flow too) — with
+no hunting and no ambiguity. The header checkbox is the linchpin: step 3
+clears all 15 in one click, so the user only adds back the two they
+want rather than unchecking thirteen by hand. Note the path never
+engages a filter — recency sort alone surfaces the edited cards.
 
 ## Behavior details
 

--- a/src/lib/relativeTime.test.ts
+++ b/src/lib/relativeTime.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import { relativeTime } from "./relativeTime";
+
+const now = new Date("2026-05-22T12:00:00Z");
+
+describe("relativeTime", () => {
+  test("minutes ago", () => {
+    expect(relativeTime("2026-05-22T11:30:00Z", now)).toBe("30 minutes ago");
+  });
+
+  test("hours ago", () => {
+    expect(relativeTime("2026-05-22T10:00:00Z", now)).toBe("2 hours ago");
+  });
+
+  test("days ago", () => {
+    expect(relativeTime("2026-05-19T12:00:00Z", now)).toBe("3 days ago");
+  });
+
+  test("seconds ago uses 'now' bucket", () => {
+    expect(relativeTime("2026-05-22T11:59:50Z", now)).toBe("now");
+  });
+});

--- a/src/lib/relativeTime.ts
+++ b/src/lib/relativeTime.ts
@@ -1,3 +1,4 @@
+// Locale pinned to "en" so wording ("2 hours ago", "now") is deterministic.
 const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
 
 const DIVISIONS: { amount: number; unit: Intl.RelativeTimeFormatUnit }[] = [
@@ -15,9 +16,8 @@ export function relativeTime(iso: string, now: Date = new Date()): string {
   let duration = (new Date(iso).getTime() - now.getTime()) / 1000;
   for (const division of DIVISIONS) {
     if (Math.abs(duration) < division.amount) {
-      const rounded = Math.round(duration);
-      // For seconds, round to 0 to get "now" for small durations
-      const value = division.unit === "second" && Math.abs(rounded) < 60 ? 0 : rounded;
+      // Sub-minute durations collapse to "now" rather than "N seconds ago".
+      const value = division.unit === "second" ? 0 : Math.round(duration);
       return rtf.format(value, division.unit);
     }
     duration /= division.amount;

--- a/src/lib/relativeTime.ts
+++ b/src/lib/relativeTime.ts
@@ -1,0 +1,26 @@
+const rtf = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+
+const DIVISIONS: { amount: number; unit: Intl.RelativeTimeFormatUnit }[] = [
+  { amount: 60, unit: "second" },
+  { amount: 60, unit: "minute" },
+  { amount: 24, unit: "hour" },
+  { amount: 7, unit: "day" },
+  { amount: 4.34524, unit: "week" },
+  { amount: 12, unit: "month" },
+  { amount: Number.POSITIVE_INFINITY, unit: "year" },
+];
+
+/** "2 hours ago", "3 days ago", "now". Past values produce "… ago". */
+export function relativeTime(iso: string, now: Date = new Date()): string {
+  let duration = (new Date(iso).getTime() - now.getTime()) / 1000;
+  for (const division of DIVISIONS) {
+    if (Math.abs(duration) < division.amount) {
+      const rounded = Math.round(duration);
+      // For seconds, round to 0 to get "now" for small durations
+      const value = division.unit === "second" && Math.abs(rounded) < 60 ? 0 : rounded;
+      return rtf.format(value, division.unit);
+    }
+    duration /= division.amount;
+  }
+  return rtf.format(Math.round(duration), "year");
+}

--- a/src/lib/ui/Checkbox.module.css
+++ b/src/lib/ui/Checkbox.module.css
@@ -1,0 +1,27 @@
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+}
+
+.box {
+  width: 1.1rem;
+  height: 1.1rem;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  display: inline-flex;
+  flex: none;
+}
+
+.checkbox[data-selected] .box,
+.checkbox[data-indeterminate] .box {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+.checkbox[data-focus-visible] .box {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}

--- a/src/lib/ui/Checkbox.module.css
+++ b/src/lib/ui/Checkbox.module.css
@@ -13,6 +13,8 @@
   border-radius: var(--radius-sm);
   background: var(--color-surface);
   display: inline-flex;
+  align-items: center;
+  justify-content: center;
   flex: none;
 }
 
@@ -20,6 +22,20 @@
 .checkbox[data-indeterminate] .box {
   background: var(--color-accent);
   border-color: var(--color-accent);
+}
+
+.checkbox[data-selected] .box::after {
+  content: "✓";
+  color: var(--color-accent-fg);
+  font-size: 0.8rem;
+  line-height: 1;
+}
+
+.checkbox[data-indeterminate] .box::after {
+  content: "–";
+  color: var(--color-accent-fg);
+  font-size: 0.8rem;
+  line-height: 1;
 }
 
 .checkbox[data-disabled] {

--- a/src/lib/ui/Checkbox.module.css
+++ b/src/lib/ui/Checkbox.module.css
@@ -3,6 +3,7 @@
   align-items: center;
   gap: var(--space-2);
   cursor: pointer;
+  font: inherit;
 }
 
 .box {
@@ -19,6 +20,11 @@
 .checkbox[data-indeterminate] .box {
   background: var(--color-accent);
   border-color: var(--color-accent);
+}
+
+.checkbox[data-disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .checkbox[data-focus-visible] .box {

--- a/src/lib/ui/Checkbox.test.tsx
+++ b/src/lib/ui/Checkbox.test.tsx
@@ -31,15 +31,12 @@ describe("Checkbox", () => {
     expect(box).toBeChecked();
   });
 
-  test("indeterminate renders aria-checked=mixed", () => {
+  test("indeterminate renders as partially checked", () => {
     render(
       <Checkbox isSelected={false} isIndeterminate onChange={() => {}} aria-label="Select all">
         {null}
       </Checkbox>,
     );
-    expect(screen.getByRole("checkbox", { name: "Select all" })).toHaveAttribute(
-      "aria-checked",
-      "mixed",
-    );
+    expect(screen.getByRole("checkbox", { name: "Select all" })).toBePartiallyChecked();
   });
 });

--- a/src/lib/ui/Checkbox.test.tsx
+++ b/src/lib/ui/Checkbox.test.tsx
@@ -1,0 +1,45 @@
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, test } from "vitest";
+import { render, screen } from "../../test/render";
+import { Checkbox } from "./Checkbox";
+
+function Harness() {
+  const [selected, setSelected] = useState(false);
+  return (
+    <Checkbox isSelected={selected} onChange={setSelected}>
+      Accept
+    </Checkbox>
+  );
+}
+
+describe("Checkbox", () => {
+  test("renders a checkbox with its label as the accessible name", () => {
+    render(
+      <Checkbox isSelected={false} onChange={() => {}}>
+        Accept
+      </Checkbox>,
+    );
+    expect(screen.getByRole("checkbox", { name: "Accept" })).toBeInTheDocument();
+  });
+
+  test("toggles on click", async () => {
+    render(<Harness />);
+    const box = screen.getByRole("checkbox", { name: "Accept" });
+    expect(box).not.toBeChecked();
+    await userEvent.click(box);
+    expect(box).toBeChecked();
+  });
+
+  test("indeterminate renders aria-checked=mixed", () => {
+    render(
+      <Checkbox isSelected={false} isIndeterminate onChange={() => {}} aria-label="Select all">
+        {null}
+      </Checkbox>,
+    );
+    expect(screen.getByRole("checkbox", { name: "Select all" })).toHaveAttribute(
+      "aria-checked",
+      "mixed",
+    );
+  });
+});

--- a/src/lib/ui/Checkbox.tsx
+++ b/src/lib/ui/Checkbox.tsx
@@ -1,0 +1,40 @@
+import { type ReactNode, useEffect, useRef } from "react";
+import {
+  Checkbox as RACCheckbox,
+  type CheckboxProps as RACCheckboxProps,
+} from "react-aria-components";
+import styles from "./Checkbox.module.css";
+
+export type CheckboxProps = Omit<RACCheckboxProps, "className" | "children"> & {
+  className?: string;
+  children?: ReactNode;
+};
+
+export function Checkbox({ className, children, isIndeterminate, ...rest }: CheckboxProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // RAC sets input.indeterminate as a DOM property but does not set the aria-checked attribute.
+  // Browsers compute aria-checked="mixed" from the property, but JSDOM does not; we set it
+  // explicitly so assistive technology and test queries see the correct state.
+  useEffect(() => {
+    if (inputRef.current) {
+      if (isIndeterminate) {
+        inputRef.current.setAttribute("aria-checked", "mixed");
+      } else {
+        inputRef.current.removeAttribute("aria-checked");
+      }
+    }
+  }, [isIndeterminate]);
+
+  return (
+    <RACCheckbox
+      {...rest}
+      isIndeterminate={isIndeterminate}
+      inputRef={inputRef}
+      className={[styles.checkbox, className].filter(Boolean).join(" ")}
+    >
+      <span className={styles.box} aria-hidden="true" />
+      {children}
+    </RACCheckbox>
+  );
+}

--- a/src/lib/ui/Checkbox.tsx
+++ b/src/lib/ui/Checkbox.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect, useRef } from "react";
+import type { ReactNode } from "react";
 import {
   Checkbox as RACCheckbox,
   type CheckboxProps as RACCheckboxProps,
@@ -10,29 +10,9 @@ export type CheckboxProps = Omit<RACCheckboxProps, "className" | "children"> & {
   children?: ReactNode;
 };
 
-export function Checkbox({ className, children, isIndeterminate, ...rest }: CheckboxProps) {
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  // RAC sets input.indeterminate as a DOM property but does not set the aria-checked attribute.
-  // Browsers compute aria-checked="mixed" from the property, but JSDOM does not; we set it
-  // explicitly so assistive technology and test queries see the correct state.
-  useEffect(() => {
-    if (inputRef.current) {
-      if (isIndeterminate) {
-        inputRef.current.setAttribute("aria-checked", "mixed");
-      } else {
-        inputRef.current.removeAttribute("aria-checked");
-      }
-    }
-  }, [isIndeterminate]);
-
+export function Checkbox({ className, children, ...rest }: CheckboxProps) {
   return (
-    <RACCheckbox
-      {...rest}
-      isIndeterminate={isIndeterminate}
-      inputRef={inputRef}
-      className={[styles.checkbox, className].filter(Boolean).join(" ")}
-    >
+    <RACCheckbox {...rest} className={[styles.checkbox, className].filter(Boolean).join(" ")}>
       <span className={styles.box} aria-hidden="true" />
       {children}
     </RACCheckbox>

--- a/src/lib/ui/README.md
+++ b/src/lib/ui/README.md
@@ -14,6 +14,7 @@ Thin wrappers around `react-aria-components` (and a couple of native elements) t
 | `Textarea` | A multi-line text field. |
 | `TagInput` | A controlled chip-input field. Click a chip to edit in place; click between chips to insert; `×` removes. Full keyboard nav via ←/→ and Enter/Delete. |
 | `Switch` | An on/off toggle with a track + thumb. Children are the label. |
+| `Checkbox` | A checkbox. Supports `isIndeterminate` for tri-state (renders `aria-checked="mixed"`). Children are the label; omit them and pass `aria-label` for a label-less control. |
 | `ToggleButton` | A toggleable button (alone or inside a `ToggleButtonGroup`). |
 | `ToggleButtonGroup` | A segmented selector — wraps `ToggleButton` children. |
 | `DialogShell` | The outer scaffolding (overlay + modal + dialog) for any modal. |

--- a/src/views/PrintSelectionModal.module.css
+++ b/src/views/PrintSelectionModal.module.css
@@ -90,6 +90,40 @@
   color: var(--color-text-muted);
 }
 
+.kindGroup {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.chip {
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-pill, 999px);
+  cursor: pointer;
+  font-size: var(--fs-sm);
+}
+
+.chip[data-selected] {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-on-accent, #fff);
+}
+
+.chip[data-focus-visible] {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.clearFiltersLink {
+  border: 0;
+  background: none;
+  padding: 0;
+  font: inherit;
+  color: var(--color-accent);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
 .hiddenLine {
   font-size: var(--fs-sm);
   color: var(--color-text-muted);

--- a/src/views/PrintSelectionModal.module.css
+++ b/src/views/PrintSelectionModal.module.css
@@ -1,0 +1,108 @@
+.modal {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  gap: var(--space-3);
+  padding: var(--space-4);
+}
+
+.filterRow {
+  display: flex;
+  gap: var(--space-3);
+  align-items: end;
+  flex-wrap: wrap;
+}
+
+.searchField {
+  flex: 1 1 12rem;
+}
+
+.sortLabel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  font-size: var(--fs-sm);
+}
+
+.sortSelect {
+  font: inherit;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-1);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.rowKind {
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+  text-transform: capitalize;
+}
+
+.rowTime {
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+}
+
+.footer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--space-3);
+}
+
+.footerActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3);
+}
+
+.bulkRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-1);
+  border-bottom: 1px solid var(--color-border-strong);
+}
+
+.shownCount {
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+}
+
+.hiddenLine {
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/views/PrintSelectionModal.module.css
+++ b/src/views/PrintSelectionModal.module.css
@@ -15,6 +15,10 @@
 
 .searchField {
   flex: 1 1 12rem;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  font-size: var(--fs-sm);
 }
 
 .sortLabel {

--- a/src/views/PrintSelectionModal.module.css
+++ b/src/views/PrintSelectionModal.module.css
@@ -1,40 +1,92 @@
-.modal {
+.modalContainer {
+  flex: 1;
   display: flex;
   flex-direction: column;
-  height: 100%;
-  gap: var(--space-3);
-  padding: var(--space-4);
+  min-height: 0;
 }
 
-.filterRow {
-  display: flex;
-  gap: var(--space-3);
-  align-items: end;
-  flex-wrap: wrap;
+.searchRow {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .searchField {
-  flex: 1 1 12rem;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-  font-size: var(--fs-sm);
+  display: block;
 }
 
-.sortLabel {
+.toolbar {
   display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-  font-size: var(--fs-sm);
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border);
 }
 
-.sortSelect {
+.sortTrigger {
   font: inherit;
-  padding: var(--space-1) var(--space-2);
-  border: 1px solid var(--color-border-strong);
+  font-family: var(--font-body);
+  font-size: var(--fs-sm);
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   background: var(--color-surface);
   color: var(--color-text);
+  cursor: pointer;
+}
+
+.sortTrigger[data-hovered] {
+  background: var(--color-surface-2);
+  border-color: var(--color-border-strong);
+}
+
+.sortTrigger[data-pressed] {
+  background: var(--color-border);
+}
+
+.sortTrigger[data-focus-visible] {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.sortPopover {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  outline: none;
+}
+
+.sortMenu {
+  padding: var(--space-1);
+  outline: none;
+}
+
+.sortMenuItem {
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-sm);
+  cursor: pointer;
+  outline: none;
+}
+
+.sortMenuItem[data-hovered],
+.sortMenuItem[data-focused] {
+  background: var(--color-surface-2);
+}
+
+.bulkRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.shownCount {
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
 }
 
 .list {
@@ -43,6 +95,7 @@
   padding: 0;
   overflow-y: auto;
   flex: 1 1 auto;
+  min-height: 0;
   display: flex;
   flex-direction: column;
 }
@@ -52,8 +105,12 @@
   grid-template-columns: 1fr auto auto;
   align-items: center;
   gap: var(--space-3);
-  padding: var(--space-2) var(--space-1);
+  padding: var(--space-2) var(--space-4);
   border-bottom: 1px solid var(--color-border);
+}
+
+.row:last-child {
+  border-bottom: 0;
 }
 
 .rowKind {
@@ -67,12 +124,19 @@
   color: var(--color-text-muted);
 }
 
+.emptyState {
+  padding: var(--space-5);
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
 .footer {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
   border-top: 1px solid var(--color-border);
-  padding-top: var(--space-3);
+  background: var(--color-surface-2);
 }
 
 .footerActions {
@@ -81,41 +145,10 @@
   gap: var(--space-3);
 }
 
-.bulkRow {
-  display: flex;
-  align-items: center;
-  gap: var(--space-3);
-  padding: var(--space-2) var(--space-1);
-  border-bottom: 1px solid var(--color-border-strong);
-}
-
-.shownCount {
+.hiddenLine {
+  margin: 0;
   font-size: var(--fs-sm);
   color: var(--color-text-muted);
-}
-
-.kindGroup {
-  display: flex;
-  gap: var(--space-2);
-}
-
-.chip {
-  padding: var(--space-1) var(--space-3);
-  border: 1px solid var(--color-border-strong);
-  border-radius: 999px;
-  cursor: pointer;
-  font-size: var(--fs-sm);
-}
-
-.chip[data-selected] {
-  background: var(--color-accent);
-  border-color: var(--color-accent);
-  color: var(--color-accent-fg);
-}
-
-.chip[data-focus-visible] {
-  outline: 2px solid var(--color-focus-ring);
-  outline-offset: 2px;
 }
 
 .clearFiltersLink {
@@ -126,17 +159,6 @@
   color: var(--color-accent);
   text-decoration: underline;
   cursor: pointer;
-}
-
-.hiddenLine {
-  font-size: var(--fs-sm);
-  color: var(--color-text-muted);
-}
-
-.emptyState {
-  color: var(--color-text-muted);
-  font-size: var(--fs-sm);
-  padding: var(--space-3) var(--space-1);
 }
 
 .srOnly {

--- a/src/views/PrintSelectionModal.module.css
+++ b/src/views/PrintSelectionModal.module.css
@@ -98,7 +98,7 @@
 .chip {
   padding: var(--space-1) var(--space-3);
   border: 1px solid var(--color-border-strong);
-  border-radius: var(--radius-pill, 999px);
+  border-radius: 999px;
   cursor: pointer;
   font-size: var(--fs-sm);
 }
@@ -106,7 +106,7 @@
 .chip[data-selected] {
   background: var(--color-accent);
   border-color: var(--color-accent);
-  color: var(--color-on-accent, #fff);
+  color: var(--color-accent-fg);
 }
 
 .chip[data-focus-visible] {

--- a/src/views/PrintSelectionModal.module.css
+++ b/src/views/PrintSelectionModal.module.css
@@ -89,6 +89,12 @@
   color: var(--color-text-muted);
 }
 
+.colHeader {
+  margin-left: auto;
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+}
+
 .list {
   list-style: none;
   margin: 0;

--- a/src/views/PrintSelectionModal.module.css
+++ b/src/views/PrintSelectionModal.module.css
@@ -133,6 +133,12 @@
   color: var(--color-text-muted);
 }
 
+.emptyState {
+  color: var(--color-text-muted);
+  font-size: var(--fs-sm);
+  padding: var(--space-3) var(--space-1);
+}
+
 .srOnly {
   position: absolute;
   width: 1px;

--- a/src/views/PrintSelectionModal.module.css
+++ b/src/views/PrintSelectionModal.module.css
@@ -167,6 +167,11 @@
   cursor: pointer;
 }
 
+.clearFiltersLink:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
 .srOnly {
   position: absolute;
   width: 1px;

--- a/src/views/PrintSelectionModal.test.tsx
+++ b/src/views/PrintSelectionModal.test.tsx
@@ -129,10 +129,28 @@ describe("<PrintSelectionModal>", () => {
     expect(screen.getByRole("button", { name: "Apply (0 cards)" })).toBeInTheDocument();
   });
 
-  test("header shows 'X of Y shown' status", () => {
+  test("header shows 'X of Y shown' status, associated with the checkbox", () => {
     const cards = itemCardFactory.buildList(3);
     open(cards, allIds(cards));
     expect(screen.getByText("3 of 3 shown")).toBeInTheDocument();
+    expect(
+      screen.getByRole("checkbox", { name: /select all shown cards/i }),
+    ).toHaveAccessibleDescription(/3 of 3 shown/);
+  });
+
+  test("the Kind filter defaults to All", () => {
+    const cards = itemCardFactory.buildList(2);
+    open(cards, allIds(cards));
+    expect(screen.getByRole("radio", { name: /^all/i })).toBeChecked();
+  });
+
+  test("shows an empty state when no cards match, hiding the Updated header", async () => {
+    const cards = itemCardFactory.buildList(3);
+    open(cards, allIds(cards));
+    await userEvent.type(screen.getByRole("searchbox", { name: /search cards/i }), "zzzzz");
+    expect(screen.getByText("No cards match.")).toBeInTheDocument();
+    expect(screen.getByText("0 of 0 shown")).toBeInTheDocument();
+    expect(screen.queryByText("Updated")).not.toBeInTheDocument();
   });
 
   test("Kind filter hides the other kind without unchecking it", async () => {

--- a/src/views/PrintSelectionModal.test.tsx
+++ b/src/views/PrintSelectionModal.test.tsx
@@ -201,7 +201,8 @@ describe("<PrintSelectionModal>", () => {
     let rows = screen.getAllByRole("checkbox", { name: /Alpha|Bravo/ });
     expect(rows[0]).toHaveAccessibleName("Bravo");
     expect(rows[1]).toHaveAccessibleName("Alpha");
-    await userEvent.selectOptions(screen.getByRole("combobox", { name: /sort/i }), "name");
+    await userEvent.click(screen.getByRole("button", { name: /sort/i }));
+    await userEvent.click(screen.getByRole("menuitem", { name: /name/i }));
     rows = screen.getAllByRole("checkbox", { name: /Alpha|Bravo/ });
     expect(rows[0]).toHaveAccessibleName("Alpha");
     expect(rows[1]).toHaveAccessibleName("Bravo");

--- a/src/views/PrintSelectionModal.test.tsx
+++ b/src/views/PrintSelectionModal.test.tsx
@@ -82,4 +82,49 @@ describe("<PrintSelectionModal>", () => {
     expect(screen.getByRole("checkbox", { name: "Cloak" })).toBeInTheDocument();
     expect(screen.getByRole("checkbox", { name: "Bless" })).toBeInTheDocument();
   });
+
+  test("header checkbox clears all visible when all are checked", async () => {
+    const cards = itemCardFactory.buildList(3);
+    open(cards, allIds(cards));
+    const header = screen.getByRole("checkbox", { name: /select all shown cards/i });
+    expect(header).toBeChecked();
+    await userEvent.click(header);
+    expect(screen.getByRole("button", { name: "Apply (0 cards)" })).toBeInTheDocument();
+  });
+
+  test("header checkbox selects all visible when none are checked", async () => {
+    const cards = itemCardFactory.buildList(3);
+    open(cards, new Set()); // start empty
+    const header = screen.getByRole("checkbox", { name: /select all shown cards/i });
+    expect(header).not.toBeChecked();
+    await userEvent.click(header);
+    expect(screen.getByRole("button", { name: "Apply (3 cards)" })).toBeInTheDocument();
+  });
+
+  test("header checkbox is indeterminate (mixed) when some visible are checked", async () => {
+    const cards = itemCardFactory.buildList(3);
+    open(cards, allIds(cards));
+    const [first] = cards;
+    if (!first) throw new Error("expected a card");
+    await userEvent.click(screen.getByRole("checkbox", { name: first.name }));
+    const header = screen.getByRole("checkbox", { name: /select all shown cards/i });
+    expect(header).toBePartiallyChecked();
+  });
+
+  test("clicking an indeterminate header clears all visible", async () => {
+    const cards = itemCardFactory.buildList(3);
+    open(cards, allIds(cards));
+    const [first] = cards;
+    if (!first) throw new Error("expected a card");
+    await userEvent.click(screen.getByRole("checkbox", { name: first.name })); // now 2 of 3
+    const header = screen.getByRole("checkbox", { name: /select all shown cards/i });
+    await userEvent.click(header);
+    expect(screen.getByRole("button", { name: "Apply (0 cards)" })).toBeInTheDocument();
+  });
+
+  test("header shows 'X of Y shown' status", () => {
+    const cards = itemCardFactory.buildList(3);
+    open(cards, allIds(cards));
+    expect(screen.getByText("3 of 3 shown")).toBeInTheDocument();
+  });
 });

--- a/src/views/PrintSelectionModal.test.tsx
+++ b/src/views/PrintSelectionModal.test.tsx
@@ -127,4 +127,52 @@ describe("<PrintSelectionModal>", () => {
     open(cards, allIds(cards));
     expect(screen.getByText("3 of 3 shown")).toBeInTheDocument();
   });
+
+  test("Kind filter hides the other kind without unchecking it", async () => {
+    const item = itemCardFactory.build({ name: "Cloak" });
+    const spell = spellCardFactory.build({ name: "Bless" });
+    const cards = [item, spell];
+    open(cards, allIds(cards));
+    await userEvent.click(screen.getByRole("radio", { name: /items/i }));
+    expect(screen.queryByRole("checkbox", { name: "Bless" })).not.toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "Cloak" })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("radio", { name: /all/i }));
+    expect(screen.getByRole("checkbox", { name: "Bless" })).toBeChecked();
+  });
+
+  test("name search narrows the list case-insensitively", async () => {
+    const a = itemCardFactory.build({ name: "Acid Arrow" });
+    const b = itemCardFactory.build({ name: "Bless" });
+    open([a, b], allIds([a, b]));
+    await userEvent.type(screen.getByRole("searchbox", { name: /search cards/i }), "acid");
+    expect(screen.getByRole("checkbox", { name: "Acid Arrow" })).toBeInTheDocument();
+    expect(screen.queryByRole("checkbox", { name: "Bless" })).not.toBeInTheDocument();
+  });
+
+  test("hidden-checked line appears when a filter hides a selected card", async () => {
+    const item = itemCardFactory.build({ name: "Cloak" });
+    const spell = spellCardFactory.build({ name: "Bless" });
+    const cards = [item, spell];
+    open(cards, allIds(cards));
+    await userEvent.click(screen.getByRole("radio", { name: /items/i }));
+    expect(screen.getByText(/1 selected card is hidden by filters/i)).toBeInTheDocument();
+  });
+
+  test("Clear filters link restores the full list and removes the hidden-checked line", async () => {
+    const item = itemCardFactory.build({ name: "Cloak" });
+    const spell = spellCardFactory.build({ name: "Bless" });
+    const cards = [item, spell];
+    open(cards, allIds(cards));
+    await userEvent.click(screen.getByRole("radio", { name: /items/i }));
+    await userEvent.click(screen.getByRole("button", { name: /clear filters/i }));
+    expect(screen.getByRole("checkbox", { name: "Bless" })).toBeInTheDocument();
+    expect(screen.queryByText(/hidden by filters/i)).not.toBeInTheDocument();
+  });
+
+  test("exposes a polite live region announcing the selected total", () => {
+    const cards = itemCardFactory.buildList(3);
+    open(cards, allIds(cards));
+    const live = screen.getByText(/3 cards selected/i);
+    expect(live).toHaveAttribute("aria-live", "polite");
+  });
 });

--- a/src/views/PrintSelectionModal.test.tsx
+++ b/src/views/PrintSelectionModal.test.tsx
@@ -74,6 +74,13 @@ describe("<PrintSelectionModal>", () => {
     expect(screen.getByRole("button", { name: "Apply (2 cards)" })).toBeInTheDocument();
   });
 
+  test("each timestamp is labelled 'Updated' for screen readers", () => {
+    const card = itemCardFactory.build({ name: "Cloak", updatedAt: "2026-05-23T11:00:00Z" });
+    open([card], allIds([card]));
+    const time = document.querySelector("time");
+    expect(time).toHaveTextContent(/^Updated /);
+  });
+
   test("a spell and an item both appear when present", () => {
     const item = itemCardFactory.build({ name: "Cloak" });
     const spell = spellCardFactory.build({ name: "Bless" });

--- a/src/views/PrintSelectionModal.test.tsx
+++ b/src/views/PrintSelectionModal.test.tsx
@@ -1,0 +1,85 @@
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, test, vi } from "vitest";
+import { itemCardFactory, spellCardFactory } from "../cards/factories";
+import type { CardId, RenderableCard } from "../cards/types";
+import { render, screen } from "../test/render";
+import { PrintSelectionModal } from "./PrintSelectionModal";
+
+function open(cards: RenderableCard[], initial: Set<CardId>, onApply = vi.fn()) {
+  function Harness() {
+    const [closed, setClosed] = useState(false);
+    if (closed) return <p>closed</p>;
+    return (
+      <PrintSelectionModal
+        cards={cards}
+        initialSelection={initial}
+        onApply={onApply}
+        onClose={() => setClosed(true)}
+      />
+    );
+  }
+  render(<Harness />);
+  return { onApply };
+}
+
+const allIds = (cards: RenderableCard[]) => new Set(cards.map((c) => c.id));
+
+describe("<PrintSelectionModal>", () => {
+  test("lists every renderable card with a checkbox, recency-sorted (newest first)", () => {
+    const older = itemCardFactory.build({ name: "Older", updatedAt: "2026-05-01T00:00:00Z" });
+    const newer = itemCardFactory.build({ name: "Newer", updatedAt: "2026-05-20T00:00:00Z" });
+    const cards = [older, newer];
+    open(cards, allIds(cards));
+    const rowChecks = screen.getAllByRole("checkbox", { name: /Older|Newer/ });
+    expect(rowChecks).toHaveLength(2);
+    expect(rowChecks[0]).toHaveAccessibleName("Newer");
+    expect(rowChecks[1]).toHaveAccessibleName("Older");
+  });
+
+  test("focus lands on the name search input on open", () => {
+    const cards = itemCardFactory.buildList(2);
+    open(cards, allIds(cards));
+    expect(screen.getByRole("searchbox", { name: /search cards/i })).toHaveFocus();
+  });
+
+  test("Apply commits the current draft and closes", async () => {
+    const cards = itemCardFactory.buildList(2);
+    const { onApply } = open(cards, allIds(cards));
+    await userEvent.click(screen.getByRole("button", { name: /apply/i }));
+    expect(onApply).toHaveBeenCalledTimes(1);
+    const committed = onApply.mock.calls[0]?.[0] as Set<string>;
+    expect([...committed].sort()).toEqual([...allIds(cards)].sort());
+    expect(screen.getByText("closed")).toBeInTheDocument();
+  });
+
+  test("Cancel discards the draft (onApply not called) and closes", async () => {
+    const cards = itemCardFactory.buildList(2);
+    const { onApply } = open(cards, allIds(cards));
+    const [first] = cards;
+    if (!first) throw new Error("expected cards");
+    await userEvent.click(screen.getByRole("checkbox", { name: first.name }));
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onApply).not.toHaveBeenCalled();
+    expect(screen.getByText("closed")).toBeInTheDocument();
+  });
+
+  test("toggling a row updates the Apply total", async () => {
+    const cards = itemCardFactory.buildList(3);
+    open(cards, allIds(cards));
+    expect(screen.getByRole("button", { name: "Apply (3 cards)" })).toBeInTheDocument();
+    const [first] = cards;
+    if (!first) throw new Error("expected cards");
+    await userEvent.click(screen.getByRole("checkbox", { name: first.name }));
+    expect(screen.getByRole("button", { name: "Apply (2 cards)" })).toBeInTheDocument();
+  });
+
+  test("a spell and an item both appear when present", () => {
+    const item = itemCardFactory.build({ name: "Cloak" });
+    const spell = spellCardFactory.build({ name: "Bless" });
+    const cards = [item, spell];
+    open(cards, allIds(cards));
+    expect(screen.getByRole("checkbox", { name: "Cloak" })).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "Bless" })).toBeInTheDocument();
+  });
+});

--- a/src/views/PrintSelectionModal.test.tsx
+++ b/src/views/PrintSelectionModal.test.tsx
@@ -156,6 +156,8 @@ describe("<PrintSelectionModal>", () => {
     open(cards, allIds(cards));
     await userEvent.click(screen.getByRole("radio", { name: /items/i }));
     expect(screen.getByText(/1 selected card is hidden by filters/i)).toBeInTheDocument();
+    expect(screen.getByText("1 of 1 shown")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Apply (2 cards)" })).toBeInTheDocument();
   });
 
   test("Clear filters link restores the full list and removes the hidden-checked line", async () => {
@@ -174,5 +176,34 @@ describe("<PrintSelectionModal>", () => {
     open(cards, allIds(cards));
     const live = screen.getByText(/3 cards selected/i);
     expect(live).toHaveAttribute("aria-live", "polite");
+  });
+
+  test("Clear filters resets a name search and restores hidden selected cards", async () => {
+    const cloak = itemCardFactory.build({ name: "Cloak" });
+    const bless = spellCardFactory.build({ name: "Bless" });
+    const cards = [cloak, bless];
+    open(cards, allIds(cards));
+    await userEvent.type(screen.getByRole("searchbox", { name: /search cards/i }), "cloak");
+    expect(screen.queryByRole("checkbox", { name: "Bless" })).not.toBeInTheDocument();
+    expect(screen.getByText(/1 selected card is hidden by filters/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /clear filters/i }));
+    expect(screen.getByRole("checkbox", { name: "Bless" })).toBeInTheDocument();
+    expect(screen.getByRole("searchbox", { name: /search cards/i })).toHaveValue("");
+  });
+
+  test("sorting by name reorders rows alphabetically", async () => {
+    // Recency order (default) is Bravo (newer) then Alpha (older); name sort flips it.
+    const bravo = itemCardFactory.build({ name: "Bravo", updatedAt: "2026-05-20T00:00:00Z" });
+    const alpha = itemCardFactory.build({ name: "Alpha", updatedAt: "2026-05-01T00:00:00Z" });
+    const cards = [bravo, alpha];
+    open(cards, allIds(cards));
+    // Default recency: Bravo first.
+    let rows = screen.getAllByRole("checkbox", { name: /Alpha|Bravo/ });
+    expect(rows[0]).toHaveAccessibleName("Bravo");
+    expect(rows[1]).toHaveAccessibleName("Alpha");
+    await userEvent.selectOptions(screen.getByRole("combobox", { name: /sort/i }), "name");
+    rows = screen.getAllByRole("checkbox", { name: /Alpha|Bravo/ });
+    expect(rows[0]).toHaveAccessibleName("Alpha");
+    expect(rows[1]).toHaveAccessibleName("Bravo");
   });
 });

--- a/src/views/PrintSelectionModal.tsx
+++ b/src/views/PrintSelectionModal.tsx
@@ -157,6 +157,7 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
             <span className={styles.shownCount}>
               {visibleCheckedCount} of {visible.length} shown
             </span>
+            {visible.length > 0 && <span className={styles.colHeader}>Updated</span>}
           </div>
 
           <ul className={styles.list}>

--- a/src/views/PrintSelectionModal.tsx
+++ b/src/views/PrintSelectionModal.tsx
@@ -38,6 +38,8 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
   const allVisibleChecked = visible.length > 0 && visibleCheckedCount === visible.length;
   const headerIndeterminate = !allVisibleChecked && visibleCheckedCount > 0;
 
+  // Intentionally ignores RAC's onChange boolean: RAC passes `true` when clicked
+  // from the indeterminate state, but the rule is always "any visible checked → clear".
   const onHeaderToggle = () => {
     const next = new Set(draft);
     if (visibleCheckedCount > 0) {

--- a/src/views/PrintSelectionModal.tsx
+++ b/src/views/PrintSelectionModal.tsx
@@ -2,6 +2,7 @@ import { useId, useMemo, useState } from "react";
 import { Radio, RadioGroup } from "react-aria-components";
 import type { CardId, RenderableCard } from "../cards/types";
 import { type DeckKindFilter, type DeckSort, deckListing } from "../decks/deckListing";
+import { pluralize } from "../lib/pluralize";
 import { relativeTime } from "../lib/relativeTime";
 import { Button } from "../lib/ui/Button";
 import { Checkbox } from "../lib/ui/Checkbox";
@@ -15,8 +16,6 @@ type Props = {
   onApply: (next: Set<CardId>) => void;
   onClose: () => void;
 };
-
-const cardWord = (n: number) => (n === 1 ? "card" : "cards");
 
 export function PrintSelectionModal({ cards, initialSelection, onApply, onClose }: Props) {
   const [draft, setDraft] = useState<Set<CardId>>(() => new Set(initialSelection));
@@ -139,25 +138,29 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
           </div>
 
           <ul className={styles.list}>
-            {visible.map((c) => (
-              <li key={c.id} className={styles.row}>
-                <Checkbox isSelected={draft.has(c.id)} onChange={() => toggle(c.id)}>
-                  {c.name}
-                </Checkbox>
-                <span className={styles.rowKind} aria-hidden="true">
-                  {c.kind}
-                </span>
-                <time className={styles.rowTime} dateTime={c.updatedAt}>
-                  {relativeTime(c.updatedAt)}
-                </time>
-              </li>
-            ))}
+            {visible.length === 0 ? (
+              <li className={styles.emptyState}>No cards match.</li>
+            ) : (
+              visible.map((c) => (
+                <li key={c.id} className={styles.row}>
+                  <Checkbox isSelected={draft.has(c.id)} onChange={() => toggle(c.id)}>
+                    {c.name}
+                  </Checkbox>
+                  <span className={styles.rowKind} aria-hidden="true">
+                    {c.kind}
+                  </span>
+                  <time className={styles.rowTime} dateTime={c.updatedAt}>
+                    {relativeTime(c.updatedAt)}
+                  </time>
+                </li>
+              ))
+            )}
           </ul>
 
           <div className={styles.footer}>
             {hiddenSelectedCount > 0 && (
               <p className={styles.hiddenLine}>
-                {`${hiddenSelectedCount} selected ${cardWord(hiddenSelectedCount)} ${
+                {`${hiddenSelectedCount} selected ${hiddenSelectedCount === 1 ? "card" : "cards"} ${
                   hiddenSelectedCount === 1 ? "is" : "are"
                 } hidden by filters — still included when you Apply.`}{" "}
                 <button type="button" className={styles.clearFiltersLink} onClick={clearFilters}>
@@ -166,7 +169,7 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
               </p>
             )}
             <span className={styles.srOnly} aria-live="polite">
-              {`${total} ${cardWord(total)} selected`}
+              {`${pluralize(total, "card")} selected`}
             </span>
             <div className={styles.footerActions}>
               <Button variant="secondary" onPress={onClose}>
@@ -179,7 +182,7 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
                   onClose();
                 }}
               >
-                {`Apply (${total} ${cardWord(total)})`}
+                {`Apply (${pluralize(total, "card")})`}
               </Button>
             </div>
           </div>

--- a/src/views/PrintSelectionModal.tsx
+++ b/src/views/PrintSelectionModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useId, useMemo, useState } from "react";
 import { TextField } from "react-aria-components";
 import type { CardId, RenderableCard } from "../cards/types";
 import { type DeckSort, deckListing } from "../decks/deckListing";
@@ -22,6 +22,7 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
   const [draft, setDraft] = useState<Set<CardId>>(() => new Set(initialSelection));
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState<DeckSort>("updated");
+  const sortId = useId();
 
   const visible = useMemo(() => {
     const { cards: sorted } = deckListing(cards, { kind: "all", sort });
@@ -61,9 +62,10 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
                 autoFocus
               />
             </TextField>
-            <label className={styles.sortLabel}>
-              <span>Sort</span>
+            <div className={styles.sortLabel}>
+              <label htmlFor={sortId}>Sort</label>
               <select
+                id={sortId}
                 className={styles.sortSelect}
                 value={sort}
                 onChange={(e) => setSort(e.target.value as DeckSort)}
@@ -71,7 +73,7 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
                 <option value="updated">Recently edited</option>
                 <option value="name">Name A→Z</option>
               </select>
-            </label>
+            </div>
           </div>
 
           <ul className={styles.list}>

--- a/src/views/PrintSelectionModal.tsx
+++ b/src/views/PrintSelectionModal.tsx
@@ -1,5 +1,5 @@
 import { useId, useMemo, useState } from "react";
-import { Radio, RadioGroup, TextField } from "react-aria-components";
+import { Radio, RadioGroup } from "react-aria-components";
 import type { CardId, RenderableCard } from "../cards/types";
 import { type DeckKindFilter, type DeckSort, deckListing } from "../decks/deckListing";
 import { relativeTime } from "../lib/relativeTime";
@@ -24,6 +24,7 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
   const [sort, setSort] = useState<DeckSort>("updated");
   const [kind, setKind] = useState<DeckKindFilter>("all");
   const sortId = useId();
+  const searchId = useId();
 
   const visible = useMemo(() => {
     const { cards: sorted } = deckListing(cards, { kind, sort });
@@ -100,15 +101,17 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
                 Spells
               </Radio>
             </RadioGroup>
-            <TextField aria-label="Search cards" className={styles.searchField}>
+            <div className={styles.searchField}>
+              <label htmlFor={searchId}>Search cards</label>
               <Input
+                id={searchId}
                 type="search"
                 placeholder="Search cards…"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 autoFocus
               />
-            </TextField>
+            </div>
             <div className={styles.sortLabel}>
               <label htmlFor={sortId}>Sort</label>
               <select

--- a/src/views/PrintSelectionModal.tsx
+++ b/src/views/PrintSelectionModal.tsx
@@ -30,6 +30,24 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
     return q ? sorted.filter((c) => c.name.toLowerCase().includes(q)) : sorted;
   }, [cards, sort, search]);
 
+  const visibleIds = useMemo(() => visible.map((c) => c.id), [visible]);
+  const visibleCheckedCount = useMemo(
+    () => visibleIds.filter((id) => draft.has(id)).length,
+    [visibleIds, draft],
+  );
+  const allVisibleChecked = visible.length > 0 && visibleCheckedCount === visible.length;
+  const headerIndeterminate = !allVisibleChecked && visibleCheckedCount > 0;
+
+  const onHeaderToggle = () => {
+    const next = new Set(draft);
+    if (visibleCheckedCount > 0) {
+      for (const id of visibleIds) next.delete(id);
+    } else {
+      for (const id of visibleIds) next.add(id);
+    }
+    setDraft(next);
+  };
+
   const toggle = (id: CardId) => {
     const next = new Set(draft);
     if (next.has(id)) next.delete(id);
@@ -74,6 +92,18 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
                 <option value="name">Name A→Z</option>
               </select>
             </div>
+          </div>
+
+          <div className={styles.bulkRow}>
+            <Checkbox
+              aria-label="Select all shown cards"
+              isSelected={allVisibleChecked}
+              isIndeterminate={headerIndeterminate}
+              onChange={onHeaderToggle}
+            />
+            <span className={styles.shownCount}>
+              {visibleCheckedCount} of {visible.length} shown
+            </span>
           </div>
 
           <ul className={styles.list}>

--- a/src/views/PrintSelectionModal.tsx
+++ b/src/views/PrintSelectionModal.tsx
@@ -1,7 +1,7 @@
 import { useId, useMemo, useState } from "react";
-import { TextField } from "react-aria-components";
+import { Radio, RadioGroup, TextField } from "react-aria-components";
 import type { CardId, RenderableCard } from "../cards/types";
-import { type DeckSort, deckListing } from "../decks/deckListing";
+import { type DeckKindFilter, type DeckSort, deckListing } from "../decks/deckListing";
 import { relativeTime } from "../lib/relativeTime";
 import { Button } from "../lib/ui/Button";
 import { Checkbox } from "../lib/ui/Checkbox";
@@ -22,13 +22,14 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
   const [draft, setDraft] = useState<Set<CardId>>(() => new Set(initialSelection));
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState<DeckSort>("updated");
+  const [kind, setKind] = useState<DeckKindFilter>("all");
   const sortId = useId();
 
   const visible = useMemo(() => {
-    const { cards: sorted } = deckListing(cards, { kind: "all", sort });
+    const { cards: sorted } = deckListing(cards, { kind, sort });
     const q = search.trim().toLowerCase();
     return q ? sorted.filter((c) => c.name.toLowerCase().includes(q)) : sorted;
-  }, [cards, sort, search]);
+  }, [cards, kind, sort, search]);
 
   const visibleIds = useMemo(() => visible.map((c) => c.id), [visible]);
   const visibleCheckedCount = useMemo(
@@ -57,6 +58,16 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
     setDraft(next);
   };
 
+  const hiddenSelectedCount = useMemo(() => {
+    const visibleIdSet = new Set(visibleIds);
+    return cards.filter((c) => draft.has(c.id) && !visibleIdSet.has(c.id)).length;
+  }, [cards, draft, visibleIds]);
+
+  const clearFilters = () => {
+    setKind("all");
+    setSearch("");
+  };
+
   const total = draft.size;
 
   return (
@@ -73,6 +84,22 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
       {() => (
         <div className={styles.modal}>
           <div className={styles.filterRow}>
+            <RadioGroup
+              className={styles.kindGroup}
+              aria-label="Filter by card kind"
+              value={kind}
+              onChange={(v) => setKind(v as DeckKindFilter)}
+            >
+              <Radio value="all" className={styles.chip}>
+                All
+              </Radio>
+              <Radio value="item" className={styles.chip}>
+                Items
+              </Radio>
+              <Radio value="spell" className={styles.chip}>
+                Spells
+              </Radio>
+            </RadioGroup>
             <TextField aria-label="Search cards" className={styles.searchField}>
               <Input
                 type="search"
@@ -125,6 +152,19 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
           </ul>
 
           <div className={styles.footer}>
+            {hiddenSelectedCount > 0 && (
+              <p className={styles.hiddenLine}>
+                {`${hiddenSelectedCount} selected ${cardWord(hiddenSelectedCount)} ${
+                  hiddenSelectedCount === 1 ? "is" : "are"
+                } hidden by filters — still included when you Apply.`}{" "}
+                <button type="button" className={styles.clearFiltersLink} onClick={clearFilters}>
+                  Clear filters
+                </button>
+              </p>
+            )}
+            <span className={styles.srOnly} aria-live="polite">
+              {`${total} ${cardWord(total)} selected`}
+            </span>
             <div className={styles.footerActions}>
               <Button variant="secondary" onPress={onClose}>
                 Cancel

--- a/src/views/PrintSelectionModal.tsx
+++ b/src/views/PrintSelectionModal.tsx
@@ -1,0 +1,113 @@
+import { useMemo, useState } from "react";
+import { TextField } from "react-aria-components";
+import type { CardId, RenderableCard } from "../cards/types";
+import { type DeckSort, deckListing } from "../decks/deckListing";
+import { relativeTime } from "../lib/relativeTime";
+import { Button } from "../lib/ui/Button";
+import { Checkbox } from "../lib/ui/Checkbox";
+import { DialogShell } from "../lib/ui/DialogShell";
+import { Input } from "../lib/ui/Input";
+import styles from "./PrintSelectionModal.module.css";
+
+type Props = {
+  cards: RenderableCard[];
+  initialSelection: Set<CardId>;
+  onApply: (next: Set<CardId>) => void;
+  onClose: () => void;
+};
+
+const cardWord = (n: number) => (n === 1 ? "card" : "cards");
+
+export function PrintSelectionModal({ cards, initialSelection, onApply, onClose }: Props) {
+  const [draft, setDraft] = useState<Set<CardId>>(() => new Set(initialSelection));
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<DeckSort>("updated");
+
+  const visible = useMemo(() => {
+    const { cards: sorted } = deckListing(cards, { kind: "all", sort });
+    const q = search.trim().toLowerCase();
+    return q ? sorted.filter((c) => c.name.toLowerCase().includes(q)) : sorted;
+  }, [cards, sort, search]);
+
+  const toggle = (id: CardId) => {
+    const next = new Set(draft);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    setDraft(next);
+  };
+
+  const total = draft.size;
+
+  return (
+    <DialogShell
+      isOpen
+      onOpenChange={(o) => {
+        if (!o) onClose();
+      }}
+      aria-label="Choose cards to print"
+      size="lg"
+      height={{ fixed: "min(70vh, 640px)" }}
+      bleed
+    >
+      {() => (
+        <div className={styles.modal}>
+          <div className={styles.filterRow}>
+            <TextField aria-label="Search cards" className={styles.searchField}>
+              <Input
+                type="search"
+                placeholder="Search cards…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                autoFocus
+              />
+            </TextField>
+            <label className={styles.sortLabel}>
+              <span>Sort</span>
+              <select
+                className={styles.sortSelect}
+                value={sort}
+                onChange={(e) => setSort(e.target.value as DeckSort)}
+              >
+                <option value="updated">Recently edited</option>
+                <option value="name">Name A→Z</option>
+              </select>
+            </label>
+          </div>
+
+          <ul className={styles.list}>
+            {visible.map((c) => (
+              <li key={c.id} className={styles.row}>
+                <Checkbox isSelected={draft.has(c.id)} onChange={() => toggle(c.id)}>
+                  {c.name}
+                </Checkbox>
+                <span className={styles.rowKind} aria-hidden="true">
+                  {c.kind}
+                </span>
+                <time className={styles.rowTime} dateTime={c.updatedAt}>
+                  {relativeTime(c.updatedAt)}
+                </time>
+              </li>
+            ))}
+          </ul>
+
+          <div className={styles.footer}>
+            <div className={styles.footerActions}>
+              <Button variant="secondary" onPress={onClose}>
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                onPress={() => {
+                  onApply(draft);
+                  onClose();
+                }}
+              >
+                {`Apply (${total} ${cardWord(total)})`}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </DialogShell>
+  );
+}

--- a/src/views/PrintSelectionModal.tsx
+++ b/src/views/PrintSelectionModal.tsx
@@ -157,7 +157,11 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
             <span className={styles.shownCount}>
               {visibleCheckedCount} of {visible.length} shown
             </span>
-            {visible.length > 0 && <span className={styles.colHeader}>Updated</span>}
+            {visible.length > 0 && (
+              <span className={styles.colHeader} aria-hidden="true">
+                Updated
+              </span>
+            )}
           </div>
 
           <ul className={styles.list}>
@@ -173,6 +177,7 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
                     {c.kind}
                   </span>
                   <time className={styles.rowTime} dateTime={c.updatedAt}>
+                    <span className={styles.srOnly}>{"Updated "}</span>
                     {relativeTime(c.updatedAt)}
                   </time>
                 </li>

--- a/src/views/PrintSelectionModal.tsx
+++ b/src/views/PrintSelectionModal.tsx
@@ -1,13 +1,23 @@
-import { useId, useMemo, useState } from "react";
-import { Radio, RadioGroup } from "react-aria-components";
+import { useMemo, useState } from "react";
+import {
+  Menu,
+  MenuItem,
+  MenuTrigger,
+  Popover,
+  Button as RACButton,
+  TextField,
+} from "react-aria-components";
 import type { CardId, RenderableCard } from "../cards/types";
 import { type DeckKindFilter, type DeckSort, deckListing } from "../decks/deckListing";
 import { pluralize } from "../lib/pluralize";
 import { relativeTime } from "../lib/relativeTime";
 import { Button } from "../lib/ui/Button";
 import { Checkbox } from "../lib/ui/Checkbox";
+import { DialogHeader } from "../lib/ui/DialogHeader";
 import { DialogShell } from "../lib/ui/DialogShell";
 import { Input } from "../lib/ui/Input";
+import { ToggleButton } from "../lib/ui/ToggleButton";
+import { ToggleButtonGroup } from "../lib/ui/ToggleButtonGroup";
 import styles from "./PrintSelectionModal.module.css";
 
 type Props = {
@@ -22,14 +32,15 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState<DeckSort>("updated");
   const [kind, setKind] = useState<DeckKindFilter>("all");
-  const sortId = useId();
-  const searchId = useId();
 
+  const { cards: listed, counts } = useMemo(
+    () => deckListing(cards, { kind, sort }),
+    [cards, kind, sort],
+  );
   const visible = useMemo(() => {
-    const { cards: sorted } = deckListing(cards, { kind, sort });
     const q = search.trim().toLowerCase();
-    return q ? sorted.filter((c) => c.name.toLowerCase().includes(q)) : sorted;
-  }, [cards, kind, sort, search]);
+    return q ? listed.filter((c) => c.name.toLowerCase().includes(q)) : listed;
+  }, [listed, search]);
 
   const visibleIds = useMemo(() => visible.map((c) => c.id), [visible]);
   const visibleCheckedCount = useMemo(
@@ -82,47 +93,58 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
       bleed
     >
       {() => (
-        <div className={styles.modal}>
-          <div className={styles.filterRow}>
-            <RadioGroup
-              className={styles.kindGroup}
-              aria-label="Filter by card kind"
-              value={kind}
-              onChange={(v) => setKind(v as DeckKindFilter)}
-            >
-              <Radio value="all" className={styles.chip}>
-                All
-              </Radio>
-              <Radio value="item" className={styles.chip}>
-                Items
-              </Radio>
-              <Radio value="spell" className={styles.chip}>
-                Spells
-              </Radio>
-            </RadioGroup>
-            <div className={styles.searchField}>
-              <label htmlFor={searchId}>Search cards</label>
+        <div className={styles.modalContainer}>
+          <DialogHeader title="Choose cards to print" onClose={onClose} />
+
+          <div className={styles.searchRow}>
+            <TextField aria-label="Search cards" className={styles.searchField}>
               <Input
-                id={searchId}
                 type="search"
                 placeholder="Search cards…"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 autoFocus
               />
-            </div>
-            <div className={styles.sortLabel}>
-              <label htmlFor={sortId}>Sort</label>
-              <select
-                id={sortId}
-                className={styles.sortSelect}
-                value={sort}
-                onChange={(e) => setSort(e.target.value as DeckSort)}
-              >
-                <option value="updated">Recently edited</option>
-                <option value="name">Name A→Z</option>
-              </select>
-            </div>
+            </TextField>
+          </div>
+
+          <div className={styles.toolbar}>
+            <ToggleButtonGroup
+              aria-label="Filter by kind"
+              selectionMode="single"
+              disallowEmptySelection
+              selectedKeys={[kind]}
+              onSelectionChange={(keys) => {
+                const next = Array.from(keys)[0];
+                if (next === "all" || next === "item" || next === "spell") setKind(next);
+              }}
+            >
+              <ToggleButton id="all">All ({counts.all})</ToggleButton>
+              <ToggleButton id="item">Items ({counts.item})</ToggleButton>
+              <ToggleButton id="spell">Spells ({counts.spell})</ToggleButton>
+            </ToggleButtonGroup>
+            <MenuTrigger>
+              <RACButton className={styles.sortTrigger}>
+                Sort: {sort === "updated" ? "Recently edited" : "Name"}{" "}
+                <span aria-hidden="true">▾</span>
+              </RACButton>
+              <Popover className={styles.sortPopover} placement="bottom end">
+                <Menu
+                  className={styles.sortMenu}
+                  onAction={(key) => {
+                    if (key === "updated") setSort("updated");
+                    else if (key === "name") setSort("name");
+                  }}
+                >
+                  <MenuItem id="updated" className={styles.sortMenuItem}>
+                    Recently edited
+                  </MenuItem>
+                  <MenuItem id="name" className={styles.sortMenuItem}>
+                    Name
+                  </MenuItem>
+                </Menu>
+              </Popover>
+            </MenuTrigger>
           </div>
 
           <div className={styles.bulkRow}>

--- a/src/views/PrintSelectionModal.tsx
+++ b/src/views/PrintSelectionModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useId, useMemo, useState } from "react";
 import {
   Menu,
   MenuItem,
@@ -80,6 +80,7 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
   };
 
   const total = draft.size;
+  const shownCountId = useId();
 
   return (
     <DialogShell
@@ -150,11 +151,12 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
           <div className={styles.bulkRow}>
             <Checkbox
               aria-label="Select all shown cards"
+              aria-describedby={shownCountId}
               isSelected={allVisibleChecked}
               isIndeterminate={headerIndeterminate}
               onChange={onHeaderToggle}
             />
-            <span className={styles.shownCount}>
+            <span id={shownCountId} className={styles.shownCount}>
               {visibleCheckedCount} of {visible.length} shown
             </span>
             {visible.length > 0 && (

--- a/src/views/PrintView.module.css
+++ b/src/views/PrintView.module.css
@@ -72,6 +72,37 @@
   padding-left: var(--space-4);
 }
 
+.selectionBlock {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  align-items: flex-start;
+}
+
+.selectionCount {
+  margin: 0;
+  font-weight: 500;
+}
+
+.selectionCount[data-empty] {
+  color: var(--color-warning-fg, var(--color-danger-fg));
+}
+
+.selectAllLink {
+  border: 0;
+  background: none;
+  padding: 0;
+  font: inherit;
+  color: var(--color-accent);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.selectAllLink:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
 .divider {
   border: 0;
   border-top: 1px solid var(--color-border);

--- a/src/views/PrintView.module.css
+++ b/src/views/PrintView.module.css
@@ -113,6 +113,11 @@
   width: 100%;
 }
 
+.printButton[aria-disabled="true"] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .tip {
   font-size: var(--fs-sm);
   color: var(--color-text-muted);

--- a/src/views/PrintView.module.css
+++ b/src/views/PrintView.module.css
@@ -85,7 +85,7 @@
 }
 
 .selectionCount[data-empty] {
-  color: var(--color-warning-fg, var(--color-danger-fg));
+  color: var(--color-warning-fg);
 }
 
 .selectAllLink {

--- a/src/views/PrintView.test.tsx
+++ b/src/views/PrintView.test.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from "react";
 import { describe, expect, test, vi } from "vitest";
 import * as layoutPaginatorModule from "../cards/layoutPaginator";
 import { invariant } from "../lib/invariant";
-import { makeCardRow, makeItemPayload } from "../test/factories";
+import { makeAbilityPayload, makeCardRow, makeItemPayload } from "../test/factories";
 import { SB_URL as SB, server } from "../test/msw";
 import { render, screen, waitFor } from "../test/render";
 import { PrintView } from "./PrintView";
@@ -316,6 +316,91 @@ describe("<PrintView>", () => {
     render(wrap(<PrintView deckId="d1" />));
     await waitFor(() => expect(screen.getByText("All 2 cards")).toBeInTheDocument());
     expect(screen.getByRole("button", { name: /choose cards/i })).toBeInTheDocument();
+  });
+
+  test("narrowing via the modal updates the count and the printed set", async () => {
+    const keep = makeCardRow.build({ payload: makeItemPayload.build({ name: "Keep" }) });
+    const drop = makeCardRow.build({ payload: makeItemPayload.build({ name: "Drop" }) });
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json([keep, drop])),
+    );
+    render(wrap(<PrintView deckId="d1" />));
+    await waitFor(() => expect(screen.getByText("All 2 cards")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: /choose cards/i }));
+    await userEvent.click(screen.getByRole("checkbox", { name: "Drop" }));
+    await userEvent.click(screen.getByRole("button", { name: /apply/i }));
+
+    expect(screen.getByText("1 of 2 cards")).toBeInTheDocument();
+    // Card.tsx renders the card name in an <h3> inside data-role="card-root".
+    // After Apply the modal is closed, so these headings belong only to printed cards.
+    const printedNames = Array.from(document.querySelectorAll('[data-role="card-root"] h3')).map(
+      (el) => el.textContent,
+    );
+    expect(printedNames).toContain("Keep");
+    expect(printedNames).not.toContain("Drop");
+  });
+
+  test("Cancel preserves the previous selection", async () => {
+    const cards = makeCardRow.buildList(2);
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+    );
+    render(wrap(<PrintView deckId="d1" />));
+    await waitFor(() => expect(screen.getByText("All 2 cards")).toBeInTheDocument());
+    await userEvent.click(screen.getByRole("button", { name: /choose cards/i }));
+    await userEvent.click(screen.getByRole("checkbox", { name: /select all shown cards/i })); // clears draft
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(screen.getByText("All 2 cards")).toBeInTheDocument();
+  });
+
+  test("empty selection disables Print and shows the empty message", async () => {
+    const cards = makeCardRow.buildList(2);
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+    );
+    render(wrap(<PrintView deckId="d1" />));
+    await waitFor(() => expect(screen.getByText("All 2 cards")).toBeInTheDocument());
+    await userEvent.click(screen.getByRole("button", { name: /choose cards/i }));
+    await userEvent.click(screen.getByRole("checkbox", { name: /select all shown cards/i })); // clears
+    await userEvent.click(screen.getByRole("button", { name: /apply/i }));
+    expect(screen.getByText("0 of 2 cards")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^print$/i })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+    expect(screen.getByText(/no cards selected/i)).toBeInTheDocument();
+  });
+
+  test("Select all link restores the full selection after narrowing", async () => {
+    const a = makeCardRow.build({ payload: makeItemPayload.build({ name: "Alpha" }) });
+    const b = makeCardRow.build({ payload: makeItemPayload.build({ name: "Beta" }) });
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json([a, b])),
+    );
+    render(wrap(<PrintView deckId="d1" />));
+    await waitFor(() => expect(screen.getByText("All 2 cards")).toBeInTheDocument());
+    await userEvent.click(screen.getByRole("button", { name: /choose cards/i }));
+    await userEvent.click(screen.getByRole("checkbox", { name: "Beta" }));
+    await userEvent.click(screen.getByRole("button", { name: /apply/i }));
+    expect(screen.getByText("1 of 2 cards")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /select all/i }));
+    expect(screen.getByText("All 2 cards")).toBeInTheDocument();
+  });
+
+  test("ability (non-renderable) cards never reach the picker", async () => {
+    const item = makeCardRow.build({ payload: makeItemPayload.build({ name: "Cloak" }) });
+    const ability = makeCardRow.build({ payload: makeAbilityPayload.build({ name: "Rage" }) });
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () =>
+        HttpResponse.json([item, ability]),
+      ),
+    );
+    render(wrap(<PrintView deckId="d1" />));
+    await waitFor(() => expect(screen.getByText("All 1 card")).toBeInTheDocument());
+    await userEvent.click(screen.getByRole("button", { name: /choose cards/i }));
+    expect(screen.getByRole("checkbox", { name: "Cloak" })).toBeInTheDocument();
+    expect(screen.queryByRole("checkbox", { name: "Rage" })).not.toBeInTheDocument();
   });
 
   test("'Continue content on back' selected state persists across disable/re-enable", async () => {

--- a/src/views/PrintView.test.tsx
+++ b/src/views/PrintView.test.tsx
@@ -288,6 +288,36 @@ describe("<PrintView>", () => {
     expect(back1.querySelector('[data-role="card-body"]')).toHaveTextContent("pg2");
   });
 
+  test("opens with all renderable cards selected and shows 'All N cards'", async () => {
+    const cards = makeCardRow.buildList(3);
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+    );
+    render(wrap(<PrintView deckId="d1" />));
+    await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
+    expect(screen.getByText("All 3 cards")).toBeInTheDocument();
+  });
+
+  test("the 'Select all' link is hidden when all cards are selected", async () => {
+    const cards = makeCardRow.buildList(3);
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+    );
+    render(wrap(<PrintView deckId="d1" />));
+    await waitFor(() => expect(screen.getByText("All 3 cards")).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: /select all/i })).not.toBeInTheDocument();
+  });
+
+  test("exposes a 'Choose cards' button", async () => {
+    const cards = makeCardRow.buildList(2);
+    server.use(
+      http.post(`${SB}/rest/v1/rpc/get_public_deck_cards`, () => HttpResponse.json(cards)),
+    );
+    render(wrap(<PrintView deckId="d1" />));
+    await waitFor(() => expect(screen.getByText("All 2 cards")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /choose cards/i })).toBeInTheDocument();
+  });
+
   test("'Continue content on back' selected state persists across disable/re-enable", async () => {
     const card = makeCardRow.build({ payload: makeItemPayload.build({ body: "X" }) });
     vi.spyOn(layoutPaginatorModule, "layoutPaginate").mockImplementation(({ bodyHtml }) =>

--- a/src/views/PrintView.tsx
+++ b/src/views/PrintView.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useId, useState } from "react";
+import { Fragment, useId, useMemo, useState } from "react";
 import { imposeBackPage } from "../cards/backImposition";
 import { Card, type CardsPerPage } from "../cards/Card";
 import { CardBack } from "../cards/CardBack";
@@ -10,6 +10,8 @@ import { Button } from "../lib/ui/Button";
 import { LoadingState } from "../lib/ui/LoadingState";
 import { Switch } from "../lib/ui/Switch";
 import styles from "./PrintView.module.css";
+import { selectionCountLabel } from "./printSelectionLabel";
+import { usePrintSelection } from "./usePrintSelection";
 
 type Props = { deckId: string };
 
@@ -39,10 +41,24 @@ export function PrintView({ deckId }: Props) {
   const [printBacks, setPrintBacks] = useState(false);
   const [contentOnBack, setContentOnBack] = useState(false);
   const perPageId = useId();
+  const emptyHintId = useId();
 
   const cards = cardsQuery.data ?? [];
-  const printable = cards.filter(isRenderableCard);
-  const { physicalCards } = useExpandedCards(printable, perPage);
+  const printable = useMemo(() => cards.filter(isRenderableCard), [cards]);
+  const renderableIds = useMemo(() => printable.map((c) => c.id), [printable]);
+
+  const {
+    selected,
+    setSelected: _setSelected,
+    selectAll,
+  } = usePrintSelection(deckId, renderableIds, cardsQuery.isSuccess);
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+
+  const selectedPrintable = printable.filter((c) => selected.has(c.id));
+  const isEmptySelection = printable.length > 0 && selectedPrintable.length === 0;
+  const isNarrowed = selected.size > 0 && selected.size < printable.length;
+  const noneSelected = selectedPrintable.length === 0;
+  const { physicalCards } = useExpandedCards(selectedPrintable, perPage);
   const printSlots = pairSlots(physicalCards, {
     contentOnBack: printBacks && contentOnBack,
   });
@@ -56,6 +72,22 @@ export function PrintView({ deckId }: Props) {
   return (
     <div className={styles.root} data-print-view>
       <aside className={styles.sidebar}>
+        {printable.length > 0 && (
+          <div className={styles.selectionBlock}>
+            <p className={styles.selectionCount} data-empty={isEmptySelection || undefined}>
+              {selectionCountLabel(selectedPrintable.length, printable.length)}
+            </p>
+            <Button variant="secondary" size="sm" onPress={() => setIsPickerOpen(true)}>
+              Choose cards…
+            </Button>
+            {isNarrowed && (
+              <button type="button" className={styles.selectAllLink} onClick={selectAll}>
+                Select all
+              </button>
+            )}
+          </div>
+        )}
+        <hr className={styles.divider} />
         <div className={styles.field}>
           <label htmlFor={perPageId} className={styles.fieldLabel}>
             Cards per page
@@ -104,11 +136,20 @@ export function PrintView({ deckId }: Props) {
           className={styles.printButton}
           variant="primary"
           size="lg"
-          onPress={() => window.print()}
-          isDisabled={printable.length === 0}
+          aria-disabled={noneSelected || undefined}
+          aria-describedby={isEmptySelection ? emptyHintId : undefined}
+          onPress={() => {
+            if (noneSelected) return;
+            window.print();
+          }}
         >
           Print
         </Button>
+        {isEmptySelection && (
+          <p id={emptyHintId} className={styles.tip}>
+            Select at least 1 card to print.
+          </p>
+        )}
         <p className={styles.tip}>
           Tip: in the print dialog, choose <em>Margins: None</em> and uncheck{" "}
           <em>Headers and footers</em> for best results.
@@ -117,6 +158,7 @@ export function PrintView({ deckId }: Props) {
 
       <div>
         {printable.length === 0 && <p>No printable cards in this deck yet.</p>}
+        {isEmptySelection && <p>No cards selected — use Choose cards to pick what to print.</p>}
 
         <div className={styles.sheet}>
           {pages.map((pageSlots) => {
@@ -165,6 +207,14 @@ export function PrintView({ deckId }: Props) {
           })}
         </div>
       </div>
+      {isPickerOpen && (
+        <div role="dialog" aria-label="Choose cards to print">
+          {/* Placeholder — replaced by PrintSelectionModal in Stage 3. */}
+          <button type="button" onClick={() => setIsPickerOpen(false)}>
+            Close
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/views/PrintView.tsx
+++ b/src/views/PrintView.tsx
@@ -47,11 +47,7 @@ export function PrintView({ deckId }: Props) {
   const printable = useMemo(() => cards.filter(isRenderableCard), [cards]);
   const renderableIds = useMemo(() => printable.map((c) => c.id), [printable]);
 
-  const {
-    selected,
-    setSelected: _setSelected,
-    selectAll,
-  } = usePrintSelection(deckId, renderableIds, cardsQuery.isSuccess);
+  const { selected, selectAll } = usePrintSelection(deckId, renderableIds, cardsQuery.isSuccess);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
 
   const selectedPrintable = printable.filter((c) => selected.has(c.id));
@@ -73,21 +69,23 @@ export function PrintView({ deckId }: Props) {
     <div className={styles.root} data-print-view>
       <aside className={styles.sidebar}>
         {printable.length > 0 && (
-          <div className={styles.selectionBlock}>
-            <p className={styles.selectionCount} data-empty={isEmptySelection || undefined}>
-              {selectionCountLabel(selectedPrintable.length, printable.length)}
-            </p>
-            <Button variant="secondary" size="sm" onPress={() => setIsPickerOpen(true)}>
-              Choose cards…
-            </Button>
-            {isNarrowed && (
-              <button type="button" className={styles.selectAllLink} onClick={selectAll}>
-                Select all
-              </button>
-            )}
-          </div>
+          <>
+            <div className={styles.selectionBlock}>
+              <p className={styles.selectionCount} data-empty={isEmptySelection || undefined}>
+                {selectionCountLabel(selectedPrintable.length, printable.length)}
+              </p>
+              <Button variant="secondary" size="sm" onPress={() => setIsPickerOpen(true)}>
+                Choose cards…
+              </Button>
+              {isNarrowed && (
+                <button type="button" className={styles.selectAllLink} onClick={selectAll}>
+                  Select all
+                </button>
+              )}
+            </div>
+            <hr className={styles.divider} />
+          </>
         )}
-        <hr className={styles.divider} />
         <div className={styles.field}>
           <label htmlFor={perPageId} className={styles.fieldLabel}>
             Cards per page

--- a/src/views/PrintView.tsx
+++ b/src/views/PrintView.tsx
@@ -9,6 +9,7 @@ import { useDeckCards } from "../decks/queries";
 import { Button } from "../lib/ui/Button";
 import { LoadingState } from "../lib/ui/LoadingState";
 import { Switch } from "../lib/ui/Switch";
+import { PrintSelectionModal } from "./PrintSelectionModal";
 import styles from "./PrintView.module.css";
 import { selectionCountLabel } from "./printSelectionLabel";
 import { usePrintSelection } from "./usePrintSelection";
@@ -47,7 +48,11 @@ export function PrintView({ deckId }: Props) {
   const printable = useMemo(() => cards.filter(isRenderableCard), [cards]);
   const renderableIds = useMemo(() => printable.map((c) => c.id), [printable]);
 
-  const { selected, selectAll } = usePrintSelection(deckId, renderableIds, cardsQuery.isSuccess);
+  const { selected, setSelected, selectAll } = usePrintSelection(
+    deckId,
+    renderableIds,
+    cardsQuery.isSuccess,
+  );
   const [isPickerOpen, setIsPickerOpen] = useState(false);
 
   const selectedPrintable = printable.filter((c) => selected.has(c.id));
@@ -206,12 +211,12 @@ export function PrintView({ deckId }: Props) {
         </div>
       </div>
       {isPickerOpen && (
-        <div role="dialog" aria-label="Choose cards to print">
-          {/* Placeholder — replaced by PrintSelectionModal in Stage 3. */}
-          <button type="button" onClick={() => setIsPickerOpen(false)}>
-            Close
-          </button>
-        </div>
+        <PrintSelectionModal
+          cards={printable}
+          initialSelection={selected}
+          onApply={setSelected}
+          onClose={() => setIsPickerOpen(false)}
+        />
       )}
     </div>
   );

--- a/src/views/printSelectionLabel.test.ts
+++ b/src/views/printSelectionLabel.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "vitest";
+import { selectionCountLabel } from "./printSelectionLabel";
+
+describe("selectionCountLabel", () => {
+  test("all selected reads 'All N cards'", () => {
+    expect(selectionCountLabel(15, 15)).toBe("All 15 cards");
+  });
+
+  test("narrowed reads 'X of N cards'", () => {
+    expect(selectionCountLabel(7, 15)).toBe("7 of 15 cards");
+  });
+
+  test("zero selected reads '0 of N cards'", () => {
+    expect(selectionCountLabel(0, 15)).toBe("0 of 15 cards");
+  });
+
+  test("singular total pluralizes correctly", () => {
+    expect(selectionCountLabel(1, 1)).toBe("All 1 card");
+    expect(selectionCountLabel(0, 1)).toBe("0 of 1 card");
+  });
+});

--- a/src/views/printSelectionLabel.ts
+++ b/src/views/printSelectionLabel.ts
@@ -1,7 +1,7 @@
-const cardWord = (n: number) => (n === 1 ? "card" : "cards");
+import { pluralize } from "../lib/pluralize";
 
 /** Sidebar count phrasing. `total` is the renderable-card count. */
 export function selectionCountLabel(selected: number, total: number): string {
-  if (selected === total) return `All ${total} ${cardWord(total)}`;
-  return `${selected} of ${total} ${cardWord(total)}`;
+  if (selected === total) return `All ${pluralize(total, "card")}`;
+  return `${selected} of ${pluralize(total, "card")}`;
 }

--- a/src/views/printSelectionLabel.ts
+++ b/src/views/printSelectionLabel.ts
@@ -1,0 +1,7 @@
+const cardWord = (n: number) => (n === 1 ? "card" : "cards");
+
+/** Sidebar count phrasing. `total` is the renderable-card count. */
+export function selectionCountLabel(selected: number, total: number): string {
+  if (selected === total) return `All ${total} ${cardWord(total)}`;
+  return `${selected} of ${total} ${cardWord(total)}`;
+}

--- a/src/views/usePrintSelection.test.tsx
+++ b/src/views/usePrintSelection.test.tsx
@@ -1,0 +1,50 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { usePrintSelection } from "./usePrintSelection";
+
+describe("usePrintSelection", () => {
+  test("initializes to all renderable ids once data is ready", () => {
+    const { result } = renderHook(({ ids, ready }) => usePrintSelection("d1", ids, ready), {
+      initialProps: { ids: ["a", "b", "c"], ready: true },
+    });
+    expect([...result.current.selected].sort()).toEqual(["a", "b", "c"]);
+  });
+
+  test("does not initialize until ready is true", () => {
+    const { result, rerender } = renderHook(
+      ({ ids, ready }) => usePrintSelection("d1", ids, ready),
+      { initialProps: { ids: [] as string[], ready: false } },
+    );
+    expect(result.current.selected.size).toBe(0);
+    rerender({ ids: ["a", "b"], ready: true });
+    expect([...result.current.selected].sort()).toEqual(["a", "b"]);
+  });
+
+  test("a refetch of the same deck does not reset a narrowed selection", () => {
+    const { result, rerender } = renderHook(
+      ({ ids, ready }) => usePrintSelection("d1", ids, ready),
+      { initialProps: { ids: ["a", "b", "c"], ready: true } },
+    );
+    act(() => result.current.setSelected(new Set(["a"])));
+    expect([...result.current.selected]).toEqual(["a"]);
+    rerender({ ids: ["a", "b", "c"], ready: true });
+    expect([...result.current.selected]).toEqual(["a"]);
+  });
+
+  test("switching deckId re-initializes to all", () => {
+    const { result, rerender } = renderHook(
+      ({ deckId, ids }) => usePrintSelection(deckId, ids, true),
+      { initialProps: { deckId: "d1", ids: ["a", "b"] } },
+    );
+    act(() => result.current.setSelected(new Set(["a"])));
+    rerender({ deckId: "d2", ids: ["x", "y", "z"] });
+    expect([...result.current.selected].sort()).toEqual(["x", "y", "z"]);
+  });
+
+  test("selectAll restores the full renderable set", () => {
+    const { result } = renderHook(() => usePrintSelection("d1", ["a", "b", "c"], true));
+    act(() => result.current.setSelected(new Set(["a"])));
+    act(() => result.current.selectAll());
+    expect([...result.current.selected].sort()).toEqual(["a", "b", "c"]);
+  });
+});

--- a/src/views/usePrintSelection.ts
+++ b/src/views/usePrintSelection.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef, useState } from "react";
+import type { CardId } from "../cards/types";
+
+export type PrintSelection = {
+  selected: Set<CardId>;
+  setSelected: (next: Set<CardId>) => void;
+  selectAll: () => void;
+};
+
+/**
+ * Owns the print selection as a Set of card ids. Initializes to "all
+ * renderable" exactly once per deckId (when `ready` first turns true),
+ * so a background refetch — which hands us a new `renderableIds` array
+ * identity — does not silently wipe a narrowed selection. Switching to a
+ * different deckId re-initializes.
+ */
+export function usePrintSelection(
+  deckId: string,
+  renderableIds: CardId[],
+  ready: boolean,
+): PrintSelection {
+  const [selected, setSelected] = useState<Set<CardId>>(() => new Set());
+  const initializedFor = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (ready && initializedFor.current !== deckId) {
+      initializedFor.current = deckId;
+      setSelected(new Set(renderableIds));
+    }
+  }, [ready, deckId, renderableIds]);
+
+  return {
+    selected,
+    setSelected,
+    selectAll: () => setSelected(new Set(renderableIds)),
+  };
+}


### PR DESCRIPTION
### Description (What does it do?)

Adds a way to print a **subset** of a deck instead of always printing every card. Previously the print view rendered every renderable card with no way to narrow the set, so refreshing one or two edited cards meant reprinting the whole deck.

**Sidebar (`PrintView`):** a live count line (`All 15 cards` / `7 of 15 cards` / `0 of 15 cards`), a **Choose cards…** button, and a **Select all** link shown only when the selection is narrowed. The Print button is disabled (and explains why) when nothing is selected. Selection is ephemeral component state — it defaults to the whole deck and resets on refresh (sharing a print is done by PDF, not URL).

**Picker (`PrintSelectionModal`):** built on the design system to match `BrowseApiModal` / `DeckView` — `DialogHeader` chrome, a full-width search row, a `ToggleButtonGroup` kind filter with counts (`All (5) / Items (4) / Spells (1)`), a `Sort: … ▾` popover (recency / name), a tri-state header checkbox (Gmail rule: any visible checked → clear; none → select all), per-row checkboxes with an `Updated` timestamp column, a hidden-checked footer line + Clear filters, and Apply/Cancel.

The print pipeline downstream is unchanged — it just receives a filtered card array.

New pieces: a `Checkbox` primitive in `src/lib/ui/` (with `isIndeterminate`), a `relativeTime` helper in `src/lib/`, a `usePrintSelection` hook, and a `selectionCountLabel` helper. The kind/sort filtering reuses the existing `deckListing`.

### Screenshots:
- [ ] Desktop screenshot of the picker (have one locally — will attach)
- [ ] Mobile width

### How can this be tested?

1. Open a deck → **Print** → **Choose cards…**.
2. Friction case: click the header checkbox once to clear all, check the two recently-edited cards (top of the default recency sort), **Apply** → only those print.
3. Try the kind filter, name search, and `Sort: Name`. Note that filters narrow the *list* but not the *selection* — if a selected card is hidden, the footer says so and Clear filters brings it back.
4. Clear all → Apply → Print is disabled with a hint and the sheet shows an empty-selection message.

Tests cover: the selection hook's init-once-per-deck guard (survives refetch, resets on deck switch), the count phrasing + relative-time helpers, the `Checkbox` indeterminate state, and the modal end-to-end — tri-state header (incl. indeterminate→clear), kind filter, search (incl. empty state), sort-by-name, the hidden-checked / Apply-total divergence, and the integration flow through `PrintView` to the printed output.

### Additional Context

A few things that may look unusual but are intentional:

- **Print button uses `aria-disabled` (not `isDisabled`)** so it stays focusable and a screen reader can announce the `aria-describedby` "Select at least 1 card" hint.
- **The kind `ToggleButtonGroup` renders `role="radio"`** in single-select mode — that's how `DeckView` does it too; tests query it as `radio`.
- **Each `<time>` carries a visually-hidden "Updated " prefix** so SR users hear "Updated, 20 minutes ago"; the visual column header is `aria-hidden`. (A `<table>` would be the textbook association but would mean rewriting the interactive checkbox list — disproportionate for one label column.)
- **Sort-dropdown CSS is now triplicated** (`DeckView`, `PrintSelectionModal`, and `BrowseApiModal`'s menu). A five-lens review judged extracting a shared primitive premature (divergent shapes; repo-wide refactor); recorded in `TECH_DEBT.md` with the trigger to revisit.
- The diff includes the design **spec and implementation plan** under `docs/superpowers/` for traceability.

The feature went through multiple spec-review rounds and a per-task implementation review, plus a final five-lens branch review (UX/UI/a11y, testing, code quality, architecture, repo conventions).