### PR TITLE
refactor(auth): validate pending anon-import payload with zod

### DIFF
--- a/src/auth/anonImport.test.ts
+++ b/src/auth/anonImport.test.ts
@@ -74,6 +74,38 @@ describe("anonImport storage", () => {
     expect(window.localStorage.getItem("dndCards.pendingAnonImport")).toBeNull();
     expect(readPending()).toEqual(payload);
   });
+
+  it("returns null on a v2 payload with a non-array anonDeckIds", () => {
+    window.localStorage.setItem(
+      "deckwright.pendingAnonImport",
+      JSON.stringify({ version: 2, anonDeckIds: "nope", importedDeckIds: [] }),
+    );
+    expect(readPending()).toBeNull();
+  });
+
+  it("returns null on a v2 payload missing importedDeckIds", () => {
+    window.localStorage.setItem(
+      "deckwright.pendingAnonImport",
+      JSON.stringify({ version: 2, anonDeckIds: [] }),
+    );
+    expect(readPending()).toBeNull();
+  });
+
+  it("returns null on a v2 payload with non-string array elements", () => {
+    window.localStorage.setItem(
+      "deckwright.pendingAnonImport",
+      JSON.stringify({ version: 2, anonDeckIds: [1, 2], importedDeckIds: [] }),
+    );
+    expect(readPending()).toBeNull();
+  });
+
+  it("validates a v2 payload with unknown extra keys, stripping them", () => {
+    window.localStorage.setItem(
+      "deckwright.pendingAnonImport",
+      JSON.stringify({ version: 2, anonDeckIds: ["d1"], importedDeckIds: [], junk: "x" }),
+    );
+    expect(readPending()).toEqual({ version: 2, anonDeckIds: ["d1"], importedDeckIds: [] });
+  });
 });
 
 type FakeSupabase = {

--- a/src/auth/anonImport.ts
+++ b/src/auth/anonImport.ts
@@ -1,14 +1,17 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { z } from "zod";
 import type { Database } from "../api/database.types";
 
 const STORAGE_KEY = "deckwright.pendingAnonImport";
 const LEGACY_STORAGE_KEY = "dndCards.pendingAnonImport";
 
-export type PendingAnonImport = {
-  version: 2;
-  anonDeckIds: string[];
-  importedDeckIds: string[];
-};
+const pendingAnonImportSchema = z.object({
+  version: z.literal(2),
+  anonDeckIds: z.array(z.string()),
+  importedDeckIds: z.array(z.string()),
+});
+
+export type PendingAnonImport = z.infer<typeof pendingAnonImportSchema>;
 
 export function stash(payload: PendingAnonImport): void {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
@@ -24,13 +27,14 @@ export function readPending(): PendingAnonImport | null {
   const raw =
     window.localStorage.getItem(STORAGE_KEY) ?? window.localStorage.getItem(LEGACY_STORAGE_KEY);
   if (!raw) return null;
+  let json: unknown;
   try {
-    const parsed = JSON.parse(raw) as { version?: number };
-    if (parsed.version !== 2) return null;
-    return parsed as PendingAnonImport;
+    json = JSON.parse(raw);
   } catch {
     return null;
   }
+  const result = pendingAnonImportSchema.safeParse(json);
+  return result.success ? result.data : null;
 }
 
 export type ResumeResult =


### PR DESCRIPTION
### What are the relevant tickets?

N/A — surfaced during a tech-debt pass (item #1: "Supabase RPC results cast without runtime validation"). The Supabase-side casts in that item were already removed by #66; this closes the one live remnant.

### Description (What does it do?)

`readPending()` in `src/auth/anonImport.ts` turned an untrusted `localStorage` blob into a typed object with two `as` casts (`JSON.parse(raw) as { version?: number }`, then `parsed as PendingAnonImport`) after only checking `version === 2`. It never validated that `anonDeckIds` / `importedDeckIds` were actually present and `string[]`, so a structurally-broken `version: 2` blob passed straight through:

- a **non-array** `anonDeckIds` (e.g. a string) slipped past the guard and drove `tryResume` to iterate the string's characters and fire `get_public_deck` RPCs with single-character deck ids — a silent garbage path;
- a **missing** `anonDeckIds` made `tryResume` throw on `.length`.

This replaces both casts with a `pendingAnonImportSchema` (zod) validated via `safeParse`, and derives `PendingAnonImport` from the schema with `z.infer` (single source of truth). `localStorage` is genuinely untrusted input — the same category the repo already validates with zod (`src/decks/schema.ts`, `src/data/srd-schema.ts`). A broken v2 blob now returns `null`, so `tryResume` cleanly no-ops instead of misbehaving — strictly safer. Behavior for every previously accepted or rejected input is unchanged.

### How can this be tested?

Four unit tests were added to `src/auth/anonImport.test.ts` covering the branches the cast hid:

- `version: 2` with a non-array `anonDeckIds` → `null`
- `version: 2` missing `importedDeckIds` → `null`
- `version: 2` with non-string array elements → `null`
- `version: 2` with unknown extra keys → validates with the extra keys stripped (pins the one behavior delta: `z.object` strips unknown keys; the old cast retained them)

The existing suite (valid round-trip, v1 / unknown-version rejection, non-JSON, legacy key, all `tryResume` cases) still passes unchanged.

### Additional Context

- **Inline schema, not a `src/auth/schema.ts`** — the repo's two existing schema files are multi-consumer; this schema has a single consumer in the same module, so a dedicated file would be premature.
- **`z.object` strips unknown keys (no `.strict()`)** — intentional, to stay tolerant of future forward-compatible fields, matching the old code's pass-through leniency. The extra-keys test asserts the stripped shape, so a later switch to `.strict()` would surface there.
- This change does **not** actively clear a corrupt blob from `localStorage`; it just makes it inert (read → `null` → no-op). That's sufficient and avoids touching the write path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)