### PR TITLE
feat(print): Drive/Gmail-style range selection in the print picker

### DIFF
--- a/docs/superpowers/plans/2026-05-25-print-range-selection.md
+++ b/docs/superpowers/plans/2026-05-25-print-range-selection.md
@@ -1,0 +1,1019 @@
+# Print Range Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Google-Drive-style range selection (Shift-click, Cmd/Ctrl-click, and keyboard Shift+Arrow parity) to the "Choose cards to print" modal's card list.
+
+**Architecture:** Replace the modal's hand-rolled `<ul>` of per-row `Checkbox`es with a `react-aria-components` `ListBox` (`selectionMode="multiple"`, `selectionBehavior="toggle"`). `draft: Set<CardId>` stays the source of truth; the ListBox is a controlled view over only the *visible* (post-filter/search) cards, reconciled with selected-but-hidden cards by a pure helper `mergeVisibleSelection`. The per-row checkbox becomes a decorative `aria-hidden` glyph driven by the option's `data-selected`.
+
+**Tech Stack:** React 18 + TypeScript, `react-aria-components@1.17.0`, CSS modules, Vitest + RTL + `@testing-library/user-event`, Fishery factories.
+
+---
+
+## Background the engineer needs
+
+- The modal lives in `src/views/PrintSelectionModal.tsx` (+ `.module.css` + `.test.tsx`). It is opened by `PrintView.tsx`; **do not touch** `PrintView.tsx`, `usePrintSelection.ts`, `deckListing.ts`, or any print-output code.
+- **Verified RAC facts** (against the installed source) this plan relies on: ListBox supports `selectionMode="multiple"` + `selectionBehavior="toggle"`; Shift-extend is **additive** (selects the anchor→target range, never deselects); `escapeKeyBehavior="none"` lets Escape close the parent Dialog; ListBox ships **no** selection live-announcer (so the modal's existing polite total region is the sole announcer); a real focusable checkbox inside `role="option"` is invalid — use a decorative glyph; the selection-checkbox accessible name is generic, so tests query the **option** (`getByRole("option", { name })`) not a checkbox.
+- **House rules** (from `CLAUDE.md`): prefer `getByRole`; factories pass no values they don't assert on; **no `!` non-null assertions** (use `const [x] = arr; if (!x) throw new Error(...)`); `npm test` / `npm run build` are pre-approved; Biome's formatter is authoritative.
+- **Run tests/build from the worktree.** The worktree has a `node_modules` symlink to the repo root, so `npx vitest` / `npm run build` work.
+- **Two listboxes after this change:** the Sort control (`src/lib/ui/Select.tsx`) is itself a RAC `ListBox` whose items are `role="option"`. The card list also becomes a listbox. So tests **must scope** card-row queries to the card listbox (`within(screen.getByRole("listbox", { name: /cards to print/i }))`) to avoid matching the Sort dropdown's options.
+
+## File Structure
+
+- **Create** `src/views/printSelectionMerge.ts` — pure `mergeVisibleSelection(draft, visibleIds, keys)`; one responsibility (reconcile the ListBox's visible selection with hidden-selected cards). Colocated with the existing `printSelectionLabel.ts`.
+- **Create** `src/views/printSelectionMerge.test.ts` — unit tests for the helper (correctness lives here, RAC-independent).
+- **Modify** `src/views/PrintSelectionModal.tsx` — swap the `<ul>`/`Checkbox` list for a `ListBox`; wire `selectedKeys`/`onSelectionChange` through the helper; reuse the helper for the header toggle; add the one-line hint. Header checkbox, search, filters, sort, footer, Apply/Cancel unchanged.
+- **Modify** `src/views/PrintSelectionModal.module.css` — move the row grid onto listbox options; add the decorative glyph, option focus ring, and hint styles.
+- **Modify** `src/views/PrintSelectionModal.test.tsx` — migrate per-row selectors (`checkbox`→`option`, `toBeChecked`→`aria-selected`), keep header queries as `checkbox`, scope to the card listbox, and add new range/keyboard/structure tests.
+
+---
+
+## Task 1: Pure selection-merge helper
+
+**Files:**
+- Create: `src/views/printSelectionMerge.ts`
+- Test: `src/views/printSelectionMerge.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/views/printSelectionMerge.test.ts`:
+
+```ts
+import { describe, expect, test } from "vitest";
+import type { CardId } from "../cards/types";
+import { mergeVisibleSelection } from "./printSelectionMerge";
+
+const ids = (...xs: string[]) => xs as CardId[];
+
+describe("mergeVisibleSelection", () => {
+  test("keeps selected-but-hidden cards when the visible selection changes", () => {
+    const draft = new Set(ids("a", "b", "hidden"));
+    const visibleIds = ids("a", "b"); // 'hidden' is filtered out of the list
+    const next = mergeVisibleSelection(draft, visibleIds, new Set(ids("a")));
+    expect(next).toEqual(new Set(ids("a", "hidden")));
+  });
+
+  test('the "all" sentinel selects every visible id, plus hidden', () => {
+    const draft = new Set(ids("hidden"));
+    const visibleIds = ids("a", "b");
+    const next = mergeVisibleSelection(draft, visibleIds, "all");
+    expect(next).toEqual(new Set(ids("hidden", "a", "b")));
+  });
+
+  test("drops a key that is not in visibleIds (intersection invariant)", () => {
+    const draft = new Set<CardId>();
+    const visibleIds = ids("a", "b");
+    const next = mergeVisibleSelection(draft, visibleIds, new Set(ids("a", "ghost")));
+    expect(next).toEqual(new Set(ids("a")));
+  });
+
+  test("an empty visible set does not drop hidden-selected cards", () => {
+    const draft = new Set(ids("hidden1", "hidden2"));
+    const visibleIds: CardId[] = [];
+    const next = mergeVisibleSelection(draft, visibleIds, new Set<CardId>());
+    expect(next).toEqual(new Set(ids("hidden1", "hidden2")));
+  });
+
+  test("is idempotent: re-applying the current visible selection is content-equal", () => {
+    const draft = new Set(ids("a", "hidden"));
+    const visibleIds = ids("a", "b");
+    const current = new Set(visibleIds.filter((id) => draft.has(id))); // { a }
+    expect(mergeVisibleSelection(draft, visibleIds, current)).toEqual(draft);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/views/printSelectionMerge.test.ts`
+Expected: FAIL — "Failed to resolve import ... ./printSelectionMerge" (module doesn't exist yet).
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `src/views/printSelectionMerge.ts`:
+
+```ts
+import type { Key } from "react-aria-components";
+import type { CardId } from "../cards/types";
+
+/**
+ * Merge the ListBox's visible selection back into the full print draft,
+ * preserving cards that are selected but currently hidden by a filter/search.
+ * RAC's `onSelectionChange` emits "all" (Cmd/Ctrl+A) or a Set of the visible keys.
+ */
+export function mergeVisibleSelection(
+  draft: ReadonlySet<CardId>,
+  visibleIds: readonly CardId[],
+  keys: "all" | ReadonlySet<Key>,
+): Set<CardId> {
+  const visible = new Set<CardId>(visibleIds);
+  const next = new Set<CardId>();
+  // Selected-but-hidden cards (in the draft, not currently visible) survive untouched.
+  for (const id of draft) {
+    if (!visible.has(id)) next.add(id);
+  }
+  // Add back the visible selection — intersection with visibleIds narrows Key -> CardId
+  // and guarantees the result is a subset of (hidden ∪ visibleIds).
+  for (const id of visibleIds) {
+    if (keys === "all" || keys.has(id)) next.add(id);
+  }
+  return next;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/views/printSelectionMerge.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npm run build`
+Expected: builds with no type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/views/printSelectionMerge.ts src/views/printSelectionMerge.test.ts
+git commit -m "feat(print): add mergeVisibleSelection helper for the picker"
+```
+
+---
+
+## Task 2: Migrate the modal list to a ListBox (preserve existing behavior)
+
+This task rewrites the list rendering and migrates the existing test selectors together (the DOM shape changes, so old `checkbox` selectors can't be kept). Behavior is preserved; new gestures are tested in Task 3.
+
+**Files:**
+- Modify: `src/views/PrintSelectionModal.test.tsx` (full replacement below)
+- Modify: `src/views/PrintSelectionModal.tsx` (full replacement below)
+- Modify: `src/views/PrintSelectionModal.module.css` (full replacement below)
+
+- [ ] **Step 1: Replace the test file with the migrated selectors**
+
+Overwrite `src/views/PrintSelectionModal.test.tsx` with:
+
+```tsx
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, test, vi } from "vitest";
+import { itemCardFactory, spellCardFactory } from "../cards/factories";
+import type { CardId, RenderableCard } from "../cards/types";
+import { render, screen, within } from "../test/render";
+import { PrintSelectionModal } from "./PrintSelectionModal";
+
+function open(cards: RenderableCard[], initial: Set<CardId>, onApply = vi.fn()) {
+  function Harness() {
+    const [closed, setClosed] = useState(false);
+    if (closed) return <p>closed</p>;
+    return (
+      <PrintSelectionModal
+        cards={cards}
+        initialSelection={initial}
+        onApply={onApply}
+        onClose={() => setClosed(true)}
+      />
+    );
+  }
+  render(<Harness />);
+  return { onApply };
+}
+
+const allIds = (cards: RenderableCard[]) => new Set(cards.map((c) => c.id));
+
+// The card list is one of two listboxes in the modal (the Sort control is the
+// other), so scope row queries to it by its accessible name.
+const cardList = () => screen.getByRole("listbox", { name: /cards to print/i });
+const cardOption = (name: string | RegExp) => within(cardList()).getByRole("option", { name });
+const cardOptions = (name: RegExp) => within(cardList()).getAllByRole("option", { name });
+
+describe("<PrintSelectionModal>", () => {
+  test("lists every renderable card as an option, recency-sorted (newest first)", () => {
+    const older = itemCardFactory.build({ name: "Older", updatedAt: "2026-05-01T00:00:00Z" });
+    const newer = itemCardFactory.build({ name: "Newer", updatedAt: "2026-05-20T00:00:00Z" });
+    const cards = [older, newer];
+    open(cards, allIds(cards));
+    const rows = cardOptions(/Older|Newer/);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveAccessibleName("Newer");
+    expect(rows[1]).toHaveAccessibleName("Older");
+  });
+
+  test("focus lands on the name search input on open", () => {
+    const cards = itemCardFactory.buildList(2);
+    open(cards, allIds(cards));
+    expect(screen.getByRole("searchbox", { name: /search cards/i })).toHaveFocus();
+  });
+
+  test("Apply commits the current draft and closes", async () => {
+    const cards = itemCardFactory.buildList(2);
+    const { onApply } = open(cards, allIds(cards));
+    await userEvent.click(screen.getByRole("button", { name: /apply/i }));
+    expect(onApply).toHaveBeenCalledTimes(1);
+    const committed = onApply.mock.calls[0]?.[0] as Set<string>;
+    expect([...committed].sort()).toEqual([...allIds(cards)].sort());
+    expect(screen.getByText("closed")).toBeInTheDocument();
+  });
+
+  test("Cancel discards the draft (onApply not called) and closes", async () => {
+    const cards = itemCardFactory.buildList(2);
+    const { onApply } = open(cards, allIds(cards));
+    const [first] = cards;
+    if (!first) throw new Error("expected cards");
+    await userEvent.click(cardOption(first.name));
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onApply).not.toHaveBeenCalled();
+    expect(screen.getByText("closed")).toBeInTheDocument();
+  });
+
+  test("toggling a card updates the Apply total", async () => {
+    const cards = itemCardFactory.buildList(3);
+    open(cards, allIds(cards));
+    expect(screen.getByRole("button", { name: "Apply (3 cards)" })).toBeInTheDocument();
+    const [first] = cards;
+    if (!first) throw new Error("expected cards");
+    await userEvent.click(cardOption(first.name));
+    expect(screen.getByRole("button", { name: "Apply (2 cards)" })).toBeInTheDocument();
+  });
+
+  test("kind and timestamp are decorative — the option's name is just the card name", () => {
+    const card = itemCardFactory.build({ name: "Cloak", updatedAt: "2026-05-23T11:00:00Z" });
+    open([card], allIds([card]));
+    expect(cardOption("Cloak")).toHaveAccessibleName("Cloak");
+  });
+
+  test("a spell and an item both appear when present", () => {
+    const item = itemCardFactory.build({ name: "Cloak" });
+    const spell = spellCardFactory.build({ name: "Bless" });
+    const cards = [item, spell];
+    open(cards, allIds(cards));
+    expect(cardOption("Cloak")).toBeInTheDocument();
+    expect(cardOption("Bless")).toBeInTheDocument();
+  });
+
+  test("header checkbox clears all visible when all are checked", async () => {
+    const cards = itemCardFactory.buildList(3);
+    open(cards, allIds(cards));
+    const header = screen.getByRole("checkbox", { name: /select all shown cards/i });
+    expect(header).toBeChecked();
+    await userEvent.click(header);
+    expect(screen.getByRole("button", { name: "Apply (0 cards)" })).toBeInTheDocument();
+  });
+
+  test("header checkbox selects all visible when none are checked", async () => {
+    const cards = itemCardFactory.buildList(3);
+    open(cards, new Set()); // start empty
+    const header = screen.getByRole("checkbox", { name: /select all shown cards/i });
+    expect(header).not.toBeChecked();
+    await userEvent.click(header);
+    expect(screen.getByRole("button", { name: "Apply (3 cards)" })).toBeInTheDocument();
+  });
+
+  test("header checkbox is indeterminate (mixed) when some visible are selected", async () => {
+    const cards = itemCardFactory.buildList(3);
+    open(cards, allIds(cards));
+    const [first] = cards;
+    if (!first) throw new Error("expected a card");
+    await userEvent.click(cardOption(first.name));
+    const header = screen.getByRole("checkbox", { name: /select all shown cards/i });
+    expect(header).toBePartiallyChecked();
+  });
+
+  test("clicking an indeterminate header clears all visible", async () => {
+    const cards = itemCardFactory.buildList(3);
+    open(cards, allIds(cards));
+    const [first] = cards;
+    if (!first) throw new Error("expected a card");
+    await userEvent.click(cardOption(first.name)); // now 2 of 3
+    const header = screen.getByRole("checkbox", { name: /select all shown cards/i });
+    await userEvent.click(header);
+    expect(screen.getByRole("button", { name: "Apply (0 cards)" })).toBeInTheDocument();
+  });
+
+  test("header shows 'X of Y shown' status, associated with the checkbox", () => {
+    const cards = itemCardFactory.buildList(3);
+    open(cards, allIds(cards));
+    expect(screen.getByText("3 of 3 shown")).toBeInTheDocument();
+    expect(
+      screen.getByRole("checkbox", { name: /select all shown cards/i }),
+    ).toHaveAccessibleDescription(/3 of 3 shown/);
+  });
+
+  test("the Kind filter defaults to All", () => {
+    const cards = itemCardFactory.buildList(2);
+    open(cards, allIds(cards));
+    expect(screen.getByRole("radio", { name: /^all/i })).toBeChecked();
+  });
+
+  test("shows an empty state when no cards match, hiding the Updated header", async () => {
+    const cards = itemCardFactory.buildList(3);
+    open(cards, allIds(cards));
+    await userEvent.type(screen.getByRole("searchbox", { name: /search cards/i }), "zzzzz");
+    expect(screen.getByText("No cards match.")).toBeInTheDocument();
+    expect(screen.getByText("0 of 0 shown")).toBeInTheDocument();
+    expect(screen.queryByText("Updated")).not.toBeInTheDocument();
+  });
+
+  test("Kind filter hides the other kind without deselecting it", async () => {
+    const item = itemCardFactory.build({ name: "Cloak" });
+    const spell = spellCardFactory.build({ name: "Bless" });
+    const cards = [item, spell];
+    open(cards, allIds(cards));
+    await userEvent.click(screen.getByRole("radio", { name: /items/i }));
+    expect(within(cardList()).queryByRole("option", { name: "Bless" })).not.toBeInTheDocument();
+    expect(cardOption("Cloak")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("radio", { name: /all/i }));
+    expect(cardOption("Bless")).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("name search narrows the list case-insensitively", async () => {
+    const a = itemCardFactory.build({ name: "Acid Arrow" });
+    const b = itemCardFactory.build({ name: "Bless" });
+    open([a, b], allIds([a, b]));
+    await userEvent.type(screen.getByRole("searchbox", { name: /search cards/i }), "acid");
+    expect(cardOption("Acid Arrow")).toBeInTheDocument();
+    expect(within(cardList()).queryByRole("option", { name: "Bless" })).not.toBeInTheDocument();
+  });
+
+  test("hidden-checked line appears when a filter hides a selected card", async () => {
+    const item = itemCardFactory.build({ name: "Cloak" });
+    const spell = spellCardFactory.build({ name: "Bless" });
+    const cards = [item, spell];
+    open(cards, allIds(cards));
+    await userEvent.click(screen.getByRole("radio", { name: /items/i }));
+    expect(screen.getByText(/1 selected card is hidden by filters/i)).toBeInTheDocument();
+    expect(screen.getByText("1 of 1 shown")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Apply (2 cards)" })).toBeInTheDocument();
+  });
+
+  test("Clear filters link restores the full list and removes the hidden-checked line", async () => {
+    const item = itemCardFactory.build({ name: "Cloak" });
+    const spell = spellCardFactory.build({ name: "Bless" });
+    const cards = [item, spell];
+    open(cards, allIds(cards));
+    await userEvent.click(screen.getByRole("radio", { name: /items/i }));
+    await userEvent.click(screen.getByRole("button", { name: /clear filters/i }));
+    expect(cardOption("Bless")).toBeInTheDocument();
+    expect(screen.queryByText(/hidden by filters/i)).not.toBeInTheDocument();
+  });
+
+  test("exposes a polite live region announcing the selected total", () => {
+    const cards = itemCardFactory.buildList(3);
+    open(cards, allIds(cards));
+    const live = screen.getByText(/3 cards selected/i);
+    expect(live).toHaveAttribute("aria-live", "polite");
+  });
+
+  test("Clear filters resets a name search and restores hidden selected cards", async () => {
+    const cloak = itemCardFactory.build({ name: "Cloak" });
+    const bless = spellCardFactory.build({ name: "Bless" });
+    const cards = [cloak, bless];
+    open(cards, allIds(cards));
+    await userEvent.type(screen.getByRole("searchbox", { name: /search cards/i }), "cloak");
+    expect(within(cardList()).queryByRole("option", { name: "Bless" })).not.toBeInTheDocument();
+    expect(screen.getByText(/1 selected card is hidden by filters/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /clear filters/i }));
+    expect(cardOption("Bless")).toBeInTheDocument();
+    expect(screen.getByRole("searchbox", { name: /search cards/i })).toHaveValue("");
+  });
+
+  test("sorting by name reorders rows alphabetically", async () => {
+    // Recency order (default) is Bravo (newer) then Alpha (older); name sort flips it.
+    const bravo = itemCardFactory.build({ name: "Bravo", updatedAt: "2026-05-20T00:00:00Z" });
+    const alpha = itemCardFactory.build({ name: "Alpha", updatedAt: "2026-05-01T00:00:00Z" });
+    const cards = [bravo, alpha];
+    open(cards, allIds(cards));
+    let rows = cardOptions(/Alpha|Bravo/);
+    expect(rows[0]).toHaveAccessibleName("Bravo");
+    expect(rows[1]).toHaveAccessibleName("Alpha");
+    const sortTrigger = screen.getByRole("button", { name: /sort/i });
+    expect(sortTrigger).toHaveTextContent(/recently edited/i);
+    await userEvent.click(sortTrigger);
+    // The Sort dropdown is a separate listbox; its "Name" option is unambiguous here.
+    await userEvent.click(screen.getByRole("option", { name: "Name" }));
+    rows = cardOptions(/Alpha|Bravo/);
+    expect(rows[0]).toHaveAccessibleName("Alpha");
+    expect(rows[1]).toHaveAccessibleName("Bravo");
+  });
+});
+```
+
+- [ ] **Step 2: Run the modal tests to verify they fail**
+
+Run: `npx vitest run src/views/PrintSelectionModal.test.tsx`
+Expected: FAIL — `cardList()` finds no `listbox` named "Cards to print" (the list is still a `<ul>`), so most tests error.
+
+- [ ] **Step 3: Rewrite the component**
+
+Overwrite `src/views/PrintSelectionModal.tsx` with:
+
+```tsx
+import { useId, useMemo, useState } from "react";
+import { ListBox, ListBoxItem, TextField } from "react-aria-components";
+import type { CardId, RenderableCard } from "../cards/types";
+import { type DeckKindFilter, type DeckSort, deckListing } from "../decks/deckListing";
+import { pluralize } from "../lib/pluralize";
+import { relativeTime } from "../lib/relativeTime";
+import { Button } from "../lib/ui/Button";
+import { Checkbox } from "../lib/ui/Checkbox";
+import { DialogHeader } from "../lib/ui/DialogHeader";
+import { DialogShell } from "../lib/ui/DialogShell";
+import { Input } from "../lib/ui/Input";
+import { Select } from "../lib/ui/Select";
+import { ToggleButton } from "../lib/ui/ToggleButton";
+import { ToggleButtonGroup } from "../lib/ui/ToggleButtonGroup";
+import { mergeVisibleSelection } from "./printSelectionMerge";
+import styles from "./PrintSelectionModal.module.css";
+
+type Props = {
+  cards: RenderableCard[];
+  initialSelection: Set<CardId>;
+  onApply: (next: Set<CardId>) => void;
+  onClose: () => void;
+};
+
+export function PrintSelectionModal({ cards, initialSelection, onApply, onClose }: Props) {
+  const [draft, setDraft] = useState<Set<CardId>>(() => new Set(initialSelection));
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<DeckSort>("updated");
+  const [kind, setKind] = useState<DeckKindFilter>("all");
+
+  const { cards: listed, counts } = useMemo(
+    () => deckListing(cards, { kind, sort }),
+    [cards, kind, sort],
+  );
+  const visible = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return q ? listed.filter((c) => c.name.toLowerCase().includes(q)) : listed;
+  }, [listed, search]);
+
+  const visibleIds = useMemo(() => visible.map((c) => c.id), [visible]);
+  const visibleCheckedCount = useMemo(
+    () => visibleIds.filter((id) => draft.has(id)).length,
+    [visibleIds, draft],
+  );
+  const allVisibleChecked = visible.length > 0 && visibleCheckedCount === visible.length;
+  const headerIndeterminate = !allVisibleChecked && visibleCheckedCount > 0;
+
+  const selectedKeys = useMemo(
+    () => new Set(visibleIds.filter((id) => draft.has(id))),
+    [visibleIds, draft],
+  );
+
+  // Intentionally ignores RAC's onChange boolean: RAC passes `true` when clicked
+  // from the indeterminate state, but the rule is always "any visible checked → clear".
+  const onHeaderToggle = () => {
+    const next = visibleCheckedCount > 0 ? new Set<CardId>() : ("all" as const);
+    setDraft((prev) => mergeVisibleSelection(prev, visibleIds, next));
+  };
+
+  const hiddenSelectedCount = useMemo(() => {
+    const visibleIdSet = new Set(visibleIds);
+    return cards.filter((c) => draft.has(c.id) && !visibleIdSet.has(c.id)).length;
+  }, [cards, draft, visibleIds]);
+
+  const clearFilters = () => {
+    setKind("all");
+    setSearch("");
+  };
+
+  const total = draft.size;
+  const shownCountId = useId();
+  const hintId = useId();
+
+  return (
+    <DialogShell
+      isOpen
+      onOpenChange={(o) => {
+        if (!o) onClose();
+      }}
+      aria-label="Choose cards to print"
+      size="lg"
+      height={{ fixed: "min(70vh, 640px)" }}
+      bleed
+    >
+      {() => (
+        <div className={styles.modalContainer}>
+          <DialogHeader title="Choose cards to print" onClose={onClose} />
+
+          <div className={styles.searchRow}>
+            <TextField aria-label="Search cards" className={styles.searchField}>
+              <Input
+                type="search"
+                placeholder="Search cards…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                autoFocus
+              />
+            </TextField>
+          </div>
+
+          <div className={styles.toolbar}>
+            <ToggleButtonGroup
+              aria-label="Filter by kind"
+              selectionMode="single"
+              disallowEmptySelection
+              selectedKeys={[kind]}
+              onSelectionChange={(keys) => {
+                const next = Array.from(keys)[0];
+                if (next === "all" || next === "item" || next === "spell") setKind(next);
+              }}
+            >
+              <ToggleButton id="all">All ({counts.all})</ToggleButton>
+              <ToggleButton id="item">Items ({counts.item})</ToggleButton>
+              <ToggleButton id="spell">Spells ({counts.spell})</ToggleButton>
+            </ToggleButtonGroup>
+            <Select
+              label="Sort"
+              selectedKey={sort}
+              onSelectionChange={(key) => setSort(key as DeckSort)}
+              items={[
+                { id: "updated", label: "Recently edited" },
+                { id: "name", label: "Name" },
+              ]}
+            />
+          </div>
+
+          <div className={styles.bulkRow}>
+            <Checkbox
+              aria-label="Select all shown cards"
+              aria-describedby={shownCountId}
+              isSelected={allVisibleChecked}
+              isIndeterminate={headerIndeterminate}
+              onChange={onHeaderToggle}
+            />
+            <span id={shownCountId} className={styles.shownCount}>
+              {visibleCheckedCount} of {visible.length} shown
+            </span>
+            {visible.length > 0 && (
+              <span className={styles.colHeader} aria-hidden="true">
+                Updated
+              </span>
+            )}
+          </div>
+
+          <p className={styles.hint} id={hintId}>
+            Shift-click or Shift+↑/↓ to select a range.
+          </p>
+
+          <ListBox
+            aria-label="Cards to print"
+            aria-describedby={hintId}
+            className={styles.list}
+            selectionMode="multiple"
+            selectionBehavior="toggle"
+            escapeKeyBehavior="none"
+            selectedKeys={selectedKeys}
+            onSelectionChange={(keys) =>
+              setDraft((prev) => mergeVisibleSelection(prev, visibleIds, keys))
+            }
+            items={visible}
+            renderEmptyState={() => <span className={styles.emptyState}>No cards match.</span>}
+          >
+            {(c) => (
+              <ListBoxItem id={c.id} textValue={c.name} className={styles.row}>
+                <span className={styles.rowMain}>
+                  <span className={styles.box} aria-hidden="true" />
+                  <span className={styles.rowName}>{c.name}</span>
+                </span>
+                <span className={styles.rowKind} aria-hidden="true">
+                  {c.kind}
+                </span>
+                <time className={styles.rowTime} dateTime={c.updatedAt} aria-hidden="true">
+                  {relativeTime(c.updatedAt)}
+                </time>
+              </ListBoxItem>
+            )}
+          </ListBox>
+
+          <div className={styles.footer}>
+            {hiddenSelectedCount > 0 && (
+              <p className={styles.hiddenLine}>
+                {`${hiddenSelectedCount} selected ${hiddenSelectedCount === 1 ? "card" : "cards"} ${
+                  hiddenSelectedCount === 1 ? "is" : "are"
+                } hidden by filters — still included when you Apply.`}{" "}
+                <button type="button" className={styles.clearFiltersLink} onClick={clearFilters}>
+                  Clear filters
+                </button>
+              </p>
+            )}
+            <span className={styles.srOnly} aria-live="polite">
+              {`${pluralize(total, "card")} selected`}
+            </span>
+            <div className={styles.footerActions}>
+              <Button variant="secondary" onPress={onClose}>
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                onPress={() => {
+                  onApply(draft);
+                  onClose();
+                }}
+              >
+                {`Apply (${pluralize(total, "card")})`}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </DialogShell>
+  );
+}
+```
+
+- [ ] **Step 4: Rewrite the stylesheet**
+
+Overwrite `src/views/PrintSelectionModal.module.css` with:
+
+```css
+.modalContainer {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.searchRow {
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.searchField {
+  display: block;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.bulkRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.shownCount {
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+}
+
+.colHeader {
+  margin-left: auto;
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+}
+
+.hint {
+  margin: 0;
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+  cursor: pointer;
+}
+
+.row:last-child {
+  border-bottom: 0;
+}
+
+.row[data-focus-visible] {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: -2px;
+}
+
+.rowMain {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.rowName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.box {
+  width: 1.1rem;
+  height: 1.1rem;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+}
+
+.row[data-selected] .box {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+.row[data-selected] .box::after {
+  content: "✓";
+  color: var(--color-accent-fg);
+  font-size: 0.8rem;
+  line-height: 1;
+}
+
+.rowKind {
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+  text-transform: capitalize;
+}
+
+.rowTime {
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+}
+
+.emptyState {
+  padding: var(--space-5);
+  text-align: center;
+  color: var(--color-text-muted);
+  margin: auto;
+}
+
+.footer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  border-top: 1px solid var(--color-border);
+  background: var(--color-surface-2);
+}
+
+.footerActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-3);
+}
+
+.hiddenLine {
+  margin: 0;
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+}
+
+.clearFiltersLink {
+  border: 0;
+  background: none;
+  padding: 0;
+  font: inherit;
+  color: var(--color-accent);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.clearFiltersLink:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+```
+
+- [ ] **Step 5: Run the modal tests to verify they pass**
+
+Run: `npx vitest run src/views/PrintSelectionModal.test.tsx`
+Expected: PASS (all migrated tests). If a test still queries a row as `checkbox`, fix it to use `cardOption(...)`.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npm run build`
+Expected: builds clean. If TS objects to `selectedKeys={selectedKeys}` (Set vs Selection), the value is correct — confirm the prop accepts `Iterable<Key>`; do not cast unless required.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/views/PrintSelectionModal.tsx src/views/PrintSelectionModal.module.css src/views/PrintSelectionModal.test.tsx
+git commit -m "feat(print): move the card picker list to a multi-select ListBox"
+```
+
+---
+
+## Task 3: Add range, keyboard, and structure tests
+
+These verify the new gestures (RAC-provided + our wiring) and the structural a11y contract. They are appended to `PrintSelectionModal.test.tsx` and reuse the `open`, `allIds`, `cardList`, `cardOption` helpers defined in Task 2.
+
+**Files:**
+- Modify: `src/views/PrintSelectionModal.test.tsx` (append a new `describe` block + one helper)
+
+- [ ] **Step 1: Append the new tests**
+
+Add this `mk` helper and `describe` block at the **end** of `src/views/PrintSelectionModal.test.tsx` (after the existing `describe(...)` block closes). `mk` builds a card with an explicit `updatedAt` so the recency-sorted DOM order is deterministic (newest first = call order); both `name` and `updatedAt` are asserted-on (name via query, updatedAt via order), so this respects the factory rules.
+
+```tsx
+// Newest-first: pass higher day numbers first so recency order == call order.
+const mk = (name: string, day: string) =>
+  itemCardFactory.build({ name, updatedAt: `2026-05-${day}T00:00:00Z` });
+
+describe("<PrintSelectionModal> range + keyboard selection", () => {
+  test("the card list is a multi-selectable listbox; options expose aria-selected", () => {
+    const cards = itemCardFactory.buildList(2);
+    open(cards, allIds(cards));
+    expect(cardList()).toHaveAttribute("aria-multiselectable", "true");
+    const [first] = cards;
+    if (!first) throw new Error("expected a card");
+    expect(cardOption(first.name)).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("the listbox is described by the range hint", () => {
+    const cards = itemCardFactory.buildList(2);
+    open(cards, allIds(cards));
+    expect(cardList()).toHaveAccessibleDescription(/shift-click/i);
+  });
+
+  test("Escape closes the modal rather than only clearing selection", async () => {
+    const cards = itemCardFactory.buildList(3);
+    const { onApply } = open(cards, allIds(cards));
+    const [first] = cards;
+    if (!first) throw new Error("expected a card");
+    await userEvent.click(cardOption(first.name)); // moves focus into the listbox
+    await userEvent.keyboard("{Escape}");
+    expect(onApply).not.toHaveBeenCalled();
+    expect(screen.getByText("closed")).toBeInTheDocument();
+  });
+
+  test("bare ArrowDown moves focus without changing selection", async () => {
+    const cards = itemCardFactory.buildList(3);
+    open(cards, new Set()); // none selected
+    const [first, second] = cards;
+    if (!first || !second) throw new Error("expected cards");
+    cardOption(first.name).focus();
+    await userEvent.keyboard("{ArrowDown}");
+    expect(cardOption(second.name)).toHaveFocus();
+    expect(cardOption(first.name)).toHaveAttribute("aria-selected", "false");
+    expect(cardOption(second.name)).toHaveAttribute("aria-selected", "false");
+  });
+
+  test("a plain click toggles a single card and never replaces the selection", async () => {
+    const user = userEvent.setup();
+    const cards = [mk("A", "20"), mk("B", "19"), mk("C", "18")];
+    open(cards, allIds(cards)); // all selected
+    await user.click(cardOption("A")); // toggle A off; B and C stay
+    expect(cardOption("A")).toHaveAttribute("aria-selected", "false");
+    expect(cardOption("B")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("C")).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("Shift-click selects the inclusive range (additive)", async () => {
+    const user = userEvent.setup();
+    const cards = [mk("A", "20"), mk("B", "19"), mk("C", "18"), mk("D", "17")];
+    open(cards, new Set());
+    await user.click(cardOption("A"));
+    await user.keyboard("{Shift>}");
+    await user.click(cardOption("C"));
+    await user.keyboard("{/Shift}");
+    expect(cardOption("A")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("B")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("C")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("D")).toHaveAttribute("aria-selected", "false");
+  });
+
+  test("Cmd/Ctrl-click toggles a single card without disturbing others", async () => {
+    const user = userEvent.setup();
+    const cards = [mk("A", "20"), mk("B", "19"), mk("C", "18")];
+    open(cards, new Set());
+    await user.click(cardOption("A"));
+    await user.keyboard("{Meta>}");
+    await user.click(cardOption("C"));
+    await user.keyboard("{/Meta}");
+    expect(cardOption("A")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("B")).toHaveAttribute("aria-selected", "false");
+    expect(cardOption("C")).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("Shift+ArrowDown extends the selection by keyboard", async () => {
+    const user = userEvent.setup();
+    const cards = [mk("A", "20"), mk("B", "19"), mk("C", "18")];
+    open(cards, new Set());
+    await user.click(cardOption("A")); // select + anchor + focus A
+    await user.keyboard("{Shift>}{ArrowDown}{/Shift}");
+    expect(cardOption("A")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("B")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("C")).toHaveAttribute("aria-selected", "false");
+  });
+
+  test("range selection spans only visible rows; a filtered-out selected card is preserved", async () => {
+    const user = userEvent.setup();
+    const a = itemCardFactory.build({ name: "A", updatedAt: "2026-05-20T00:00:00Z" });
+    const b = spellCardFactory.build({ name: "B", updatedAt: "2026-05-19T00:00:00Z" });
+    const c = itemCardFactory.build({ name: "C", updatedAt: "2026-05-18T00:00:00Z" });
+    const cards = [a, b, c];
+    open(cards, new Set([b.id])); // only the spell B is selected
+    await user.click(screen.getByRole("radio", { name: /items/i })); // hides B; A, C visible
+    expect(screen.getByText(/1 selected card is hidden by filters/i)).toBeInTheDocument();
+    await user.click(cardOption("A"));
+    await user.keyboard("{Shift>}");
+    await user.click(cardOption("C"));
+    await user.keyboard("{/Shift}");
+    expect(cardOption("A")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("C")).toHaveAttribute("aria-selected", "true");
+    // A + C (visible) + B (hidden, preserved) = 3
+    expect(screen.getByRole("button", { name: "Apply (3 cards)" })).toBeInTheDocument();
+  });
+
+  test("range selection works after changing the sort order", async () => {
+    const user = userEvent.setup();
+    const bravo = itemCardFactory.build({ name: "Bravo", updatedAt: "2026-05-20T00:00:00Z" });
+    const alpha = itemCardFactory.build({ name: "Alpha", updatedAt: "2026-05-18T00:00:00Z" });
+    const cards = [bravo, alpha];
+    open(cards, new Set());
+    await user.click(screen.getByRole("button", { name: /sort/i }));
+    await user.click(screen.getByRole("option", { name: "Name" })); // order -> Alpha, Bravo
+    await user.click(cardOption("Alpha"));
+    await user.keyboard("{Shift>}");
+    await user.click(cardOption("Bravo"));
+    await user.keyboard("{/Shift}");
+    expect(cardOption("Alpha")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("Bravo")).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("Cmd/Ctrl+A selects all shown and the header reads checked", async () => {
+    const user = userEvent.setup();
+    const cards = itemCardFactory.buildList(3);
+    open(cards, new Set()); // none
+    const [first] = cards;
+    if (!first) throw new Error("expected a card");
+    cardOption(first.name).focus();
+    // jsdom is treated as non-Mac, so Ctrl+A is select-all. If this env resolves as
+    // Mac, switch to "{Meta>}a{/Meta}".
+    await user.keyboard("{Control>}a{/Control}");
+    expect(screen.getByRole("button", { name: "Apply (3 cards)" })).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: /select all shown cards/i })).toBeChecked();
+  });
+});
+```
+
+- [ ] **Step 2: Run the modal tests to verify they pass**
+
+Run: `npx vitest run src/views/PrintSelectionModal.test.tsx`
+Expected: PASS (all migrated + new tests).
+Troubleshooting if any interaction test fails:
+- Modifier-held click not registering → ensure `userEvent.setup()` is used and the modifier is held with `user.keyboard("{Shift>}")` *before* `user.click(...)` and released after.
+- `Cmd/Ctrl+A` test fails with 0 selected → the env resolved as Mac; change `{Control>}a{/Control}` to `{Meta>}a{/Meta}`.
+- `.focus()` doesn't move roving focus → click the option first to enter the listbox, then drive arrows.
+
+- [ ] **Step 3: Run the full suite + typecheck**
+
+Run: `npx vitest run` then `npm run build`
+Expected: entire suite passes; build is clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/views/PrintSelectionModal.test.tsx
+git commit -m "test(print): cover range, keyboard, and listbox a11y for the picker"
+```
+
+---
+
+## Self-review (author's checklist — already run)
+
+**Spec coverage:** range select (Task 3 Shift-click) · keyboard parity Shift+Arrow/Space/bare-arrow-no-select/Cmd+A (Task 3) · additive single toggle Cmd-click (Task 3) · plain-click never replaces / touch (Task 3) · preserved search/filter/sort/header/hidden-line/Apply/Cancel (Task 2 migrated) · merge + intersection + idempotency (Task 1) · `escapeKeyBehavior` (Task 3 Escape) · one-line hint + `aria-describedby` (Task 2 component + Task 3 describedby) · `aria-multiselectable`/`aria-selected` (Task 3 structure) · decorative kind/time, option name == card name (Task 2 component + decorative test) · `renderEmptyState` (Task 2 empty-state test) · two-listbox scoping (Task 2 helpers + sort test) · focus-visible on option (Task 2 CSS). `PrintView`/pipeline untouched, so no print-output task. Type-ahead and Cmd/Ctrl+Shift+Home/End are RAC-provided and not separately tested (acceptable — pure library behavior).
+
+**Type consistency:** `mergeVisibleSelection(draft, visibleIds, keys)` signature is identical in Task 1 (definition), the component's `onSelectionChange` and `onHeaderToggle` (Task 2), and is RAC-independent. `cardList`/`cardOption`/`cardOptions`/`allIds`/`open`/`mk` are defined once and reused.
+
+**Placeholder scan:** none — every step has full file content or an exact command + expected result.

--- a/docs/superpowers/specs/2026-05-24-print-range-selection-design.md
+++ b/docs/superpowers/specs/2026-05-24-print-range-selection-design.md
@@ -45,14 +45,12 @@ below reflects this.
 
 ## Non-goals
 
-- **Discoverability affordance — pending one decision (see Risks).** The
-  default position is to rely on convention with no hint. Review raised a
-  stronger case than "undiscovered new feature": the Tab model changes
-  (see Accessibility), which is a mild *regression* for existing
-  keyboard users, and a single static line ("Use arrow keys to move,
-  Space to select, Shift to extend") would mitigate both the regression
-  and discoverability at near-zero cost. Flagged for the owner; built
-  only if chosen.
+- **No heavy discoverability affordance** — no coachmark, animated tour,
+  or dismissible callout. A *single static one-line hint* near the list
+  **is** in scope (see Components / Accessibility); it was decided in
+  favor after review flagged the Tab-model change (Accessibility) as a
+  mild regression for existing keyboard users that the hint also
+  mitigates.
 - **No recency/date *filter*.** ("Edited this week / since a date.") The
   existing recency *sort* already surfaces recent cards at the top and is
   preserved; a date filter is a possible future follow-up, out of scope.
@@ -283,13 +281,20 @@ run — versus today's *N* unchecks (8 for a 20→12 narrowing, 20 for a
   `getByRole("option", { name })` resolves cleanly. The decorative
   checkbox glyph is `aria-hidden`, not focusable or queryable.
 - **`escapeKeyBehavior="none"`** so Escape closes the dialog (Cancel).
+- **One-line hint.** A single static, muted helper line sits near the
+  list (in/under the bulk-select row) — candidate copy: *"Shift-click or
+  Shift + ↑/↓ to select a range."* It is plain visible text (not a
+  callout/coachmark) and is associated with the listbox via
+  `aria-describedby`, so SR users hear it on entering the list — which is
+  what makes it double as the Tab-model-change mitigation, not just mouse
+  discoverability. Final copy is for the plan; keep it to one short line.
 - **Tab model change (called out).** Today every row checkbox is its own
   Tab stop; the ListBox is a single Tab stop with arrow roving. Order:
   search → kind toggles → sort → header checkbox → (one Tab into the
   listbox; arrows within) → footer "Clear filters" → Cancel/Apply. The
   header checkbox precedes the list and stays reachable. A net win for
-  most, but a behavior change for Tab-only users — the discoverability
-  decision in Non-goals/Risks is the mitigation.
+  most, but a behavior change for Tab-only users — the one-line hint
+  above (announced via `aria-describedby` on entry) is the mitigation.
 - **Empty state** uses ListBox's `renderEmptyState` to keep "No cards
   match." Note RAC wraps that content in a `role="option"` element, so
   the empty modal contains *one* option — tests assert by text and must
@@ -394,12 +399,10 @@ basis for the "no extra test dependency / no e2e harness" claim above.
   layer-(c) test.
 - **Escape regression.** Easy to miss `escapeKeyBehavior`; covered by a
   test.
-- **Tab-model change / discoverability.** Decision pending (Non-goals):
-  the Tab change is a mild regression for keyboard users and a one-line
-  static hint mitigates both it and discoverability cheaply. The
-  worst-case without it is non-destructive (users fall back to today's
-  per-card path), so it is not a blocker — but it is the one open product
-  call.
+- **Tab-model change / discoverability.** Resolved: the one-line hint is
+  in scope (Components / Accessibility), associated with the listbox via
+  `aria-describedby`, mitigating both the Tab-model regression and
+  Shift-range discoverability.
 - **Touch gets no range gesture** — accepted and documented.
 - **(Resolved) jsdom drivability + Shift semantics** — previously the top
   risk; settled by source-reading + the spike above. No longer open.

--- a/docs/superpowers/specs/2026-05-24-print-range-selection-design.md
+++ b/docs/superpowers/specs/2026-05-24-print-range-selection-design.md
@@ -153,39 +153,46 @@ Gets its own test.
 `ListBox` is a *controlled selection view over only the visible
 (post-filter, post-search) cards*:
 
-- `selectedKeys` = the visible cards in `draft`, `useMemo`'d over
-  `[draft, visibleIds]`.
-- `onSelectionChange(keys)` merges back via a **pure, unit-tested
-  helper** rather than inline logic:
+- `selectedKeys` = the whole `draft`, passed to the `ListBox` directly.
+  `draft` may include cards hidden by the current filter/search; RAC
+  renders only the visible collection and leaves the rest of the set
+  untouched (verified against the 1.17.0 source: RAC does **not** prune a
+  controlled `selectedKeys` against the collection, and `toggleSelection`
+  / `extendSelection` copy the whole set before mutating, so hidden keys
+  ride through).
+- `onSelectionChange(keys)` stores RAC's result **as-is** for ordinary
+  toggles and range changes (`setDraft(keys as Set<CardId>)`), and routes
+  only the `"all"` (Cmd/Ctrl+A) sentinel through the pure helper:
 
   ```ts
   // printSelectionMerge.ts — colocated with printSelectionLabel.ts
   mergeVisibleSelection(
     draft: Set<CardId>,
     visibleIds: CardId[],
-    keys: Selection,        // RAC: "all" | Set<Key>  (Key = string | number)
+    keys: "all" | ReadonlySet<Key>,   // Key from react-aria-components
   ): Set<CardId>
   ```
 
-  - `hidden` = `draft` minus `visibleIds`.
-  - `keys === "all"` (the Cmd/Ctrl+A sentinel) resolves to all
-    `visibleIds` — and only those, because the ListBox collection is fed
-    only the visible cards.
-  - otherwise `resolvedVisible = visibleIds.filter(id => keys.has(id))`
-    — an **intersection**, not a cast. This narrows RAC's `Key`
-    (`string | number`) to `CardId` and guarantees
-    `result ⊆ (hidden ∪ visibleIds)` regardless of what `keys` contains.
-  - `next = hidden ∪ resolvedVisible`.
+  - `hidden` = `draft` minus `visibleIds`; for `"all"`,
+    `next = hidden ∪ visibleIds`.
+  - otherwise it intersects: `next = hidden ∪ visibleIds.filter(id => keys.has(id))`
+    — narrowing `Key` to `CardId` and guaranteeing `next ⊆ (hidden ∪ visibleIds)`.
 
-  The helper always returns a concrete `Set` (never re-emits `"all"`) and
-  is **idempotent**: re-applying the current visible selection yields a
-  content-equal `draft` (matters under React `StrictMode` double-invoke,
-  since `onSelectionChange` calls `setDraft`).
+  **Why the normal path stores the Selection as-is** instead of rebuilding
+  a plain `Set` each render: RAC keeps the range *anchor* on the
+  `Selection` object it hands back, and `convertSelection` only preserves
+  it when the controlled value is itself a `Selection`. Rebuilding a plain
+  `Set` nulls the anchor and collapses Shift / Shift+Arrow ranges to a
+  single item — a real bug, caught by the range tests. So the per-row path
+  must pass RAC's object back untouched. The helper therefore guards only
+  the two **bulk** paths that emit sentinels — the header toggle
+  (select-all / clear-visible) and Cmd/Ctrl+A (`"all"`) — where a fresh
+  `Set` (and an anchor reset) is fine. At Apply, `draft` is normalized to a
+  plain `Set` for downstream consumers.
 
-Extracting the helper is deliberate: it puts the merge's *correctness*
-(hidden∪visible, the `"all"` sentinel, the intersection invariant, empty
-visible) under fast deterministic unit tests independent of any RAC/jsdom
-interaction.
+The helper is pure and unit-tested (hidden∪visible, the `"all"` sentinel,
+the intersection invariant, empty-visible, idempotency), independent of
+RAC/jsdom.
 
 This preserves today's contract exactly: filters/search change only
 which rows are *shown*, never the selection; selected-but-hidden cards
@@ -206,18 +213,20 @@ with the `mixed` indeterminate state.
 Keyboard users also get Cmd/Ctrl+A inside the list. These two paths are
 **not equivalent** and the spec does not claim they are: from a
 *partially* selected state, the header follows "any visible checked →
-clear", while Cmd/Ctrl+A follows the standard listbox "select all (then a
-second press deselects all)". Different outcomes from the same mixed
-start. Both route through `mergeVisibleSelection` and neither can drop a
-hidden-selected card, so the divergence is accepted and documented rather
-than reconciled (reconciling would change shipped #84 behavior + tests).
-A test asserts the header reads checked, not mixed, after Cmd/Ctrl+A.
+clear", while Cmd/Ctrl+A just selects all shown. (RAC's select-all
+shortcut is **not** a toggle — it calls `selectAll()`, which is a no-op
+once everything shown is selected; a second press does nothing.) Different
+outcomes from the same mixed start. Both route through
+`mergeVisibleSelection` and neither can drop a hidden-selected card, so
+the divergence is accepted and documented rather than reconciled
+(reconciling would change shipped #84 behavior + tests). A test asserts
+the header reads checked, not mixed, after Cmd/Ctrl+A.
 
 The sidebar count, Select-all link, Apply/Cancel, Print-button disable,
-and empty-selection messaging are untouched. Empty selection is reachable
-via header-clear or a second Cmd/Ctrl+A (Shift can't reach it — it's
-additive); the existing disabled-Print + "Select at least 1 card" state
-handles it, unchanged.
+and empty-selection messaging are untouched. The keyboard route to an
+empty selection is the header checkbox (Space) — Cmd/Ctrl+A only ever
+selects, and Shift is additive, so neither clears; the existing
+disabled-Print + "Select at least 1 card" state handles empty, unchanged.
 
 ### Anchor across view changes
 

--- a/docs/superpowers/specs/2026-05-24-print-range-selection-design.md
+++ b/docs/superpowers/specs/2026-05-24-print-range-selection-design.md
@@ -93,6 +93,13 @@ plain-clicked card, after its own toggle) to the clicked card to the
 unselected cards in between); anchor deselected → the range *clears*. Plain
 and Cmd/Ctrl click toggle one card.
 
+There's no formal standard for the *edge* behaviors (Finder, Gmail, etc. all
+differ), so we match **Gmail**, since it's a checkbox list like ours:
+*extending* the range includes the clicked card, but *shrinking* it back
+inward (Shift-clicking nearer the anchor) excludes the clicked card and drops
+everything out to the previous extent — e.g. click 1 → Shift-5 → Shift-3
+leaves {1, 2}, not {1, 2, 3}. (Finder keeps the clicked card; we don't.)
+
 RAC's `ListBox` does **not** provide this rule, so it's layered on with care.
 Three RAC behaviors (verified against the installed 1.17.0 source) shaped
 the implementation:
@@ -100,12 +107,17 @@ the implementation:
 1. **Shift-extend is additive-only.** `SelectionManager.extendSelection`
    always `.add()`s the anchor→target range; it never deselects. So we
    can't lean on RAC for the clear/fill rule — on a Shift-click we recompute
-   the range from the pre-click selection and overwrite RAC's result.
+   the range and overwrite RAC's result. We rebuild from a **base snapshot**
+   taken when the anchor was set (not the live draft), so a second
+   Shift-click from the same anchor *re-bases* the range rather than stacking
+   on the prior range, and we track the range's moving end (`extentRef`) to
+   tell an extend (include the clicked card) from a shrink (exclude it).
 2. **No anchor is recorded on a *deselecting* click** (`toggleSelection`
    sets `anchorKey` only when adding). So "click a card to start,
    Shift-click another to clear the run" has no RAC anchor. We track our
    **own** anchor: a `data-card-id` on each `ListBoxItem`, read in
-   `onPointerDownCapture` on every plain (non-Shift) click.
+   `onPointerDownCapture` on every plain (non-Shift) click that lands on an
+   option (a stray Shift+pointerdown on chrome can't set the flag).
 3. **`onSelectionChange` is suppressed when the result is unchanged**
    (an `!equalSets` guard) — exactly the deselect-an-already-selected-range
    case, so a change-handler override would never fire. We enable

--- a/docs/superpowers/specs/2026-05-24-print-range-selection-design.md
+++ b/docs/superpowers/specs/2026-05-24-print-range-selection-design.md
@@ -1,0 +1,249 @@
+# Print selection: Drive-style range selection
+
+## Problem
+
+The "Choose cards to print" modal (`PrintSelectionModal`, shipped in
+#84) lists each renderable card with its own independent checkbox.
+Selecting a subset means toggling cards one at a time, or hitting the
+header "select all shown" and then unchecking the ones you don't want.
+
+For the common goal — grab a contiguous run of recently-edited cards
+("everything I've touched since last week"), which the default recency
+sort already floats to the top of the list — there's no fast gesture.
+Narrowing a 20-card deck to its 12 newest is 12 clicks (or 8 unchecks
+after select-all). Every other list-selection UI the user reaches for
+(Google Drive, Gmail, the macOS Finder) lets them click one item and
+Shift-click another to take the whole range in two clicks.
+
+## Goals
+
+- **One-gesture range select.** Click the first card, Shift-click the
+  last → every card between them (inclusive) is selected. The Drive /
+  Gmail / file-manager convention.
+- **Keyboard parity, not a lesser path.** Keyboard-only users get the
+  *same* range power: arrow to a card, Space to toggle, Shift+↑/↓ (and
+  Shift+Home/End) to extend a range, Cmd/Ctrl+A to select all shown,
+  type-ahead to jump by name.
+- **Additive single toggle.** Cmd/Ctrl-click toggles one card without
+  disturbing the rest — like Drive's checkbox column.
+- **Everything else is preserved exactly.** Name search, the kind
+  filter (All / Items / Spells), the sort selector with its **recency
+  default and Name option**, the header "select all shown" tri-state,
+  the "hidden by filters — still included when you Apply" footer line +
+  Clear-filters link, Apply/Cancel, and the whole `PrintView` sidebar —
+  all unchanged in behavior.
+- **No regression to print output.** The pipeline downstream of the
+  modal still receives the same `Set<CardId>`.
+
+## Non-goals
+
+- **No discoverability affordance, for now.** No "Tip: Shift-click to
+  select a range" hint or equivalent. Range-select is treated as an
+  expected affordance (Drive/Gmail add no hint either). Explicitly
+  deferred — revisit only if real use shows users miss it.
+- **No recency/date *filter*.** ("Edited this week / since a date.")
+  The existing recency *sort* already surfaces recent cards at the top
+  and is preserved; a date filter is a possible future follow-up, out
+  of scope here. Considered and deferred so this change stays a pure
+  interaction-layer upgrade.
+- **No "true Finder" destructive plain-click.** A plain click or Space
+  toggles a card; it never clears the rest of the selection. The
+  checked set *is* the print output, so a click that wipes the prior
+  selection would be a footgun. (This is why Finder's model was rejected
+  in favour of Drive's checkbox-column model.)
+- **No changes to filters/search/sort logic, the sidebar,
+  `usePrintSelection`, the print pipeline, page layout, or the `Card`
+  component.** Only how the list renders and how selection is driven
+  changes.
+
+## Approach
+
+Replace the hand-rolled `<ul>` of name-labelled `lib/ui/Checkbox` rows
+with a `react-aria-components` **`GridList`** in
+`selectionMode="multiple"`, `selectionBehavior="toggle"`. RAC's
+selection manager then provides the entire Drive-style interaction
+model — for both pointer and keyboard — conforming to the WAI-ARIA
+selection pattern, with roving focus, the selection anchor, and
+`aria-selected` announcements handled by the library:
+
+- **Pointer:** click toggles a card; Shift-click selects the range from
+  the anchor to the clicked card; Cmd/Ctrl-click toggles a single card.
+- **Keyboard:** ↑/↓ move focus; Space toggles the focused card;
+  Shift+↑/↓ and Shift+Home/End extend a contiguous range; Cmd/Ctrl+A
+  selects all shown; type-ahead jumps by card name.
+
+Each row still renders a real selection checkbox
+(`<Checkbox slot="selection">`), preserving the visible, clickable
+checkbox affordance from today's UI and from Drive/Gmail. The range
+anchor is managed internally by RAC.
+
+**Why `GridList` over a hand-rolled Shift-click handler.** The mouse
+part (Shift-click range) is easy to hand-roll; the *keyboard* part —
+Shift+Arrow range extension, roving focus, select-all, type-ahead, and
+correct `aria-multiselectable` / `aria-selected` semantics — is exactly
+the part that's easy to get subtly wrong by hand, and it's the direct
+answer to the a11y concern that motivated this work. RAC owns it. The
+cost is a refactor of one component plus a selector migration in its
+tests (see Tests).
+
+### Escape must close the dialog, not clear selection
+
+RAC's `GridList` defaults to `escapeKeyBehavior="clearSelection"` —
+pressing Escape inside the list would clear the selection instead of
+bubbling up to close the modal. The modal's current contract is
+"Escape = Cancel = close, discarding the draft". So the `GridList` must
+set **`escapeKeyBehavior="none"`** so Escape propagates to the Dialog
+and closes it, preserving today's behavior. This is a known gotcha and
+gets its own test.
+
+### Source of truth and the filter/search interaction
+
+`draft: Set<CardId>` remains the single source of truth for what will
+print — unchanged. The `GridList` is a *controlled selection view over
+only the visible (post-filter, post-search) cards*:
+
+- `selectedKeys` = the visible cards that are in `draft`.
+- `onSelectionChange(keys)` merges the new visible selection back with
+  the selected-but-hidden cards:
+  - `hidden` = `draft` minus the currently visible ids (cards selected
+    but filtered out),
+  - `keys === "all"` (the Cmd/Ctrl+A sentinel) resolves to all visible
+    ids,
+  - `next = hidden ∪ resolvedVisibleSelection`.
+
+  We always resolve to a concrete `Set` and never pass the `"all"`
+  sentinel back into `selectedKeys`.
+
+This preserves today's contract exactly: filters/search change only
+which rows are *shown*, never the selection; selected-but-hidden cards
+stay selected and still print; the "N selected cards are hidden by
+filters — still included when you Apply" footer line and its "Clear
+filters" link behave as before. Range selection necessarily operates
+only over visible rows (you can't range across a hidden card), which is
+the correct and expected behavior. The merge helper is the one genuinely
+new piece of logic — it's the same shape as today's `onHeaderToggle`,
+which already splits visible vs. hidden.
+
+### Header "select all shown" and sidebar
+
+The header tri-state checkbox ("Select all shown cards" + "X of Y
+shown" status) stays, sitting *outside* the `GridList` (GridList has no
+built-in header). It drives the same visible-selection merge:
+clear-all-visible / select-all-visible per the existing two-outcome
+rule, with the indeterminate (`mixed`) state when only some visible
+cards are selected. Keyboard users additionally get Cmd/Ctrl+A inside
+the list as an equivalent select-all-shown. The sidebar count,
+Select-all link, Apply/Cancel, Print-button disable, and
+empty-selection messaging are untouched.
+
+## Accessibility
+
+This is the heart of the change.
+
+- The list becomes a `role="grid"` (`GridList`) with
+  `aria-multiselectable`, each card a `role="row"` carrying
+  `aria-selected`. RAC manages roving focus, the selection anchor, and
+  selection announcements.
+- **Keyboard parity with the pointer** — the direct answer to "how does
+  range-select work for keyboard-only users": Space toggles the focused
+  card; Shift+↑/↓ and Shift+Home/End extend a contiguous range;
+  Cmd/Ctrl+A selects all shown; type-ahead by name. Same power as the
+  mouse, same as Drive.
+- Each row keeps a real selection checkbox, and the row's `textValue` is
+  the card name so type-ahead and the row's accessible name are by name.
+- `escapeKeyBehavior="none"` so Escape closes the dialog (Cancel),
+  matching today.
+- Preserved as-is: the header checkbox's `aria-checked="mixed"`
+  indeterminate state and stable action-verb name ("Select all shown
+  cards") with "X of Y shown" as adjacent status text via
+  `aria-describedby`; the single polite live region announcing the
+  selected total; focus-on-open landing on the search input; and
+  focus-return-on-close to the "Choose cards…" button.
+- No discoverability hint is added (deferred); the affordance relies on
+  convention.
+
+## Components
+
+- **`PrintSelectionModal.tsx`** — the list rendering changes from
+  `<ul>` + per-row `Checkbox` to a RAC `GridList` + `GridListItem`s. The
+  `draft` state, search/kind-filter/sort, header checkbox, footer, and
+  Apply/Cancel wiring are adapted but functionally preserved. The
+  `selectedKeys` ↔ `draft` merge (hidden ∪ visible, plus the `"all"`
+  sentinel) is the one new piece of logic.
+- **`PrintSelectionModal.module.css`** — the row layout (name / kind /
+  time grid) moves onto GridList rows/items; visual parity with today's
+  rows is a requirement. (This modal is screen UI, not print-sensitive,
+  so styling changes here are safe — but it should look unchanged apart
+  from selection behavior.)
+- **No changes** to `PrintView.tsx`, `deckListing.ts`,
+  `usePrintSelection.ts`, the sidebar, or any print-output code.
+
+**Implementation notes for the plan:**
+
+- Confirm RAC `GridList`'s selection-checkbox labeling and how the row
+  accessible name composes (name alone vs. name + kind + time) — this
+  determines the test selectors. Verify early.
+- Verify whether `lib/ui/Checkbox` can be reused via `slot="selection"`
+  or whether a thin GridList-specific selection checkbox is cleaner.
+- If `GridList`'s real-checkbox rendering proves awkward, a `ListBox`
+  (`role="listbox"` / `role="option"` with decorative checkbox visuals)
+  is the lighter alternative with the *same* selection semantics; the
+  plan may choose it after a short spike. Either way the external
+  behavior in Tests must hold.
+
+## Tests
+
+**Migration.** Most existing modal tests keep their *assertions* but
+change *selectors*: rows are queried by
+`getByRole("row", { name: /CardName/ })` and asserted via
+`aria-selected`, replacing `getByRole("checkbox", { name })` /
+`toBeChecked()`. The behavior tests for search, kind filter, sort
+(recency default + Name), header select-all, hidden-by-filters line,
+Apply count, and Cancel are all preserved with updated selectors. This
+mechanical migration is the bulk of the diff.
+
+**New behavior tests** (against accessible roles):
+
+- Click one card, then Shift-click a card further down → every card in
+  the inclusive range (recency order) is selected; cards outside it are
+  not.
+- Range *deselect*: from an all-selected list, toggle one card off, then
+  Shift-click another → the range takes the toggled state. (Pin the
+  exact state RAC produces rather than assuming it.)
+- Cmd/Ctrl-click toggles a single card without changing the others.
+- Keyboard: focus a row, Shift+↓ extends selection to the next row(s);
+  Cmd/Ctrl+A selects all shown; Space toggles the focused row.
+- Range selection spans only visible rows: with a filter hiding a card
+  whose recency position falls between the anchor and target, that
+  hidden card is unaffected, and the Apply total + hidden-by-filters
+  line still reconcile.
+- Escape closes the modal (Cancel) rather than only clearing the
+  selection.
+- The list exposes `aria-multiselectable` and rows expose
+  `aria-selected` (sanity check on the ARIA pattern).
+
+## Risks
+
+- **Test selector migration surface.** The change touches most existing
+  modal tests. They're role-based and the behaviors are unchanged, so
+  it's mechanical — but confirm the row accessible name early so the new
+  selectors are right the first time.
+- **Controlled selection over a filtered collection.** The
+  `selectedKeys` ↔ `draft` merge (hidden ∪ visible, plus the `"all"`
+  sentinel) is the one subtle bit. Get it wrong and either
+  hidden-selected cards drop out on a selection change, or Cmd/Ctrl+A
+  over-selects. Covered by the hidden-range test.
+- **Exact Shift-range semantics.** RAC defines the resulting state of a
+  Shift-extension; the plan should pin it with a test rather than
+  assume, and confirm it matches the "click first, Shift-click last →
+  both ends and everything between selected" expectation for the
+  recency use case.
+- **Escape behavior regression.** Easy to miss `escapeKeyBehavior`;
+  without it, Escape stops closing the modal. Covered by a test.
+
+## Forward compatibility
+
+If a second multi-select list with range selection appears (e.g. bulk
+PDF export of decks), the `GridList` + filter + header-select-all
+arrangement could extract into a `src/lib/ui/` primitive. One consumer
+isn't a pattern; revisit when there's a second.

--- a/docs/superpowers/specs/2026-05-24-print-range-selection-design.md
+++ b/docs/superpowers/specs/2026-05-24-print-range-selection-design.md
@@ -21,9 +21,10 @@ Shift-click another to take the whole range in two clicks.
   last → every card between them (inclusive) is selected. The Drive /
   Gmail / file-manager convention.
 - **Keyboard parity, not a lesser path.** Keyboard-only users get the
-  *same* range power: arrow to a card, Space to toggle, Shift+↑/↓ (and
-  Shift+Home/End) to extend a range, Cmd/Ctrl+A to select all shown,
-  type-ahead to jump by name.
+  *same* range power: arrow to a card (moves focus only), Space to
+  toggle, **Shift+↑/↓ to extend a range** (and Cmd/Ctrl+Shift+Home/End
+  to extend to an end), Cmd/Ctrl+A to select all shown, type-ahead to
+  jump by name.
 - **Additive single toggle.** Cmd/Ctrl-click toggles one card without
   disturbing the rest — like Drive's checkbox column.
 - **Everything else is preserved exactly.** Name search, the kind
@@ -37,10 +38,12 @@ Shift-click another to take the whole range in two clicks.
 
 ## Non-goals
 
-- **No discoverability affordance, for now.** No "Tip: Shift-click to
-  select a range" hint or equivalent. Range-select is treated as an
-  expected affordance (Drive/Gmail add no hint either). Explicitly
-  deferred — revisit only if real use shows users miss it.
+- **No discoverability affordance, for this iteration.** No "Tip:
+  Shift-click to select a range" hint or coachmark. Per decision, the
+  affordance relies on convention. (Review flagged a one-line static
+  hint as near-zero-cost and worth reconsidering, since this is a
+  rare-use tool with no analytics to detect a missed gesture — recorded
+  as a fast follow, not built here.)
 - **No recency/date *filter*.** ("Edited this week / since a date.")
   The existing recency *sort* already surfaces recent cards at the top
   and is preserved; a date filter is a possible future follow-up, out
@@ -59,60 +62,102 @@ Shift-click another to take the whole range in two clicks.
 ## Approach
 
 Replace the hand-rolled `<ul>` of name-labelled `lib/ui/Checkbox` rows
-with a `react-aria-components` **`GridList`** in
-`selectionMode="multiple"`, `selectionBehavior="toggle"`. RAC's
-selection manager then provides the entire Drive-style interaction
-model — for both pointer and keyboard — conforming to the WAI-ARIA
-selection pattern, with roving focus, the selection anchor, and
-`aria-selected` announcements handled by the library:
+with a `react-aria-components` **`ListBox`** in `selectionMode="multiple"`,
+`selectionBehavior="toggle"`. RAC's selection manager then provides the
+entire Drive-style interaction model — for both pointer and keyboard —
+conforming to the WAI-ARIA listbox pattern, with roving focus, the
+selection anchor, and `aria-selected` announcements handled by the
+library:
 
 - **Pointer:** click toggles a card; Shift-click selects the range from
   the anchor to the clicked card; Cmd/Ctrl-click toggles a single card.
-- **Keyboard:** ↑/↓ move focus; Space toggles the focused card;
-  Shift+↑/↓ and Shift+Home/End extend a contiguous range; Cmd/Ctrl+A
+- **Keyboard:** ↑/↓ move focus *without* changing selection
+  (`selectOnFocus` is `false` under `toggle` behavior); Space toggles
+  the focused card; Shift+↑/↓ extend a contiguous range; Cmd/Ctrl+A
   selects all shown; type-ahead jumps by card name.
 
-Each row still renders a real selection checkbox
-(`<Checkbox slot="selection">`), preserving the visible, clickable
-checkbox affordance from today's UI and from Drive/Gmail. The range
-anchor is managed internally by RAC.
+### Why `ListBox`, not `GridList`
 
-**Why `GridList` over a hand-rolled Shift-click handler.** The mouse
-part (Shift-click range) is easy to hand-roll; the *keyboard* part —
-Shift+Arrow range extension, roving focus, select-all, type-ahead, and
-correct `aria-multiselectable` / `aria-selected` semantics — is exactly
-the part that's easy to get subtly wrong by hand, and it's the direct
-answer to the a11y concern that motivated this work. RAC owns it. The
-cost is a refactor of one component plus a selector migration in its
-tests (see Tests).
+These rows are a single column of selectable items with **no
+interactive children** — just name, kind, and a timestamp, all text.
+That is the textbook `role="listbox"` / `role="option"` case. `GridList`
+(`role="grid"`/`row`/`gridcell`) is for rows that contain focusable
+controls reachable by arrow/tab navigation — which is why the icon
+picker (`IconPickerDialog`, genuinely 2-D) correctly uses it, and why
+this list should not. Verified against the installed
+`react-aria-components@1.17.0` source, `ListBox` gives us, equivalently
+to GridList: `selectionMode="multiple"` + `selectionBehavior="toggle"`,
+Shift+Arrow range extension, Cmd/Ctrl+A, Shift-click / Cmd-click,
+type-ahead, and the same `escapeKeyBehavior` prop. ListBox is the better
+fit for three concrete reasons:
+
+1. **No double-announcement.** `GridList` ships its own selection
+   `LiveAnnouncer` (`useGridSelectionAnnouncement`) that speaks on every
+   in-grid selection change. `ListBox` ships **none** — selection is
+   conveyed purely via `aria-selected`. So the modal's existing single
+   polite "N cards selected" region stays the *sole* announcer; with
+   GridList it would double-speak.
+2. **Cleaner SR semantics** — a list of options announces as a list, not
+   a one-column table.
+3. **No anti-pattern.** A real focusable checkbox is invalid inside
+   `role="option"` (RAC enforces "checkboxes are not allowed inside a
+   listbox"), so the per-row checkbox becomes a **decorative,
+   `aria-hidden` visual** driven by the option's `isSelected` render
+   prop — selection state is carried by `aria-selected`, the glyph is
+   presentation only. (In a GridList it would be a real
+   `<Checkbox slot="selection">`; we don't want that here.)
+
+The cost is a refactor of one component plus a selector migration in its
+tests (`checkbox`→`option`); see Tests.
 
 ### Escape must close the dialog, not clear selection
 
-RAC's `GridList` defaults to `escapeKeyBehavior="clearSelection"` —
-pressing Escape inside the list would clear the selection instead of
-bubbling up to close the modal. The modal's current contract is
-"Escape = Cancel = close, discarding the draft". So the `GridList` must
-set **`escapeKeyBehavior="none"`** so Escape propagates to the Dialog
-and closes it, preserving today's behavior. This is a known gotcha and
-gets its own test.
+RAC's selection layer defaults `escapeKeyBehavior="clearSelection"` —
+pressing Escape inside the list would clear the selection (when
+non-empty) instead of bubbling up to close the modal. The modal's
+contract is "Escape = Cancel = close, discarding the draft". So the
+`ListBox` sets **`escapeKeyBehavior="none"`** so Escape propagates to the
+Dialog. Confirmed present on `ListBox` in 1.17.0. Gets its own test.
 
 ### Source of truth and the filter/search interaction
 
 `draft: Set<CardId>` remains the single source of truth for what will
-print — unchanged. The `GridList` is a *controlled selection view over
+print — unchanged. The `ListBox` is a *controlled selection view over
 only the visible (post-filter, post-search) cards*:
 
-- `selectedKeys` = the visible cards that are in `draft`.
+- `selectedKeys` = the visible cards that are in `draft`, `useMemo`'d
+  over `[draft, visibleIds]`.
 - `onSelectionChange(keys)` merges the new visible selection back with
-  the selected-but-hidden cards:
-  - `hidden` = `draft` minus the currently visible ids (cards selected
-    but filtered out),
-  - `keys === "all"` (the Cmd/Ctrl+A sentinel) resolves to all visible
-    ids,
+  the selected-but-hidden cards. This logic is extracted into a **pure,
+  unit-tested helper** rather than living inline:
+
+  ```ts
+  // printSelectionMerge.ts — colocated with printSelectionLabel.ts
+  mergeVisibleSelection(
+    draft: Set<CardId>,
+    visibleIds: CardId[],
+    keys: Selection,        // RAC: "all" | Set<Key>
+  ): Set<CardId>
+  ```
+
+  - `hidden` = `draft` minus `visibleIds` (cards selected but filtered
+    out),
+  - `keys === "all"` (the Cmd/Ctrl+A sentinel) resolves to all
+    `visibleIds` — and *only* visible ids, because the ListBox's
+    collection is fed only the visible cards, so RAC's `"all"` can only
+    mean "all visible",
   - `next = hidden ∪ resolvedVisibleSelection`.
 
-  We always resolve to a concrete `Set` and never pass the `"all"`
-  sentinel back into `selectedKeys`.
+  The helper always resolves to a concrete `Set` (never re-emits the
+  `"all"` sentinel) and is **idempotent**: re-applying the current
+  visible selection yields a content-equal `draft`. This matters under
+  React `StrictMode` (double-invoked renders) and because
+  `onSelectionChange` calls `setDraft`.
+
+Extracting the helper is also the mitigation for the test-feasibility
+risk below: it puts the *correctness* of the merge (hidden∪visible, the
+`"all"` sentinel, empty-visible) under fast deterministic unit tests
+that don't depend on whether jsdom can fake a Shift-pointer.
 
 This preserves today's contract exactly: filters/search change only
 which rows are *shown*, never the selection; selected-but-hidden cards
@@ -120,130 +165,216 @@ stay selected and still print; the "N selected cards are hidden by
 filters — still included when you Apply" footer line and its "Clear
 filters" link behave as before. Range selection necessarily operates
 only over visible rows (you can't range across a hidden card), which is
-the correct and expected behavior. The merge helper is the one genuinely
-new piece of logic — it's the same shape as today's `onHeaderToggle`,
-which already splits visible vs. hidden.
+the correct and expected behavior. The merge is the same *shape* as
+today's `onHeaderToggle` (`PrintSelectionModal.tsx:49`), which already
+splits visible vs. hidden — it's a generalization, not a new concept.
 
 ### Header "select all shown" and sidebar
 
 The header tri-state checkbox ("Select all shown cards" + "X of Y
-shown" status) stays, sitting *outside* the `GridList` (GridList has no
-built-in header). It drives the same visible-selection merge:
-clear-all-visible / select-all-visible per the existing two-outcome
-rule, with the indeterminate (`mixed`) state when only some visible
-cards are selected. Keyboard users additionally get Cmd/Ctrl+A inside
-the list as an equivalent select-all-shown. The sidebar count,
-Select-all link, Apply/Cancel, Print-button disable, and
-empty-selection messaging are untouched.
+shown" status) stays, sitting *outside* the `ListBox`. It drives the
+same `mergeVisibleSelection` path: clear-all-visible / select-all-visible
+per the existing two-outcome rule, with the indeterminate (`mixed`)
+state when only some visible cards are selected. Keyboard users
+additionally get Cmd/Ctrl+A inside the list as an equivalent
+select-all-shown.
+
+Note one accepted divergence between the two select-all paths: from a
+*partially* selected state, the header follows its "any visible checked →
+clear" rule, while RAC's Cmd/Ctrl+A follows "select all, then a second
+press deselects all". Different outcomes from the same mixed start, but
+both routes go through `mergeVisibleSelection` and neither can drop a
+hidden-selected card, so the divergence is acceptable and documented
+rather than reconciled. (Test asserts that after Cmd/Ctrl+A the header
+reads checked, not mixed.)
+
+The sidebar count, Select-all link, Apply/Cancel, Print-button disable,
+and empty-selection messaging are untouched.
+
+### Anchor across view changes
+
+The range anchor is managed internally by RAC, keyed by item. The
+modal mutates the visible collection constantly (search-as-you-type,
+kind filter, sort flip), so the anchor's referent can move or vanish:
+
+- If the anchor card is filtered/searched out of the collection, a
+  subsequent Shift-click extends from RAC's current focus fallback, not
+  from the now-absent card.
+- If the sort flips, the anchor's *visual position* changes, so a
+  Shift-click spans a different visual run than before the flip.
+
+This is accepted: it is fine for the anchor to reset/relocate when the
+collection changes, as long as the result is sensible and **never
+destructive**. The merge guarantees the worst case is mis-selecting some
+*visible* rows (fully recoverable by the user), never dropping a
+hidden-selected card. A test pins that Shift-click after a sort change
+produces a sane, non-destructive selection.
+
+### Touch and pointers without modifiers
+
+Range-select is inherently a modifier gesture; there is no Shift or Cmd
+key on touch. On touch (and any modifier-less pointer), tapping a card
+**toggles** it — additive and non-destructive, because
+`selectionBehavior="toggle"` makes a plain press a toggle, never a
+replace. So touch users keep exactly today's one-tap-per-card behavior;
+the range gesture simply doesn't exist for them. Their fast path is the
+header "select all shown" + recency sort (tap select-all, then tap off
+the few they don't want). This limitation is stated, not hidden, and a
+test confirms a plain tap toggles rather than replaces the selection.
 
 ## Accessibility
 
-This is the heart of the change.
-
-- The list becomes a `role="grid"` (`GridList`) with
-  `aria-multiselectable`, each card a `role="row"` carrying
-  `aria-selected`. RAC manages roving focus, the selection anchor, and
-  selection announcements.
+- The list becomes `role="listbox"` with `aria-multiselectable`, each
+  card a `role="option"` carrying `aria-selected`; the list gets an
+  `aria-label` (e.g. "Cards to print"). RAC manages roving focus, the
+  selection anchor, and focus order.
 - **Keyboard parity with the pointer** — the direct answer to "how does
-  range-select work for keyboard-only users": Space toggles the focused
-  card; Shift+↑/↓ and Shift+Home/End extend a contiguous range;
-  Cmd/Ctrl+A selects all shown; type-ahead by name. Same power as the
-  mouse, same as Drive.
-- Each row keeps a real selection checkbox, and the row's `textValue` is
-  the card name so type-ahead and the row's accessible name are by name.
-- `escapeKeyBehavior="none"` so Escape closes the dialog (Cancel),
-  matching today.
+  range-select work for keyboard-only users": arrow moves focus only,
+  Space toggles, Shift+↑/↓ extend a range (Cmd/Ctrl+Shift+Home/End to an
+  end), Cmd/Ctrl+A selects all shown, type-ahead by name. Same power as
+  the mouse.
+- **One announcer.** ListBox emits no selection live-announcements
+  (verified), so the modal's single existing polite region
+  (`PrintSelectionModal.tsx:182`) announces the running total and is the
+  *only* selection announcer — no double-speak. It covers both header
+  select-all and in-list selection changes.
+- **`textValue={card.name}`** so type-ahead jumps by name; the kind and
+  the relative timestamp stay `aria-hidden` row decoration (as today),
+  so the option's accessible name is exactly the card name and
+  `getByRole("option", { name })` resolves cleanly. The decorative
+  checkbox glyph is `aria-hidden` and not a focusable/queryable control.
+- **`escapeKeyBehavior="none"`** so Escape closes the dialog (Cancel).
+- **Tab model change (called out):** today every row checkbox is its own
+  Tab stop; the ListBox is a single Tab stop with arrow-key roving. Tab
+  order: search input → kind toggles → sort → header checkbox → (one Tab
+  into the listbox; arrows within) → footer "Clear filters" link →
+  Cancel/Apply. The header checkbox precedes the list and remains
+  reachable. Net improvement for most, but it is a behavior change for
+  Tab-only users; without a hint (deferred) it relies on the standard
+  listbox interaction model.
+- **Empty state** uses ListBox's `renderEmptyState` to keep "No cards
+  match." (a bare `<li>` would be an invalid listbox child).
 - Preserved as-is: the header checkbox's `aria-checked="mixed"`
   indeterminate state and stable action-verb name ("Select all shown
   cards") with "X of Y shown" as adjacent status text via
-  `aria-describedby`; the single polite live region announcing the
-  selected total; focus-on-open landing on the search input; and
-  focus-return-on-close to the "Choose cards…" button.
-- No discoverability hint is added (deferred); the affordance relies on
-  convention.
+  `aria-describedby`; focus-on-open landing on the search input;
+  focus-return-on-close to the "Choose cards…" button; and the focused
+  option carrying the existing `--color-focus-ring` outline.
 
 ## Components
 
 - **`PrintSelectionModal.tsx`** — the list rendering changes from
-  `<ul>` + per-row `Checkbox` to a RAC `GridList` + `GridListItem`s. The
-  `draft` state, search/kind-filter/sort, header checkbox, footer, and
-  Apply/Cancel wiring are adapted but functionally preserved. The
-  `selectedKeys` ↔ `draft` merge (hidden ∪ visible, plus the `"all"`
-  sentinel) is the one new piece of logic.
+  `<ul>` + per-row `Checkbox` to a RAC `ListBox` + `ListBoxItem`s with a
+  decorative checkbox glyph. The `draft` state, search/kind-filter/sort,
+  header checkbox, footer, and Apply/Cancel wiring are adapted but
+  functionally preserved. `selectedKeys` is `useMemo`'d; selection
+  changes call the new merge helper.
+- **`printSelectionMerge.ts`** (new) + **`printSelectionMerge.test.ts`**
+  — the pure `mergeVisibleSelection` helper, colocated with the existing
+  `printSelectionLabel.ts`. This is the one genuinely new unit of logic
+  and owns selection correctness.
 - **`PrintSelectionModal.module.css`** — the row layout (name / kind /
-  time grid) moves onto GridList rows/items; visual parity with today's
-  rows is a requirement. (This modal is screen UI, not print-sensitive,
-  so styling changes here are safe — but it should look unchanged apart
-  from selection behavior.)
+  time grid) moves onto listbox options; the focus ring and selected
+  styling carry over. Visual parity with today's rows is a requirement.
+  (This modal is screen UI, not print-sensitive, so styling changes here
+  are safe.)
 - **No changes** to `PrintView.tsx`, `deckListing.ts`,
   `usePrintSelection.ts`, the sidebar, or any print-output code.
 
-**Implementation notes for the plan:**
-
-- Confirm RAC `GridList`'s selection-checkbox labeling and how the row
-  accessible name composes (name alone vs. name + kind + time) — this
-  determines the test selectors. Verify early.
-- Verify whether `lib/ui/Checkbox` can be reused via `slot="selection"`
-  or whether a thin GridList-specific selection checkbox is cleaner.
-- If `GridList`'s real-checkbox rendering proves awkward, a `ListBox`
-  (`role="listbox"` / `role="option"` with decorative checkbox visuals)
-  is the lighter alternative with the *same* selection semantics; the
-  plan may choose it after a short spike. Either way the external
-  behavior in Tests must hold.
+**Implementation note:** the decorative checkbox is rendered off the
+`ListBoxItem` `isSelected` render prop (children-as-function or
+`data-selected`), `aria-hidden`, no `role`. Confirm the existing
+`.box` checkbox visual from `lib/ui/Checkbox.module.css` can be reused as
+pure presentation, or factor a small shared glyph.
 
 ## Tests
 
-**Migration.** Most existing modal tests keep their *assertions* but
-change *selectors*: rows are queried by
-`getByRole("row", { name: /CardName/ })` and asserted via
-`aria-selected`, replacing `getByRole("checkbox", { name })` /
-`toBeChecked()`. The behavior tests for search, kind filter, sort
-(recency default + Name), header select-all, hidden-by-filters line,
-Apply count, and Cancel are all preserved with updated selectors. This
-mechanical migration is the bulk of the diff.
+Tests split into three layers so correctness doesn't hinge on whether
+jsdom can drive modifier gestures (see Risks):
 
-**New behavior tests** (against accessible roles):
+**(a) Pure unit tests — `printSelectionMerge.test.ts`** (no RAC, fast,
+deterministic; these own correctness):
+- hidden ∪ visible: a selected-but-hidden card survives a visible
+  selection change.
+- `"all"` sentinel resolves to all visible ids (and only those).
+- empty visible set (filtered to nothing) does not drop hidden-selected
+  cards.
+- idempotency: re-applying the current visible selection yields a
+  content-equal set.
 
-- Click one card, then Shift-click a card further down → every card in
-  the inclusive range (recency order) is selected; cards outside it are
-  not.
-- Range *deselect*: from an all-selected list, toggle one card off, then
-  Shift-click another → the range takes the toggled state. (Pin the
-  exact state RAC produces rather than assuming it.)
-- Cmd/Ctrl-click toggles a single card without changing the others.
-- Keyboard: focus a row, Shift+↓ extends selection to the next row(s);
-  Cmd/Ctrl+A selects all shown; Space toggles the focused row.
-- Range selection spans only visible rows: with a filter hiding a card
-  whose recency position falls between the anchor and target, that
-  hidden card is unaffected, and the Apply total + hidden-by-filters
-  line still reconcile.
-- Escape closes the modal (Cancel) rather than only clearing the
-  selection.
-- The list exposes `aria-multiselectable` and rows expose
-  `aria-selected` (sanity check on the ARIA pattern).
+**(b) Component structure / smoke tests** (no modifier gestures):
+- The list is `role="listbox"` with `aria-multiselectable`; options
+  expose `aria-selected`.
+- `renderEmptyState` shows "No cards match." and hides the "Updated"
+  header (preserves `PrintSelectionModal.test.tsx:147`).
+- Escape closes the modal (Cancel), not just clears selection.
+- Bare ArrowDown/ArrowUp moves focus without changing selection.
+- After Cmd/Ctrl+A the header checkbox reads checked (not mixed).
+- Migration of the existing behavior tests (search, kind filter, sort
+  recency+Name, header select-all, hidden-by-filters line, Apply count,
+  Cancel): assertions preserved, selectors migrated from
+  `getByRole("checkbox", { name })` / `toBeChecked()` to
+  `getByRole("option", { name })` + `aria-selected`.
+
+**(c) Interaction tests — contingent on the spike (see Risks):**
+- Click one card, Shift-click a card further down → the inclusive range
+  (recency order) is selected; cards outside are not.
+- Range *deselect* semantics, pinned to what RAC actually produces in
+  `toggle` behavior (do not assume).
+- Cmd/Ctrl-click toggles a single card without changing others.
+- Shift+↓ extends selection to the next row(s).
+- Range selection spans only visible rows: a card hidden by a filter
+  between the anchor and target is unaffected, and the Apply total +
+  hidden-by-filters line still reconcile.
+- Shift-click after a sort flip is sensible and non-destructive.
+- Touch/plain pointer tap toggles a single card (never replaces).
+
+If a gesture proves undrivable in jsdom, correctness is still covered by
+layer (a); the affected layer-(c) tests become a best-effort/`@react-aria
+/test-utils` or browser-mode follow-up (see Risks).
 
 ## Risks
 
-- **Test selector migration surface.** The change touches most existing
-  modal tests. They're role-based and the behaviors are unchanged, so
-  it's mechanical — but confirm the row accessible name early so the new
-  selectors are right the first time.
+- **jsdom may not reliably drive modifier/pointer gestures** (lead
+  risk). This repo has no precedent for `selectionMode="multiple"`,
+  Shift-click, Cmd-click, or Shift+Arrow in tests, and already had to
+  stub `ResizeObserver` + `clientWidth/Height` in `src/test/setup.ts` to
+  make RAC's Virtualizer survive jsdom. jsdom 29 *does* expose a real
+  `PointerEvent` carrying `shiftKey`, and RAC takes the pointer path, so
+  the gestures are *probably* drivable with modifier-held `user-event`
+  clicks — but it's unproven here. **Mitigation:** (1) the pure helper
+  owns correctness; (2) a **gating spike** as the plan's first task —
+  write one throwaway test driving Shift-click and Shift+↓ against a
+  3-option multi-select ListBox and confirm `aria-selected` updates in
+  this exact jsdom + RAC 1.17.0 + user-event stack. If it works, write
+  layer (c) normally. If not, the fallback is `@react-aria/test-utils`
+  (`ListBoxTester`) — **which requires a dependency add (needs
+  approval)** — or a browser/e2e follow-up; either way layer (a) + (b)
+  still ship.
+- **Exact Shift-range / deselect semantics.** RAC defines the resulting
+  state of a Shift-extension in `toggle` behavior; the headline "select
+  everything since last week" walkthrough depends on it. The spike must
+  determine it and the walkthrough/tests must match whichever model RAC
+  implements (extend-selects-range vs. mirror-anchor-toggle). Either way
+  the operation beats today's per-card path; the click count in the
+  walkthrough is finalized after the spike.
 - **Controlled selection over a filtered collection.** The
-  `selectedKeys` ↔ `draft` merge (hidden ∪ visible, plus the `"all"`
-  sentinel) is the one subtle bit. Get it wrong and either
-  hidden-selected cards drop out on a selection change, or Cmd/Ctrl+A
-  over-selects. Covered by the hidden-range test.
-- **Exact Shift-range semantics.** RAC defines the resulting state of a
-  Shift-extension; the plan should pin it with a test rather than
-  assume, and confirm it matches the "click first, Shift-click last →
-  both ends and everything between selected" expectation for the
-  recency use case.
-- **Escape behavior regression.** Easy to miss `escapeKeyBehavior`;
-  without it, Escape stops closing the modal. Covered by a test.
+  `selectedKeys` ↔ `draft` merge is the subtle bit; get it wrong and
+  hidden-selected cards drop, or Cmd/Ctrl+A over-selects. Covered by the
+  layer-(a) tests and the hidden-range layer-(c) test.
+- **Escape regression.** Easy to miss `escapeKeyBehavior`; without it
+  Escape stops closing the modal. Covered by a test.
+- **Touch users get no range gesture** — accepted and documented; the
+  header select-all + recency sort is their fast path.
+- **Discoverability remains unaddressed** — deferred by decision; review
+  noted a one-line static hint as a near-zero-cost fast follow.
 
 ## Forward compatibility
 
 If a second multi-select list with range selection appears (e.g. bulk
-PDF export of decks), the `GridList` + filter + header-select-all
-arrangement could extract into a `src/lib/ui/` primitive. One consumer
-isn't a pattern; revisit when there's a second.
+PDF export of decks), the `ListBox` + filter + header-select-all
+arrangement plus `mergeVisibleSelection` could extract into a
+`src/lib/ui/` primitive. If such a list ever needs genuinely interactive
+per-row controls, that's the point to revisit `GridList` for it
+specifically. One consumer isn't a pattern; revisit when there's a
+second.

--- a/docs/superpowers/specs/2026-05-24-print-range-selection-design.md
+++ b/docs/superpowers/specs/2026-05-24-print-range-selection-design.md
@@ -7,24 +7,24 @@ The "Choose cards to print" modal (`PrintSelectionModal`, shipped in
 Selecting a subset means toggling cards one at a time, or hitting the
 header "select all shown" and then unchecking the ones you don't want.
 
-For the common goal — grab a contiguous run of recently-edited cards
+For the common goal — keep a contiguous run of recently-edited cards
 ("everything I've touched since last week"), which the default recency
-sort already floats to the top of the list — there's no fast gesture.
-Narrowing a 20-card deck to its 12 newest is 12 clicks (or 8 unchecks
-after select-all). Every other list-selection UI the user reaches for
-(Google Drive, Gmail, the macOS Finder) lets them click one item and
-Shift-click another to take the whole range in two clicks.
+sort already floats to the top of the list — the work is **linear in
+the number of cards toggled**. Narrowing a 20-card deck to its 12 newest
+is 8 unchecks; a 50-card deck to its 30 newest is 20. Every other
+list-selection UI the user reaches for (Google Drive, Gmail, the macOS
+Finder) makes a contiguous range a **constant** two-or-three-gesture
+operation regardless of run length.
 
 ## Goals
 
-- **One-gesture range select.** Click the first card, Shift-click the
-  last → every card between them (inclusive) is selected. The Drive /
-  Gmail / file-manager convention.
+- **Range select in a constant number of gestures.** Click the first
+  card, Shift-click the last → the whole inclusive range is selected, no
+  matter how long. The Drive / Gmail / file-manager convention.
 - **Keyboard parity, not a lesser path.** Keyboard-only users get the
-  *same* range power: arrow to a card (moves focus only), Space to
-  toggle, **Shift+↑/↓ to extend a range** (and Cmd/Ctrl+Shift+Home/End
-  to extend to an end), Cmd/Ctrl+A to select all shown, type-ahead to
-  jump by name.
+  *same* power: arrow to a card (moves focus only), Space to toggle,
+  **Shift+↑/↓ to extend a range** (Cmd/Ctrl+Shift+Home/End to extend to
+  an end), Cmd/Ctrl+A to select all shown, type-ahead to jump by name.
 - **Additive single toggle.** Cmd/Ctrl-click toggles one card without
   disturbing the rest — like Drive's checkbox column.
 - **Everything else is preserved exactly.** Name search, the kind
@@ -36,345 +36,379 @@ Shift-click another to take the whole range in two clicks.
 - **No regression to print output.** The pipeline downstream of the
   modal still receives the same `Set<CardId>`.
 
+Note on what range-select does *not* do: RAC's Shift-extend is
+**additive only** — it selects the anchor→target range, it never
+*deselects* a range (verified in source, see Approach). So from the
+default all-selected state, "drop the oldest tail" is done by
+clear-then-select, not by Shift-deselecting the tail. The walkthrough
+below reflects this.
+
 ## Non-goals
 
-- **No discoverability affordance, for this iteration.** No "Tip:
-  Shift-click to select a range" hint or coachmark. Per decision, the
-  affordance relies on convention. (Review flagged a one-line static
-  hint as near-zero-cost and worth reconsidering, since this is a
-  rare-use tool with no analytics to detect a missed gesture — recorded
-  as a fast follow, not built here.)
-- **No recency/date *filter*.** ("Edited this week / since a date.")
-  The existing recency *sort* already surfaces recent cards at the top
-  and is preserved; a date filter is a possible future follow-up, out
-  of scope here. Considered and deferred so this change stays a pure
-  interaction-layer upgrade.
+- **Discoverability affordance — pending one decision (see Risks).** The
+  default position is to rely on convention with no hint. Review raised a
+  stronger case than "undiscovered new feature": the Tab model changes
+  (see Accessibility), which is a mild *regression* for existing
+  keyboard users, and a single static line ("Use arrow keys to move,
+  Space to select, Shift to extend") would mitigate both the regression
+  and discoverability at near-zero cost. Flagged for the owner; built
+  only if chosen.
+- **No recency/date *filter*.** ("Edited this week / since a date.") The
+  existing recency *sort* already surfaces recent cards at the top and is
+  preserved; a date filter is a possible future follow-up, out of scope.
 - **No "true Finder" destructive plain-click.** A plain click or Space
-  toggles a card; it never clears the rest of the selection. The
-  checked set *is* the print output, so a click that wipes the prior
-  selection would be a footgun. (This is why Finder's model was rejected
-  in favour of Drive's checkbox-column model.)
-- **No changes to filters/search/sort logic, the sidebar,
+  toggles a card; it never clears the rest. The checked set *is* the
+  print output, so a click that wipes the prior selection would be a
+  footgun. (This is why Finder's replace-on-click model was rejected for
+  Drive's checkbox-column model.)
+- **No changes to filter/search/sort logic, the sidebar,
   `usePrintSelection`, the print pipeline, page layout, or the `Card`
-  component.** Only how the list renders and how selection is driven
-  changes.
+  component.**
+
+Scope note: this is *not* a "pure interaction-layer" tweak — be honest
+about the surface. It is a contained rewrite of the modal's card list
+(`<ul>` + per-row `Checkbox` → RAC `ListBox`/`ListBoxItem` with a
+decorative selection glyph), one new pure helper, a CSS migration of the
+row layout onto options, and a **partly non-mechanical** test migration
+(see Tests). The print pipeline, sidebar, and hook are genuinely
+untouched; the modal's list is genuinely rewritten.
 
 ## Approach
 
 Replace the hand-rolled `<ul>` of name-labelled `lib/ui/Checkbox` rows
 with a `react-aria-components` **`ListBox`** in `selectionMode="multiple"`,
 `selectionBehavior="toggle"`. RAC's selection manager then provides the
-entire Drive-style interaction model — for both pointer and keyboard —
-conforming to the WAI-ARIA listbox pattern, with roving focus, the
-selection anchor, and `aria-selected` announcements handled by the
-library:
+entire Drive-style model — pointer and keyboard — conforming to the
+WAI-ARIA listbox pattern, with roving focus, the selection anchor, and
+`aria-selected` handled by the library:
 
-- **Pointer:** click toggles a card; Shift-click selects the range from
-  the anchor to the clicked card; Cmd/Ctrl-click toggles a single card.
+- **Pointer:** click toggles a card; Shift-click selects the additive
+  range from the anchor to the clicked card; Cmd/Ctrl-click toggles a
+  single card.
 - **Keyboard:** ↑/↓ move focus *without* changing selection
-  (`selectOnFocus` is `false` under `toggle` behavior); Space toggles
-  the focused card; Shift+↑/↓ extend a contiguous range; Cmd/Ctrl+A
-  selects all shown; type-ahead jumps by card name.
+  (`selectOnFocus` is `false` under `toggle`); Space toggles; Shift+↑/↓
+  extend the additive range; Cmd/Ctrl+A selects all shown; type-ahead
+  jumps by name.
+
+### Selection semantics are additive (verified)
+
+`react-stately`'s `SelectionManager.extendSelection`
+(`SelectionManager.mjs:127-148`) trims the *previous* extension range
+then `.add()`s the anchor→target range; it never toggles-off based on
+state. Both Shift-click and Shift+Arrow route through it
+(`useSelectableItem.mjs`). The anchor moves only on a toggle-*on*
+(`toggleSelection` sets `anchorKey` when adding, not when removing). So
+Shift always *selects* a range. This is determined fact, not a spike
+question.
+
+**Drivability is proven.** A throwaway spike (a 4-option multi-select
+`toggle` ListBox in this exact jsdom + `react-aria-components@1.17.0` +
+`@testing-library/user-event` stack) confirmed that Shift-click range,
+Cmd/Ctrl-click toggle, and Shift+ArrowDown keyboard extend all update
+`aria-selected` as expected — driven with modifier-held `user.keyboard`
+around `user.click`. So the interaction tests below are writable
+directly in jsdom: **no `@react-aria/test-utils` dependency and no
+browser/e2e harness are required.** (See Validation.)
 
 ### Why `ListBox`, not `GridList`
 
-These rows are a single column of selectable items with **no
-interactive children** — just name, kind, and a timestamp, all text.
-That is the textbook `role="listbox"` / `role="option"` case. `GridList`
-(`role="grid"`/`row`/`gridcell`) is for rows that contain focusable
-controls reachable by arrow/tab navigation — which is why the icon
-picker (`IconPickerDialog`, genuinely 2-D) correctly uses it, and why
-this list should not. Verified against the installed
-`react-aria-components@1.17.0` source, `ListBox` gives us, equivalently
-to GridList: `selectionMode="multiple"` + `selectionBehavior="toggle"`,
-Shift+Arrow range extension, Cmd/Ctrl+A, Shift-click / Cmd-click,
-type-ahead, and the same `escapeKeyBehavior` prop. ListBox is the better
-fit for three concrete reasons:
+These rows are a single column of selectable items with **no interactive
+children** — name, kind, timestamp, all text. That is the textbook
+`role="listbox"`/`option` case. `GridList` (`role="grid"`/`row`/
+`gridcell`) is for rows containing focusable controls reachable by
+arrow/tab navigation — which is why the icon picker (`IconPickerDialog`,
+genuinely 2-D) correctly uses it and this list should not. Verified
+against the installed 1.17.0 source, `ListBox` matches `GridList` on
+`selectionMode="multiple"` + `selectionBehavior="toggle"`, Shift+Arrow,
+Cmd/Ctrl+A, Shift-/Cmd-click, type-ahead, and `escapeKeyBehavior`, and
+is the better fit for three reasons:
 
 1. **No double-announcement.** `GridList` ships its own selection
    `LiveAnnouncer` (`useGridSelectionAnnouncement`) that speaks on every
-   in-grid selection change. `ListBox` ships **none** — selection is
-   conveyed purely via `aria-selected`. So the modal's existing single
-   polite "N cards selected" region stays the *sole* announcer; with
-   GridList it would double-speak.
+   in-grid change. `ListBox` ships **none** (verified) — selection is
+   conveyed via `aria-selected` and roving focus. So the modal's single
+   existing polite region stays the sole *total* announcer; with GridList
+   it would double-speak.
 2. **Cleaner SR semantics** — a list of options announces as a list, not
    a one-column table.
-3. **No anti-pattern.** A real focusable checkbox is invalid inside
-   `role="option"` (RAC enforces "checkboxes are not allowed inside a
-   listbox"), so the per-row checkbox becomes a **decorative,
-   `aria-hidden` visual** driven by the option's `isSelected` render
-   prop — selection state is carried by `aria-selected`, the glyph is
-   presentation only. (In a GridList it would be a real
-   `<Checkbox slot="selection">`; we don't want that here.)
-
-The cost is a refactor of one component plus a selector migration in its
-tests (`checkbox`→`option`); see Tests.
+3. **No anti-pattern.** A focusable checkbox inside `role="option"` is
+   invalid ARIA. (RAC documents this as a convention — a source comment
+   in `useListBox.mjs`, *not* a runtime guard — so don't expect a thrown
+   error.) The per-row checkbox therefore becomes a **decorative,
+   `aria-hidden` glyph** driven by the option's `isSelected` render prop;
+   selection state lives on `aria-selected`, the glyph is presentation.
 
 ### Escape must close the dialog, not clear selection
 
 RAC's selection layer defaults `escapeKeyBehavior="clearSelection"` —
-pressing Escape inside the list would clear the selection (when
-non-empty) instead of bubbling up to close the modal. The modal's
-contract is "Escape = Cancel = close, discarding the draft". So the
-`ListBox` sets **`escapeKeyBehavior="none"`** so Escape propagates to the
-Dialog. Confirmed present on `ListBox` in 1.17.0. Gets its own test.
+Escape inside the list would clear a non-empty selection instead of
+closing the modal. The contract is "Escape = Cancel = close, discarding
+the draft", so the `ListBox` sets **`escapeKeyBehavior="none"`** to let
+Escape propagate to the Dialog. (The prop is inherited via
+`AriaListBoxProps`; it is not declared on RAC's own `ListBoxProps`
+typedoc, so a reader checking that list won't find it — it's real.)
+Gets its own test.
 
 ### Source of truth and the filter/search interaction
 
-`draft: Set<CardId>` remains the single source of truth for what will
-print — unchanged. The `ListBox` is a *controlled selection view over
-only the visible (post-filter, post-search) cards*:
+`draft: Set<CardId>` remains the single source of truth — unchanged. The
+`ListBox` is a *controlled selection view over only the visible
+(post-filter, post-search) cards*:
 
-- `selectedKeys` = the visible cards that are in `draft`, `useMemo`'d
-  over `[draft, visibleIds]`.
-- `onSelectionChange(keys)` merges the new visible selection back with
-  the selected-but-hidden cards. This logic is extracted into a **pure,
-  unit-tested helper** rather than living inline:
+- `selectedKeys` = the visible cards in `draft`, `useMemo`'d over
+  `[draft, visibleIds]`.
+- `onSelectionChange(keys)` merges back via a **pure, unit-tested
+  helper** rather than inline logic:
 
   ```ts
   // printSelectionMerge.ts — colocated with printSelectionLabel.ts
   mergeVisibleSelection(
     draft: Set<CardId>,
     visibleIds: CardId[],
-    keys: Selection,        // RAC: "all" | Set<Key>
+    keys: Selection,        // RAC: "all" | Set<Key>  (Key = string | number)
   ): Set<CardId>
   ```
 
-  - `hidden` = `draft` minus `visibleIds` (cards selected but filtered
-    out),
+  - `hidden` = `draft` minus `visibleIds`.
   - `keys === "all"` (the Cmd/Ctrl+A sentinel) resolves to all
-    `visibleIds` — and *only* visible ids, because the ListBox's
-    collection is fed only the visible cards, so RAC's `"all"` can only
-    mean "all visible",
-  - `next = hidden ∪ resolvedVisibleSelection`.
+    `visibleIds` — and only those, because the ListBox collection is fed
+    only the visible cards.
+  - otherwise `resolvedVisible = visibleIds.filter(id => keys.has(id))`
+    — an **intersection**, not a cast. This narrows RAC's `Key`
+    (`string | number`) to `CardId` and guarantees
+    `result ⊆ (hidden ∪ visibleIds)` regardless of what `keys` contains.
+  - `next = hidden ∪ resolvedVisible`.
 
-  The helper always resolves to a concrete `Set` (never re-emits the
-  `"all"` sentinel) and is **idempotent**: re-applying the current
-  visible selection yields a content-equal `draft`. This matters under
-  React `StrictMode` (double-invoked renders) and because
-  `onSelectionChange` calls `setDraft`.
+  The helper always returns a concrete `Set` (never re-emits `"all"`) and
+  is **idempotent**: re-applying the current visible selection yields a
+  content-equal `draft` (matters under React `StrictMode` double-invoke,
+  since `onSelectionChange` calls `setDraft`).
 
-Extracting the helper is also the mitigation for the test-feasibility
-risk below: it puts the *correctness* of the merge (hidden∪visible, the
-`"all"` sentinel, empty-visible) under fast deterministic unit tests
-that don't depend on whether jsdom can fake a Shift-pointer.
+Extracting the helper is deliberate: it puts the merge's *correctness*
+(hidden∪visible, the `"all"` sentinel, the intersection invariant, empty
+visible) under fast deterministic unit tests independent of any RAC/jsdom
+interaction.
 
 This preserves today's contract exactly: filters/search change only
 which rows are *shown*, never the selection; selected-but-hidden cards
 stay selected and still print; the "N selected cards are hidden by
-filters — still included when you Apply" footer line and its "Clear
-filters" link behave as before. Range selection necessarily operates
-only over visible rows (you can't range across a hidden card), which is
-the correct and expected behavior. The merge is the same *shape* as
-today's `onHeaderToggle` (`PrintSelectionModal.tsx:49`), which already
-splits visible vs. hidden — it's a generalization, not a new concept.
+filters — still included when you Apply" footer line and Clear-filters
+link behave as before. Range selection necessarily operates only over
+visible rows. The merge is the same *shape* as today's `onHeaderToggle`
+(`PrintSelectionModal.tsx:49`), generalized.
 
-### Header "select all shown" and sidebar
+### Header "select all shown" and Cmd/Ctrl+A
 
-The header tri-state checkbox ("Select all shown cards" + "X of Y
-shown" status) stays, sitting *outside* the `ListBox`. It drives the
-same `mergeVisibleSelection` path: clear-all-visible / select-all-visible
-per the existing two-outcome rule, with the indeterminate (`mixed`)
-state when only some visible cards are selected. Keyboard users
-additionally get Cmd/Ctrl+A inside the list as an equivalent
-select-all-shown.
+The header tri-state checkbox ("Select all shown cards" + "X of Y shown"
+status) stays, *outside* the `ListBox` (it remains a real `lib/ui/
+Checkbox`). It drives the same `mergeVisibleSelection` path:
+clear-all-visible / select-all-visible per the existing two-outcome rule,
+with the `mixed` indeterminate state.
 
-Note one accepted divergence between the two select-all paths: from a
-*partially* selected state, the header follows its "any visible checked →
-clear" rule, while RAC's Cmd/Ctrl+A follows "select all, then a second
-press deselects all". Different outcomes from the same mixed start, but
-both routes go through `mergeVisibleSelection` and neither can drop a
-hidden-selected card, so the divergence is acceptable and documented
-rather than reconciled. (Test asserts that after Cmd/Ctrl+A the header
-reads checked, not mixed.)
+Keyboard users also get Cmd/Ctrl+A inside the list. These two paths are
+**not equivalent** and the spec does not claim they are: from a
+*partially* selected state, the header follows "any visible checked →
+clear", while Cmd/Ctrl+A follows the standard listbox "select all (then a
+second press deselects all)". Different outcomes from the same mixed
+start. Both route through `mergeVisibleSelection` and neither can drop a
+hidden-selected card, so the divergence is accepted and documented rather
+than reconciled (reconciling would change shipped #84 behavior + tests).
+A test asserts the header reads checked, not mixed, after Cmd/Ctrl+A.
 
 The sidebar count, Select-all link, Apply/Cancel, Print-button disable,
-and empty-selection messaging are untouched.
+and empty-selection messaging are untouched. Empty selection is reachable
+via header-clear or a second Cmd/Ctrl+A (Shift can't reach it — it's
+additive); the existing disabled-Print + "Select at least 1 card" state
+handles it, unchanged.
 
 ### Anchor across view changes
 
-The range anchor is managed internally by RAC, keyed by item. The
-modal mutates the visible collection constantly (search-as-you-type,
-kind filter, sort flip), so the anchor's referent can move or vanish:
-
-- If the anchor card is filtered/searched out of the collection, a
-  subsequent Shift-click extends from RAC's current focus fallback, not
-  from the now-absent card.
-- If the sort flips, the anchor's *visual position* changes, so a
-  Shift-click spans a different visual run than before the flip.
-
-This is accepted: it is fine for the anchor to reset/relocate when the
-collection changes, as long as the result is sensible and **never
-destructive**. The merge guarantees the worst case is mis-selecting some
-*visible* rows (fully recoverable by the user), never dropping a
-hidden-selected card. A test pins that Shift-click after a sort change
-produces a sane, non-destructive selection.
+The range anchor is RAC-internal, keyed by item. The modal mutates the
+visible collection constantly (search, filter, sort), so the anchor can
+move or vanish: if the anchor card is filtered out, a later Shift-click
+extends from RAC's focus fallback; if sort flips, the anchor's visual
+position changes so a Shift-click spans a different run. This is
+accepted: the anchor may reset/relocate, as long as the result is
+sensible and **never destructive**. The merge guarantees the worst case
+is mis-selecting some *visible* rows (fully recoverable), never dropping a
+hidden-selected card. A test pins that Shift-click after a sort flip is
+sane and non-destructive.
 
 ### Touch and pointers without modifiers
 
-Range-select is inherently a modifier gesture; there is no Shift or Cmd
-key on touch. On touch (and any modifier-less pointer), tapping a card
-**toggles** it — additive and non-destructive, because
-`selectionBehavior="toggle"` makes a plain press a toggle, never a
-replace. So touch users keep exactly today's one-tap-per-card behavior;
-the range gesture simply doesn't exist for them. Their fast path is the
-header "select all shown" + recency sort (tap select-all, then tap off
-the few they don't want). This limitation is stated, not hidden, and a
-test confirms a plain tap toggles rather than replaces the selection.
+Range-select needs a modifier key, which touch lacks. On touch, tapping a
+card *toggles* it (additive, non-destructive — `toggle` behavior makes a
+plain press a toggle, never a replace; verified). So touch users keep
+exactly today's per-card behavior — this feature adds nothing new for
+them, and that's fine; their flow is unchanged from #84. (No false "fast
+path" claim: tapping select-all then tapping off a few only helps when
+keeping a majority.) A test confirms a plain tap toggles rather than
+replaces.
+
+## Walkthrough — "keep everything since last week"
+
+The list opens all-selected (default = whole deck), recency-sorted
+(newest first). Goal: keep the newest run, drop the older tail.
+
+1. Click the header "select all shown" → clears all (**1**).
+2. Click the newest card → toggles it on; it becomes the anchor (**1**).
+3. Shift-click the cutoff card → the anchor→cutoff range is selected
+   (**1**).
+
+**3 gestures, constant** regardless of how many cards are in the kept
+run — versus today's *N* unchecks (8 for a 20→12 narrowing, 20 for a
+50→30 one). Keyboard equivalent: header checkbox (Space) → Tab into list
+→ arrow to newest, Space → Shift+↓ to the cutoff.
 
 ## Accessibility
 
-- The list becomes `role="listbox"` with `aria-multiselectable`, each
-  card a `role="option"` carrying `aria-selected`; the list gets an
-  `aria-label` (e.g. "Cards to print"). RAC manages roving focus, the
-  selection anchor, and focus order.
-- **Keyboard parity with the pointer** — the direct answer to "how does
-  range-select work for keyboard-only users": arrow moves focus only,
-  Space toggles, Shift+↑/↓ extend a range (Cmd/Ctrl+Shift+Home/End to an
-  end), Cmd/Ctrl+A selects all shown, type-ahead by name. Same power as
-  the mouse.
-- **One announcer.** ListBox emits no selection live-announcements
-  (verified), so the modal's single existing polite region
-  (`PrintSelectionModal.tsx:182`) announces the running total and is the
-  *only* selection announcer — no double-speak. It covers both header
-  select-all and in-list selection changes.
-- **`textValue={card.name}`** so type-ahead jumps by name; the kind and
-  the relative timestamp stay `aria-hidden` row decoration (as today),
-  so the option's accessible name is exactly the card name and
+- The list is `role="listbox"` with `aria-multiselectable`, each card a
+  `role="option"` with `aria-selected`; the listbox gets
+  `aria-label="Cards to print"`. RAC manages roving focus and the anchor.
+- **Per-item feedback comes from roving focus, the total from the polite
+  region.** As Shift+↓ moves focus, the SR announces each option it lands
+  on with its state ("Bravo, selected") — that's the per-item feedback,
+  inherent to the listbox pattern, not something the live region must
+  supply. The modal's existing single polite region
+  (`PrintSelectionModal.tsx:182`) supplements with the running *total*
+  ("12 cards selected"); it is the *only* live region (ListBox adds
+  none), so no double-speak. The total may not re-announce on a Shift
+  step that nets zero change — acceptable, because focus already conveyed
+  the per-item change. Choosing the running-total (not per-item naming)
+  in the live region is deliberate, so it doesn't fight the focus
+  announcement.
+- **`textValue={card.name}`** for type-ahead; the kind span, the `<time>`
+  element, **and** its sr-only "Updated " text are all `aria-hidden`, so
+  the option's accessible name is exactly the card name and
   `getByRole("option", { name })` resolves cleanly. The decorative
-  checkbox glyph is `aria-hidden` and not a focusable/queryable control.
+  checkbox glyph is `aria-hidden`, not focusable or queryable.
 - **`escapeKeyBehavior="none"`** so Escape closes the dialog (Cancel).
-- **Tab model change (called out):** today every row checkbox is its own
-  Tab stop; the ListBox is a single Tab stop with arrow-key roving. Tab
-  order: search input → kind toggles → sort → header checkbox → (one Tab
-  into the listbox; arrows within) → footer "Clear filters" link →
-  Cancel/Apply. The header checkbox precedes the list and remains
-  reachable. Net improvement for most, but it is a behavior change for
-  Tab-only users; without a hint (deferred) it relies on the standard
-  listbox interaction model.
+- **Tab model change (called out).** Today every row checkbox is its own
+  Tab stop; the ListBox is a single Tab stop with arrow roving. Order:
+  search → kind toggles → sort → header checkbox → (one Tab into the
+  listbox; arrows within) → footer "Clear filters" → Cancel/Apply. The
+  header checkbox precedes the list and stays reachable. A net win for
+  most, but a behavior change for Tab-only users — the discoverability
+  decision in Non-goals/Risks is the mitigation.
 - **Empty state** uses ListBox's `renderEmptyState` to keep "No cards
-  match." (a bare `<li>` would be an invalid listbox child).
-- Preserved as-is: the header checkbox's `aria-checked="mixed"`
-  indeterminate state and stable action-verb name ("Select all shown
-  cards") with "X of Y shown" as adjacent status text via
-  `aria-describedby`; focus-on-open landing on the search input;
-  focus-return-on-close to the "Choose cards…" button; and the focused
-  option carrying the existing `--color-focus-ring` outline.
+  match." Note RAC wraps that content in a `role="option"` element, so
+  the empty modal contains *one* option — tests assert by text and must
+  not assert "zero options".
+- **Focus-visible** on the focused option binds `[data-focus-visible]`
+  (from `useOption`'s `isFocusVisible`) to the existing
+  `--color-focus-ring`; verify on the option element, not the now-
+  decorative glyph.
+- Preserved: header checkbox `aria-checked="mixed"` + stable name
+  ("Select all shown cards") + "X of Y shown" via `aria-describedby`;
+  focus-on-open to the search input; focus-return-on-close to "Choose
+  cards…". No animations exist, so no reduced-motion work.
 
 ## Components
 
-- **`PrintSelectionModal.tsx`** — the list rendering changes from
-  `<ul>` + per-row `Checkbox` to a RAC `ListBox` + `ListBoxItem`s with a
-  decorative checkbox glyph. The `draft` state, search/kind-filter/sort,
-  header checkbox, footer, and Apply/Cancel wiring are adapted but
-  functionally preserved. `selectedKeys` is `useMemo`'d; selection
-  changes call the new merge helper.
+- **`PrintSelectionModal.tsx`** — list rendering changes from `<ul>` +
+  per-row `Checkbox` to a RAC `ListBox` + `ListBoxItem`s with a
+  decorative selection glyph. `draft`, search/kind/sort, header checkbox,
+  footer, Apply/Cancel are adapted but functionally preserved.
+  `selectedKeys` is `useMemo`'d; selection changes call the merge helper.
 - **`printSelectionMerge.ts`** (new) + **`printSelectionMerge.test.ts`**
-  — the pure `mergeVisibleSelection` helper, colocated with the existing
-  `printSelectionLabel.ts`. This is the one genuinely new unit of logic
-  and owns selection correctness.
+  — the pure `mergeVisibleSelection`, colocated with `printSelectionLabel.ts`.
 - **`PrintSelectionModal.module.css`** — the row layout (name / kind /
-  time grid) moves onto listbox options; the focus ring and selected
-  styling carry over. Visual parity with today's rows is a requirement.
-  (This modal is screen UI, not print-sensitive, so styling changes here
-  are safe.)
+  time grid) moves onto listbox options; selected + focus styling carry
+  over. Note the existing glyph rule `.checkbox[data-selected] .box`
+  (`Checkbox.module.css`) must become an option-scoped rule (`data-
+  selected` lands on the option); the `[data-indeterminate]` rule is not
+  carried onto rows (only the header is ever indeterminate). Visual parity
+  with today's rows is a requirement.
 - **No changes** to `PrintView.tsx`, `deckListing.ts`,
-  `usePrintSelection.ts`, the sidebar, or any print-output code.
-
-**Implementation note:** the decorative checkbox is rendered off the
-`ListBoxItem` `isSelected` render prop (children-as-function or
-`data-selected`), `aria-hidden`, no `role`. Confirm the existing
-`.box` checkbox visual from `lib/ui/Checkbox.module.css` can be reused as
-pure presentation, or factor a small shared glyph.
+  `usePrintSelection.ts`, the sidebar, or print-output code.
 
 ## Tests
 
-Tests split into three layers so correctness doesn't hinge on whether
-jsdom can drive modifier gestures (see Risks):
+Three layers; drivability of layer (c) is spike-confirmed (see
+Validation), so none of it is "contingent".
 
-**(a) Pure unit tests — `printSelectionMerge.test.ts`** (no RAC, fast,
-deterministic; these own correctness):
-- hidden ∪ visible: a selected-but-hidden card survives a visible
-  selection change.
-- `"all"` sentinel resolves to all visible ids (and only those).
-- empty visible set (filtered to nothing) does not drop hidden-selected
-  cards.
-- idempotency: re-applying the current visible selection yields a
-  content-equal set.
+**(a) Pure unit — `printSelectionMerge.test.ts`** (no RAC, deterministic;
+owns correctness):
+- hidden ∪ visible: a selected-but-hidden card survives a visible change.
+- `"all"` sentinel → all visible ids (and only those).
+- a key present in `keys` but not in `visibleIds` is dropped (the
+  intersection invariant).
+- empty visible set does not drop hidden-selected cards.
+- idempotency: re-applying the current visible selection is content-equal.
 
-**(b) Component structure / smoke tests** (no modifier gestures):
-- The list is `role="listbox"` with `aria-multiselectable`; options
-  expose `aria-selected`.
-- `renderEmptyState` shows "No cards match." and hides the "Updated"
-  header (preserves `PrintSelectionModal.test.tsx:147`).
-- Escape closes the modal (Cancel), not just clears selection.
-- Bare ArrowDown/ArrowUp moves focus without changing selection.
+**(b) Component structure / smoke:**
+- The card list is `role="listbox"` (`aria-label` "Cards to print") with
+  `aria-multiselectable`; options expose `aria-selected`.
+- `renderEmptyState` shows "No cards match." (assert by text; do not
+  assert zero options) and hides the "Updated" header.
+- Escape closes the modal (Cancel).
+- Bare ArrowDown/Up moves focus without changing selection.
 - After Cmd/Ctrl+A the header checkbox reads checked (not mixed).
-- Migration of the existing behavior tests (search, kind filter, sort
-  recency+Name, header select-all, hidden-by-filters line, Apply count,
-  Cancel): assertions preserved, selectors migrated from
-  `getByRole("checkbox", { name })` / `toBeChecked()` to
-  `getByRole("option", { name })` + `aria-selected`.
 
-**(c) Interaction tests — contingent on the spike (see Risks):**
-- Click one card, Shift-click a card further down → the inclusive range
-  (recency order) is selected; cards outside are not.
-- Range *deselect* semantics, pinned to what RAC actually produces in
-  `toggle` behavior (do not assume).
+**(c) Interaction (jsdom-confirmed):**
+- Click a card, Shift-click one further down → the inclusive range is
+  selected (additive); cards outside are not.
 - Cmd/Ctrl-click toggles a single card without changing others.
 - Shift+↓ extends selection to the next row(s).
-- Range selection spans only visible rows: a card hidden by a filter
-  between the anchor and target is unaffected, and the Apply total +
-  hidden-by-filters line still reconcile.
+- Range spans only visible rows: a card hidden by a filter between anchor
+  and target is unaffected; the Apply total + hidden-by-filters line
+  reconcile.
 - Shift-click after a sort flip is sensible and non-destructive.
-- Touch/plain pointer tap toggles a single card (never replaces).
+- Plain tap/click toggles a single card (never replaces).
 
-If a gesture proves undrivable in jsdom, correctness is still covered by
-layer (a); the affected layer-(c) tests become a best-effort/`@react-aria
-/test-utils` or browser-mode follow-up (see Risks).
+**Migration is partly non-mechanical** — do not blanket-swap
+`checkbox`→`option`:
+- **Header** checkbox queries STAY `role="checkbox"` +
+  `toBeChecked()`/`toBePartiallyChecked()` (it's a real `Checkbox`
+  outside the listbox). Only **per-row** queries migrate to
+  `role="option"` + `aria-selected` (there is no `option` analog of
+  `toBeChecked()`).
+- The header-select-all family (`PrintSelectionModal.test.tsx:93,102,111,121`)
+  *mixes* a row toggle with header assertions — split by hand.
+- "Kind filter…unchecking" (`:156-166`) uses `toBeChecked()` on a row →
+  rewrite to `aria-selected`.
+- **Two listboxes:** the Sort `Select` is itself a RAC ListBox
+  (`role="option"` items). With its popover open there are two option
+  sets; the sort-by-name test (`:219-236`) already queries the dropdown's
+  option and will collide. Scope card-row queries with
+  `within(screen.getByRole("listbox", { name: /cards to print/i }))`, and
+  query the sort dropdown via its own listbox.
+
+## Validation
+
+A throwaway spike was run (and removed) in this worktree before
+finalizing: a 4-option `ListBox selectionMode="multiple"
+selectionBehavior="toggle"` exercised with `@testing-library/user-event`
+under the project's vitest/jsdom config. All three gestures updated
+`aria-selected` correctly — Shift-click additive range, Cmd/Ctrl-click
+single toggle, and `{Shift>}{ArrowDown}{/Shift}` keyboard extend (driven
+with modifier-held `user.keyboard` around `user.click`). This is the
+basis for the "no extra test dependency / no e2e harness" claim above.
 
 ## Risks
 
-- **jsdom may not reliably drive modifier/pointer gestures** (lead
-  risk). This repo has no precedent for `selectionMode="multiple"`,
-  Shift-click, Cmd-click, or Shift+Arrow in tests, and already had to
-  stub `ResizeObserver` + `clientWidth/Height` in `src/test/setup.ts` to
-  make RAC's Virtualizer survive jsdom. jsdom 29 *does* expose a real
-  `PointerEvent` carrying `shiftKey`, and RAC takes the pointer path, so
-  the gestures are *probably* drivable with modifier-held `user-event`
-  clicks — but it's unproven here. **Mitigation:** (1) the pure helper
-  owns correctness; (2) a **gating spike** as the plan's first task —
-  write one throwaway test driving Shift-click and Shift+↓ against a
-  3-option multi-select ListBox and confirm `aria-selected` updates in
-  this exact jsdom + RAC 1.17.0 + user-event stack. If it works, write
-  layer (c) normally. If not, the fallback is `@react-aria/test-utils`
-  (`ListBoxTester`) — **which requires a dependency add (needs
-  approval)** — or a browser/e2e follow-up; either way layer (a) + (b)
-  still ship.
-- **Exact Shift-range / deselect semantics.** RAC defines the resulting
-  state of a Shift-extension in `toggle` behavior; the headline "select
-  everything since last week" walkthrough depends on it. The spike must
-  determine it and the walkthrough/tests must match whichever model RAC
-  implements (extend-selects-range vs. mirror-anchor-toggle). Either way
-  the operation beats today's per-card path; the click count in the
-  walkthrough is finalized after the spike.
 - **Controlled selection over a filtered collection.** The
   `selectedKeys` ↔ `draft` merge is the subtle bit; get it wrong and
-  hidden-selected cards drop, or Cmd/Ctrl+A over-selects. Covered by the
-  layer-(a) tests and the hidden-range layer-(c) test.
-- **Escape regression.** Easy to miss `escapeKeyBehavior`; without it
-  Escape stops closing the modal. Covered by a test.
-- **Touch users get no range gesture** — accepted and documented; the
-  header select-all + recency sort is their fast path.
-- **Discoverability remains unaddressed** — deferred by decision; review
-  noted a one-line static hint as a near-zero-cost fast follow.
+  hidden-selected cards drop or Cmd/Ctrl+A over-selects. Covered by the
+  layer-(a) tests (incl. the intersection invariant) and the hidden-range
+  layer-(c) test.
+- **Escape regression.** Easy to miss `escapeKeyBehavior`; covered by a
+  test.
+- **Tab-model change / discoverability.** Decision pending (Non-goals):
+  the Tab change is a mild regression for keyboard users and a one-line
+  static hint mitigates both it and discoverability cheaply. The
+  worst-case without it is non-destructive (users fall back to today's
+  per-card path), so it is not a blocker — but it is the one open product
+  call.
+- **Touch gets no range gesture** — accepted and documented.
+- **(Resolved) jsdom drivability + Shift semantics** — previously the top
+  risk; settled by source-reading + the spike above. No longer open.
 
 ## Forward compatibility
 
-If a second multi-select list with range selection appears (e.g. bulk
-PDF export of decks), the `ListBox` + filter + header-select-all
-arrangement plus `mergeVisibleSelection` could extract into a
-`src/lib/ui/` primitive. If such a list ever needs genuinely interactive
-per-row controls, that's the point to revisit `GridList` for it
-specifically. One consumer isn't a pattern; revisit when there's a
-second.
+If a second multi-select list with range selection appears (e.g. bulk PDF
+export of decks), the `ListBox` + filter + header-select-all arrangement
+plus `mergeVisibleSelection` could extract into a `src/lib/ui/` primitive.
+If such a list ever needs genuinely interactive per-row controls, that's
+the point to revisit `GridList` for it specifically. One consumer isn't a
+pattern; revisit when there's a second.

--- a/docs/superpowers/specs/2026-05-24-print-range-selection-design.md
+++ b/docs/superpowers/specs/2026-05-24-print-range-selection-design.md
@@ -18,9 +18,10 @@ operation regardless of run length.
 
 ## Goals
 
-- **Range select in a constant number of gestures.** Click the first
-  card, Shift-click the last → the whole inclusive range is selected, no
-  matter how long. The Drive / Gmail / file-manager convention.
+- **Gmail-style range select.** Click a card, then Shift-click another →
+  the whole range takes the *first* card's state: Shift-click after
+  selecting **fills** the range (including gaps); Shift-click after
+  deselecting **clears** it. Constant gesture regardless of run length.
 - **Keyboard parity, not a lesser path.** Keyboard-only users get the
   *same* power: arrow to a card (moves focus only), Space to toggle,
   **Shift+↑/↓ to extend a range** (Cmd/Ctrl+Shift+Home/End to extend to
@@ -36,12 +37,9 @@ operation regardless of run length.
 - **No regression to print output.** The pipeline downstream of the
   modal still receives the same `Set<CardId>`.
 
-Note on what range-select does *not* do: RAC's Shift-extend is
-**additive only** — it selects the anchor→target range, it never
-*deselects* a range (verified in source, see Approach). So from the
-default all-selected state, "drop the oldest tail" is done by
-clear-then-select, not by Shift-deselecting the tail. The walkthrough
-below reflects this.
+Note: RAC's native Shift-extend is additive-only (it can't deselect a
+range), so the anchor-mirror rule is layered on top with a custom override.
+See "Selection semantics" in Approach for how and why.
 
 ## Non-goals
 
@@ -75,37 +73,59 @@ untouched; the modal's list is genuinely rewritten.
 
 Replace the hand-rolled `<ul>` of name-labelled `lib/ui/Checkbox` rows
 with a `react-aria-components` **`ListBox`** in `selectionMode="multiple"`,
-`selectionBehavior="toggle"`. RAC's selection manager then provides the
-entire Drive-style model — pointer and keyboard — conforming to the
-WAI-ARIA listbox pattern, with roving focus, the selection anchor, and
-`aria-selected` handled by the library:
+`selectionBehavior="toggle"`. RAC handles the WAI-ARIA listbox pattern,
+roving focus, `aria-selected`, type-ahead, and the keyboard model for free;
+the Gmail-style Shift-**click** rule is layered on top (see "Selection
+semantics"):
 
-- **Pointer:** click toggles a card; Shift-click selects the additive
-  range from the anchor to the clicked card; Cmd/Ctrl-click toggles a
-  single card.
+- **Pointer:** click toggles a card; Shift-click sets the anchor→clicked
+  range to the *anchor's* state (fill or clear); Cmd/Ctrl-click toggles one.
 - **Keyboard:** ↑/↓ move focus *without* changing selection
   (`selectOnFocus` is `false` under `toggle`); Space toggles; Shift+↑/↓
-  extend the additive range; Cmd/Ctrl+A selects all shown; type-ahead
-  jumps by name.
+  extend the selection (additive — RAC-native); Cmd/Ctrl+A selects all
+  shown; type-ahead jumps by name.
 
-### Selection semantics are additive (verified)
+### Selection semantics: Gmail-style range (anchor-mirror)
 
-`react-stately`'s `SelectionManager.extendSelection`
-(`SelectionManager.mjs:127-148`) trims the *previous* extension range
-then `.add()`s the anchor→target range; it never toggles-off based on
-state. Both Shift-click and Shift+Arrow route through it
-(`useSelectableItem.mjs`). The anchor moves only on a toggle-*on*
-(`toggleSelection` sets `anchorKey` when adding, not when removing). So
-Shift always *selects* a range. This is determined fact, not a spike
-question.
+A Shift-click sets the whole range from the **anchor** (the last
+plain-clicked card, after its own toggle) to the clicked card to the
+**anchor's** current state — anchor selected → the range *fills* (including
+unselected cards in between); anchor deselected → the range *clears*. Plain
+and Cmd/Ctrl click toggle one card.
 
-**Drivability is proven.** A throwaway spike (a 4-option multi-select
-`toggle` ListBox in this exact jsdom + `react-aria-components@1.17.0` +
-`@testing-library/user-event` stack) confirmed that Shift-click range,
-Cmd/Ctrl-click toggle, and Shift+ArrowDown keyboard extend all update
-`aria-selected` as expected — driven with modifier-held `user.keyboard`
-around `user.click`. So the interaction tests below are writable
-directly in jsdom: **no `@react-aria/test-utils` dependency and no
+RAC's `ListBox` does **not** provide this rule, so it's layered on with care.
+Three RAC behaviors (verified against the installed 1.17.0 source) shaped
+the implementation:
+
+1. **Shift-extend is additive-only.** `SelectionManager.extendSelection`
+   always `.add()`s the anchor→target range; it never deselects. So we
+   can't lean on RAC for the clear/fill rule — on a Shift-click we recompute
+   the range from the pre-click selection and overwrite RAC's result.
+2. **No anchor is recorded on a *deselecting* click** (`toggleSelection`
+   sets `anchorKey` only when adding). So "click a card to start,
+   Shift-click another to clear the run" has no RAC anchor. We track our
+   **own** anchor: a `data-card-id` on each `ListBoxItem`, read in
+   `onPointerDownCapture` on every plain (non-Shift) click.
+3. **`onSelectionChange` is suppressed when the result is unchanged**
+   (an `!equalSets` guard) — exactly the deselect-an-already-selected-range
+   case, so a change-handler override would never fire. We enable
+   react-stately's **`allowDuplicateSelectionEvents`** (a real option RAC
+   doesn't surface on `ListBox`'s prop types — passed via a small typed
+   cast, `SelectionListBox`).
+
+`onPointerDownCapture` also records whether the change came from a
+Shift+*pointer* (the event carries `shiftKey`), so the anchor-mirror
+override applies only to Shift-**click**. **Keyboard Shift+Arrow stays
+additive** (RAC-native): the anchor-mirror rule fights RAC's incremental
+grow/shrink, and additive extension is the natural keyboard behavior. The
+override mutates RAC's `Selection` object in place (clear + rebuild) so its
+anchor/current keys — needed for keyboard Shift+Arrow — survive.
+
+**Drivability is proven.** A throwaway spike confirmed that Shift-click,
+Cmd/Ctrl-click, Shift+Arrow, and `onPointerDownCapture`'s `shiftKey` all
+work in this exact jsdom + `react-aria-components@1.17.0` +
+`@testing-library/user-event` stack, so the interaction tests are writable
+directly in jsdom — **no `@react-aria/test-utils` dependency and no
 browser/e2e harness are required.** (See Validation.)
 
 ### Why `ListBox`, not `GridList`
@@ -160,12 +180,18 @@ Gets its own test.
   controlled `selectedKeys` against the collection, and `toggleSelection`
   / `extendSelection` copy the whole set before mutating, so hidden keys
   ride through).
-- `onSelectionChange(keys)` stores RAC's result **as-is** for ordinary
-  toggles and range changes (`setDraft(keys as Set<CardId>)`), and routes
-  only the `"all"` (Cmd/Ctrl+A) sentinel through the pure helper:
+- `onSelectionChange(keys)` handles three cases:
+  - **`"all"`** (Cmd/Ctrl+A) → expand the sentinel via the pure helper
+    `mergeVisibleSelection(draft, visibleIds, "all")` = `hidden ∪ visibleIds`.
+  - **Shift-click range** → recompute the range to the anchor's state and
+    overwrite RAC's result (see "Selection semantics").
+  - **any other change** (plain/Cmd toggle, keyboard Shift+Arrow) → store
+    RAC's `Selection` **as-is** (`setDraft(keys as Set<CardId>)`).
 
   ```ts
-  // printSelectionMerge.ts — colocated with printSelectionLabel.ts
+  // printSelectionMerge.ts — colocated with printSelectionLabel.ts. Used by the
+  // header toggle and the "all" sentinel (the bulk paths); the Shift-click path
+  // recomputes inline. Pure + unit-tested, independent of RAC/jsdom.
   mergeVisibleSelection(
     draft: Set<CardId>,
     visibleIds: CardId[],
@@ -173,26 +199,18 @@ Gets its own test.
   ): Set<CardId>
   ```
 
-  - `hidden` = `draft` minus `visibleIds`; for `"all"`,
-    `next = hidden ∪ visibleIds`.
+  - `hidden` = `draft` minus `visibleIds`; for `"all"`, `next = hidden ∪ visibleIds`.
   - otherwise it intersects: `next = hidden ∪ visibleIds.filter(id => keys.has(id))`
     — narrowing `Key` to `CardId` and guaranteeing `next ⊆ (hidden ∪ visibleIds)`.
 
-  **Why the normal path stores the Selection as-is** instead of rebuilding
-  a plain `Set` each render: RAC keeps the range *anchor* on the
-  `Selection` object it hands back, and `convertSelection` only preserves
-  it when the controlled value is itself a `Selection`. Rebuilding a plain
-  `Set` nulls the anchor and collapses Shift / Shift+Arrow ranges to a
-  single item — a real bug, caught by the range tests. So the per-row path
-  must pass RAC's object back untouched. The helper therefore guards only
-  the two **bulk** paths that emit sentinels — the header toggle
-  (select-all / clear-visible) and Cmd/Ctrl+A (`"all"`) — where a fresh
-  `Set` (and an anchor reset) is fine. At Apply, `draft` is normalized to a
-  plain `Set` for downstream consumers.
-
-The helper is pure and unit-tested (hidden∪visible, the `"all"` sentinel,
-the intersection invariant, empty-visible, idempotency), independent of
-RAC/jsdom.
+  **Store the `Selection` object, never a rebuilt plain `Set`:** RAC keeps the
+  range anchor on the `Selection` it returns, and `convertSelection` preserves
+  it only when the controlled value is itself a `Selection`. A fresh `Set` nulls
+  the anchor and collapses keyboard Shift+Arrow to a single item (a real bug,
+  caught by the range tests). The bulk/`"all"` paths (where an anchor reset is
+  fine) may produce a plain `Set` via the helper; the Shift-click override clears
+  and rebuilds the *same* `Selection` object rather than replacing it. At Apply,
+  `draft` is normalized to a plain `Set` for downstream consumers.
 
 This preserves today's contract exactly: filters/search change only
 which rows are *shown*, never the selection; selected-but-hidden cards
@@ -230,16 +248,15 @@ disabled-Print + "Select at least 1 card" state handles empty, unchanged.
 
 ### Anchor across view changes
 
-The range anchor is RAC-internal, keyed by item. The modal mutates the
-visible collection constantly (search, filter, sort), so the anchor can
-move or vanish: if the anchor card is filtered out, a later Shift-click
-extends from RAC's focus fallback; if sort flips, the anchor's visual
-position changes so a Shift-click spans a different run. This is
-accepted: the anchor may reset/relocate, as long as the result is
-sensible and **never destructive**. The merge guarantees the worst case
-is mis-selecting some *visible* rows (fully recoverable), never dropping a
-hidden-selected card. A test pins that Shift-click after a sort flip is
-sane and non-destructive.
+We track our own anchor (the last plain-clicked card's id). The modal
+mutates the visible collection constantly (search, filter, sort), so the
+anchor can scroll away or be filtered out: if its id isn't in the current
+`visibleIds`, the Shift-click override is skipped and RAC's additive extend
+stands (non-destructive). If sort flips, the anchor's visual position
+changes so a Shift-click spans a different run — accepted. The override only
+ever sets *visible* rows, so the worst case is recoverable and never drops a
+hidden-selected card. A test pins that range selection still works after a
+sort change.
 
 ### Touch and pointers without modifiers
 
@@ -252,20 +269,21 @@ path" claim: tapping select-all then tapping off a few only helps when
 keeping a majority.) A test confirms a plain tap toggles rather than
 replaces.
 
-## Walkthrough — "keep everything since last week"
+## Walkthrough — "drop everything older than last week"
 
 The list opens all-selected (default = whole deck), recency-sorted
-(newest first). Goal: keep the newest run, drop the older tail.
+(newest first). Goal: drop the older tail, keep the newest run.
 
-1. Click the header "select all shown" → clears all (**1**).
-2. Click the newest card → toggles it on; it becomes the anchor (**1**).
-3. Shift-click the cutoff card → the anchor→cutoff range is selected
-   (**1**).
+1. Click the first (newest) card of the tail → toggles it off; it becomes
+   the deselected anchor (**1**).
+2. Shift-click the last (oldest) card → the range follows the anchor's
+   deselected state and **clears the whole tail** (**1**).
 
-**3 gestures, constant** regardless of how many cards are in the kept
-run — versus today's *N* unchecks (8 for a 20→12 narrowing, 20 for a
-50→30 one). Keyboard equivalent: header checkbox (Space) → Tab into list
-→ arrow to newest, Space → Shift+↓ to the cutoff.
+**2 gestures, constant** regardless of tail length — versus today's *N*
+unchecks (8 for a 20→12 narrowing, 20 for a 50→30 one). Filling a run works
+symmetrically (select a card, Shift-click another → the range fills). The
+header "select all shown" + recency sort/filters remain the keyboard-only
+path; Shift+↑/↓ extends additively.
 
 ## Accessibility
 
@@ -290,13 +308,13 @@ run — versus today's *N* unchecks (8 for a 20→12 narrowing, 20 for a
   `getByRole("option", { name })` resolves cleanly. The decorative
   checkbox glyph is `aria-hidden`, not focusable or queryable.
 - **`escapeKeyBehavior="none"`** so Escape closes the dialog (Cancel).
-- **One-line hint.** A single static, muted helper line sits near the
-  list (in/under the bulk-select row) — candidate copy: *"Shift-click or
-  Shift + ↑/↓ to select a range."* It is plain visible text (not a
-  callout/coachmark) and is associated with the listbox via
-  `aria-describedby`, so SR users hear it on entering the list — which is
-  what makes it double as the Tab-model-change mitigation, not just mouse
-  discoverability. Final copy is for the plan; keep it to one short line.
+- **One-line hint.** A single static, muted helper line sits on the
+  footer's action row, left of Cancel/Apply (so the footer stays one line):
+  *"Shift-click or Shift+↑/↓ to select a range."* It is plain visible text
+  (not a callout/coachmark), rendered only when the list is non-empty, and
+  associated with the listbox via `aria-describedby` so SR users hear it on
+  entering the list — doubling as the Tab-model-change mitigation, not just
+  mouse discoverability.
 - **Tab model change (called out).** Today every row checkbox is its own
   Tab stop; the ListBox is a single Tab stop with arrow roving. Order:
   search → kind toggles → sort → header checkbox → (one Tab into the
@@ -320,10 +338,13 @@ run — versus today's *N* unchecks (8 for a 20→12 narrowing, 20 for a
 ## Components
 
 - **`PrintSelectionModal.tsx`** — list rendering changes from `<ul>` +
-  per-row `Checkbox` to a RAC `ListBox` + `ListBoxItem`s with a
-  decorative selection glyph. `draft`, search/kind/sort, header checkbox,
-  footer, Apply/Cancel are adapted but functionally preserved.
-  `selectedKeys` is `useMemo`'d; selection changes call the merge helper.
+  per-row `Checkbox` to a RAC `ListBox` + `ListBoxItem`s (each with a
+  decorative selection glyph and a `data-card-id`). `selectedKeys={draft}`
+  (controlled by the whole draft); a `SelectionListBox` typed-cast wrapper
+  passes `allowDuplicateSelectionEvents`; `onPointerDownCapture` tracks the
+  anchor + Shift-click flag; `onSelectionChange` applies the anchor-mirror
+  override or the merge helper. `draft`, search/kind/sort, header checkbox,
+  footer (now carrying the hint), Apply/Cancel are functionally preserved.
 - **`printSelectionMerge.ts`** (new) + **`printSelectionMerge.test.ts`**
   — the pure `mergeVisibleSelection`, colocated with `printSelectionLabel.ts`.
 - **`PrintSelectionModal.module.css`** — the row layout (name / kind /
@@ -360,14 +381,15 @@ owns correctness):
 - After Cmd/Ctrl+A the header checkbox reads checked (not mixed).
 
 **(c) Interaction (jsdom-confirmed):**
-- Click a card, Shift-click one further down → the inclusive range is
-  selected (additive); cards outside are not.
+- Shift-click from a **selected** anchor fills the range, including
+  unselected cards in between.
+- Shift-click from a **deselected** anchor clears the range.
 - Cmd/Ctrl-click toggles a single card without changing others.
-- Shift+↓ extends selection to the next row(s).
+- Shift+↓ extends the selection by keyboard (additive).
 - Range spans only visible rows: a card hidden by a filter between anchor
   and target is unaffected; the Apply total + hidden-by-filters line
   reconcile.
-- Shift-click after a sort flip is sensible and non-destructive.
+- Range selection still works after a sort change.
 - Plain tap/click toggles a single card (never replaces).
 
 **Migration is partly non-mechanical** — do not blanket-swap

--- a/docs/superpowers/specs/2026-05-24-print-range-selection-design.md
+++ b/docs/superpowers/specs/2026-05-24-print-range-selection-design.md
@@ -107,11 +107,14 @@ the implementation:
 1. **Shift-extend is additive-only.** `SelectionManager.extendSelection`
    always `.add()`s the anchor→target range; it never deselects. So we
    can't lean on RAC for the clear/fill rule — on a Shift-click we recompute
-   the range and overwrite RAC's result. We rebuild from a **base snapshot**
-   taken when the anchor was set (not the live draft), so a second
-   Shift-click from the same anchor *re-bases* the range rather than stacking
-   on the prior range, and we track the range's moving end (`extentRef`) to
-   tell an extend (include the clicked card) from a shrink (exclude it).
+   the range and overwrite RAC's result. We rebuild the *visible* rows from a
+   **base snapshot** taken when the anchor was set (not the live draft), so a
+   second Shift-click from the same anchor *re-bases* the range rather than
+   stacking, and we track the range's moving end (`extentRef`) to tell an
+   extend (include the clicked card) from a shrink (exclude it).
+   Filter-**hidden** selected cards are preserved from the *live draft* (not
+   the snapshot), so a card an earlier Shift-range selected isn't dropped if
+   it's later hidden.
 2. **No anchor is recorded on a *deselecting* click** (`toggleSelection`
    sets `anchorKey` only when adding). So "click a card to start,
    Shift-click another to clear the run" has no RAC anchor. We track our

--- a/src/views/PrintSelectionModal.module.css
+++ b/src/views/PrintSelectionModal.module.css
@@ -44,11 +44,9 @@
 }
 
 .hint {
-  margin: 0;
-  padding: var(--space-2) var(--space-4);
+  margin: 0 auto 0 0;
   font-size: var(--fs-sm);
   color: var(--color-text-muted);
-  border-bottom: 1px solid var(--color-border);
 }
 
 .list {
@@ -151,6 +149,8 @@
 
 .footerActions {
   display: flex;
+  align-items: center;
+  flex-wrap: wrap;
   justify-content: flex-end;
   gap: var(--space-3);
 }

--- a/src/views/PrintSelectionModal.module.css
+++ b/src/views/PrintSelectionModal.module.css
@@ -43,6 +43,14 @@
   color: var(--color-text-muted);
 }
 
+.hint {
+  margin: 0;
+  padding: var(--space-2) var(--space-4);
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+  border-bottom: 1px solid var(--color-border);
+}
+
 .list {
   list-style: none;
   margin: 0;
@@ -61,10 +69,53 @@
   gap: var(--space-3);
   padding: var(--space-2) var(--space-4);
   border-bottom: 1px solid var(--color-border);
+  cursor: pointer;
 }
 
 .row:last-child {
   border-bottom: 0;
+}
+
+.row[data-focus-visible] {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: -2px;
+}
+
+.rowMain {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.rowName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.box {
+  width: 1.1rem;
+  height: 1.1rem;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+}
+
+.row[data-selected] .box {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+.row[data-selected] .box::after {
+  content: "✓";
+  color: var(--color-accent-fg);
+  font-size: 0.8rem;
+  line-height: 1;
 }
 
 .rowKind {
@@ -82,6 +133,7 @@
   padding: var(--space-5);
   text-align: center;
   color: var(--color-text-muted);
+  margin: auto;
 }
 
 .footer {

--- a/src/views/PrintSelectionModal.module.css
+++ b/src/views/PrintSelectionModal.module.css
@@ -76,6 +76,10 @@
   border-bottom: 0;
 }
 
+.row[data-hovered] {
+  background: var(--color-surface-2);
+}
+
 .row[data-focus-visible] {
   outline: 2px solid var(--color-focus-ring);
   outline-offset: -2px;

--- a/src/views/PrintSelectionModal.module.css
+++ b/src/views/PrintSelectionModal.module.css
@@ -68,6 +68,7 @@
   padding: var(--space-2) var(--space-4);
   border-bottom: 1px solid var(--color-border);
   cursor: pointer;
+  outline: none; /* suppress the browser default; our ring is on [data-focus-visible] */
 }
 
 .row:last-child {

--- a/src/views/PrintSelectionModal.test.tsx
+++ b/src/views/PrintSelectionModal.test.tsx
@@ -240,3 +240,142 @@ describe("<PrintSelectionModal>", () => {
     expect(rows[1]).toHaveAccessibleName("Bravo");
   });
 });
+
+// Newest-first: pass higher day numbers first so recency order == call order.
+const mk = (name: string, day: string) =>
+  itemCardFactory.build({ name, updatedAt: `2026-05-${day}T00:00:00Z` });
+
+describe("<PrintSelectionModal> range + keyboard selection", () => {
+  test("the card list is a multi-selectable listbox; options expose aria-selected", () => {
+    const cards = itemCardFactory.buildList(2);
+    open(cards, allIds(cards));
+    expect(cardList()).toHaveAttribute("aria-multiselectable", "true");
+    const [first] = cards;
+    if (!first) throw new Error("expected a card");
+    expect(cardOption(first.name)).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("the listbox is described by the range hint", () => {
+    const cards = itemCardFactory.buildList(2);
+    open(cards, allIds(cards));
+    expect(cardList()).toHaveAccessibleDescription(/shift-click/i);
+  });
+
+  test("Escape closes the modal rather than only clearing selection", async () => {
+    const cards = itemCardFactory.buildList(3);
+    const { onApply } = open(cards, allIds(cards));
+    const [first] = cards;
+    if (!first) throw new Error("expected a card");
+    await userEvent.click(cardOption(first.name)); // moves focus into the listbox
+    await userEvent.keyboard("{Escape}");
+    expect(onApply).not.toHaveBeenCalled();
+    expect(screen.getByText("closed")).toBeInTheDocument();
+  });
+
+  test("bare ArrowDown moves focus without changing selection", async () => {
+    const cards = [mk("First", "20"), mk("Second", "19"), mk("Third", "18")];
+    open(cards, new Set()); // none selected
+    cardOption("First").focus();
+    await userEvent.keyboard("{ArrowDown}");
+    expect(cardOption("Second")).toHaveFocus();
+    expect(cardOption("First")).toHaveAttribute("aria-selected", "false");
+    expect(cardOption("Second")).toHaveAttribute("aria-selected", "false");
+  });
+
+  test("a plain click toggles a single card and never replaces the selection", async () => {
+    const user = userEvent.setup();
+    const cards = [mk("A", "20"), mk("B", "19"), mk("C", "18")];
+    open(cards, allIds(cards)); // all selected
+    await user.click(cardOption("A")); // toggle A off; B and C stay
+    expect(cardOption("A")).toHaveAttribute("aria-selected", "false");
+    expect(cardOption("B")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("C")).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("Shift-click selects the inclusive range (additive)", async () => {
+    const user = userEvent.setup();
+    const cards = [mk("A", "20"), mk("B", "19"), mk("C", "18"), mk("D", "17")];
+    open(cards, new Set());
+    await user.click(cardOption("A"));
+    await user.keyboard("{Shift>}");
+    await user.click(cardOption("C"));
+    await user.keyboard("{/Shift}");
+    expect(cardOption("A")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("B")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("C")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("D")).toHaveAttribute("aria-selected", "false");
+  });
+
+  test("Cmd/Ctrl-click toggles a single card without disturbing others", async () => {
+    const user = userEvent.setup();
+    const cards = [mk("A", "20"), mk("B", "19"), mk("C", "18")];
+    open(cards, new Set());
+    await user.click(cardOption("A"));
+    await user.keyboard("{Meta>}");
+    await user.click(cardOption("C"));
+    await user.keyboard("{/Meta}");
+    expect(cardOption("A")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("B")).toHaveAttribute("aria-selected", "false");
+    expect(cardOption("C")).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("Shift+ArrowDown extends the selection by keyboard", async () => {
+    const user = userEvent.setup();
+    const cards = [mk("A", "20"), mk("B", "19"), mk("C", "18")];
+    open(cards, new Set());
+    await user.click(cardOption("A")); // select + anchor + focus A
+    await user.keyboard("{Shift>}{ArrowDown}{/Shift}");
+    expect(cardOption("A")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("B")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("C")).toHaveAttribute("aria-selected", "false");
+  });
+
+  test("range selection spans only visible rows; a filtered-out selected card is preserved", async () => {
+    const user = userEvent.setup();
+    const a = itemCardFactory.build({ name: "A", updatedAt: "2026-05-20T00:00:00Z" });
+    const b = spellCardFactory.build({ name: "B", updatedAt: "2026-05-19T00:00:00Z" });
+    const c = itemCardFactory.build({ name: "C", updatedAt: "2026-05-18T00:00:00Z" });
+    const cards = [a, b, c];
+    open(cards, new Set([b.id])); // only the spell B is selected
+    await user.click(screen.getByRole("radio", { name: /items/i })); // hides B; A, C visible
+    expect(screen.getByText(/1 selected card is hidden by filters/i)).toBeInTheDocument();
+    await user.click(cardOption("A"));
+    await user.keyboard("{Shift>}");
+    await user.click(cardOption("C"));
+    await user.keyboard("{/Shift}");
+    expect(cardOption("A")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("C")).toHaveAttribute("aria-selected", "true");
+    // A + C (visible) + B (hidden, preserved) = 3
+    expect(screen.getByRole("button", { name: "Apply (3 cards)" })).toBeInTheDocument();
+  });
+
+  test("range selection works after changing the sort order", async () => {
+    const user = userEvent.setup();
+    const bravo = itemCardFactory.build({ name: "Bravo", updatedAt: "2026-05-20T00:00:00Z" });
+    const alpha = itemCardFactory.build({ name: "Alpha", updatedAt: "2026-05-18T00:00:00Z" });
+    const cards = [bravo, alpha];
+    open(cards, new Set());
+    await user.click(screen.getByRole("button", { name: /sort/i }));
+    await user.click(screen.getByRole("option", { name: "Name" })); // order -> Alpha, Bravo
+    await user.click(cardOption("Alpha"));
+    await user.keyboard("{Shift>}");
+    await user.click(cardOption("Bravo"));
+    await user.keyboard("{/Shift}");
+    expect(cardOption("Alpha")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("Bravo")).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("Cmd/Ctrl+A selects all shown and the header reads checked", async () => {
+    const user = userEvent.setup();
+    const cards = itemCardFactory.buildList(3);
+    open(cards, new Set()); // none
+    const [first] = cards;
+    if (!first) throw new Error("expected a card");
+    cardOption(first.name).focus();
+    // jsdom is treated as non-Mac, so Ctrl+A is select-all. If this env resolves as
+    // Mac, switch to "{Meta>}a{/Meta}".
+    await user.keyboard("{Control>}a{/Control}");
+    expect(screen.getByRole("button", { name: "Apply (3 cards)" })).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: /select all shown cards/i })).toBeChecked();
+  });
+});

--- a/src/views/PrintSelectionModal.test.tsx
+++ b/src/views/PrintSelectionModal.test.tsx
@@ -337,6 +337,25 @@ describe("<PrintSelectionModal> range + keyboard selection", () => {
     expect(cardOption("A")).toHaveAttribute("aria-selected", "true");
   });
 
+  test("shrinking a Shift-range drops the clicked row too (Gmail-style)", async () => {
+    const user = userEvent.setup();
+    const cards = [mk("A", "20"), mk("B", "19"), mk("C", "18"), mk("D", "17"), mk("E", "16")];
+    open(cards, new Set()); // none selected
+    await user.click(cardOption("A")); // select A, anchor A
+    await user.keyboard("{Shift>}");
+    await user.click(cardOption("E")); // extend: fill A..E
+    expect(cardOption("E")).toHaveAttribute("aria-selected", "true");
+    await user.click(cardOption("C")); // still holding Shift: shrink back to C
+    await user.keyboard("{/Shift}");
+    // Gmail: shrinking deselects the clicked row (C) and everything out to the old
+    // extent (D, E), leaving only A..B.
+    expect(cardOption("A")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("B")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("C")).toHaveAttribute("aria-selected", "false");
+    expect(cardOption("D")).toHaveAttribute("aria-selected", "false");
+    expect(cardOption("E")).toHaveAttribute("aria-selected", "false");
+  });
+
   test("Cmd/Ctrl-click toggles a single card without disturbing others", async () => {
     const user = userEvent.setup();
     const cards = [mk("A", "20"), mk("B", "19"), mk("C", "18")];

--- a/src/views/PrintSelectionModal.test.tsx
+++ b/src/views/PrintSelectionModal.test.tsx
@@ -356,6 +356,47 @@ describe("<PrintSelectionModal> range + keyboard selection", () => {
     expect(cardOption("E")).toHaveAttribute("aria-selected", "false");
   });
 
+  test("Shift-clicking the anchor then extending still includes the clicked row", async () => {
+    const user = userEvent.setup();
+    const cards = [mk("A", "20"), mk("B", "19"), mk("C", "18"), mk("D", "17"), mk("E", "16")];
+    open(cards, new Set());
+    await user.click(cardOption("A")); // anchor A
+    await user.keyboard("{Shift>}");
+    await user.click(cardOption("E")); // fill A..E (extent now E)
+    await user.click(cardOption("A")); // Shift-click the anchor — collapses, must reset the extent
+    await user.click(cardOption("D")); // extend A..D — D must be included, not read as a shrink
+    await user.keyboard("{/Shift}");
+    expect(cardOption("A")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("B")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("C")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("D")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("E")).toHaveAttribute("aria-selected", "false");
+  });
+
+  test("a card selected via a Shift-range survives being filtered out (stays in Apply)", async () => {
+    const user = userEvent.setup();
+    // recency order: Aaa, Sss(spell), Bbb, Ddd
+    const aaa = itemCardFactory.build({ name: "Aaa", updatedAt: "2026-05-20T00:00:00Z" });
+    const sss = spellCardFactory.build({ name: "Sss", updatedAt: "2026-05-19T00:00:00Z" });
+    const bbb = itemCardFactory.build({ name: "Bbb", updatedAt: "2026-05-18T00:00:00Z" });
+    const ddd = itemCardFactory.build({ name: "Ddd", updatedAt: "2026-05-17T00:00:00Z" });
+    open([aaa, sss, bbb, ddd], new Set());
+    await user.click(cardOption("Aaa")); // anchor
+    await user.keyboard("{Shift>}");
+    await user.click(cardOption("Ddd")); // fill Aaa..Ddd, incl. the spell Sss
+    await user.keyboard("{/Shift}");
+    expect(screen.getByRole("button", { name: "Apply (4 cards)" })).toBeInTheDocument();
+    await user.click(screen.getByRole("radio", { name: /items/i })); // hides Sss (still selected)
+    expect(screen.getByText(/1 selected card is hidden by filters/i)).toBeInTheDocument();
+    await user.keyboard("{Shift>}");
+    await user.click(cardOption("Bbb")); // shrink within the visible items
+    await user.keyboard("{/Shift}");
+    // The shrink drops the visible run, but the hidden spell must NOT be lost:
+    // Aaa (visible) + Sss (hidden) = 2.
+    expect(screen.getByText(/1 selected card is hidden by filters/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Apply (2 cards)" })).toBeInTheDocument();
+  });
+
   test("Cmd/Ctrl-click toggles a single card without disturbing others", async () => {
     const user = userEvent.setup();
     const cards = [mk("A", "20"), mk("B", "19"), mk("C", "18")];

--- a/src/views/PrintSelectionModal.test.tsx
+++ b/src/views/PrintSelectionModal.test.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { describe, expect, test, vi } from "vitest";
 import { itemCardFactory, spellCardFactory } from "../cards/factories";
 import type { CardId, RenderableCard } from "../cards/types";
-import { render, screen } from "../test/render";
+import { render, screen, within } from "../test/render";
 import { PrintSelectionModal } from "./PrintSelectionModal";
 
 function open(cards: RenderableCard[], initial: Set<CardId>, onApply = vi.fn()) {
@@ -25,16 +25,22 @@ function open(cards: RenderableCard[], initial: Set<CardId>, onApply = vi.fn()) 
 
 const allIds = (cards: RenderableCard[]) => new Set(cards.map((c) => c.id));
 
+// The card list is one of two listboxes in the modal (the Sort control is the
+// other), so scope row queries to it by its accessible name.
+const cardList = () => screen.getByRole("listbox", { name: /cards to print/i });
+const cardOption = (name: string | RegExp) => within(cardList()).getByRole("option", { name });
+const cardOptions = (name: RegExp) => within(cardList()).getAllByRole("option", { name });
+
 describe("<PrintSelectionModal>", () => {
-  test("lists every renderable card with a checkbox, recency-sorted (newest first)", () => {
+  test("lists every renderable card as an option, recency-sorted (newest first)", () => {
     const older = itemCardFactory.build({ name: "Older", updatedAt: "2026-05-01T00:00:00Z" });
     const newer = itemCardFactory.build({ name: "Newer", updatedAt: "2026-05-20T00:00:00Z" });
     const cards = [older, newer];
     open(cards, allIds(cards));
-    const rowChecks = screen.getAllByRole("checkbox", { name: /Older|Newer/ });
-    expect(rowChecks).toHaveLength(2);
-    expect(rowChecks[0]).toHaveAccessibleName("Newer");
-    expect(rowChecks[1]).toHaveAccessibleName("Older");
+    const rows = cardOptions(/Older|Newer/);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveAccessibleName("Newer");
+    expect(rows[1]).toHaveAccessibleName("Older");
   });
 
   test("focus lands on the name search input on open", () => {
@@ -58,27 +64,26 @@ describe("<PrintSelectionModal>", () => {
     const { onApply } = open(cards, allIds(cards));
     const [first] = cards;
     if (!first) throw new Error("expected cards");
-    await userEvent.click(screen.getByRole("checkbox", { name: first.name }));
+    await userEvent.click(cardOption(first.name));
     await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
     expect(onApply).not.toHaveBeenCalled();
     expect(screen.getByText("closed")).toBeInTheDocument();
   });
 
-  test("toggling a row updates the Apply total", async () => {
+  test("toggling a card updates the Apply total", async () => {
     const cards = itemCardFactory.buildList(3);
     open(cards, allIds(cards));
     expect(screen.getByRole("button", { name: "Apply (3 cards)" })).toBeInTheDocument();
     const [first] = cards;
     if (!first) throw new Error("expected cards");
-    await userEvent.click(screen.getByRole("checkbox", { name: first.name }));
+    await userEvent.click(cardOption(first.name));
     expect(screen.getByRole("button", { name: "Apply (2 cards)" })).toBeInTheDocument();
   });
 
-  test("each timestamp is labelled 'Updated' for screen readers", () => {
+  test("kind and timestamp are decorative — the option's name is just the card name", () => {
     const card = itemCardFactory.build({ name: "Cloak", updatedAt: "2026-05-23T11:00:00Z" });
     open([card], allIds([card]));
-    const time = document.querySelector("time");
-    expect(time).toHaveTextContent(/^Updated /);
+    expect(cardOption("Cloak")).toHaveAccessibleName("Cloak");
   });
 
   test("a spell and an item both appear when present", () => {
@@ -86,8 +91,8 @@ describe("<PrintSelectionModal>", () => {
     const spell = spellCardFactory.build({ name: "Bless" });
     const cards = [item, spell];
     open(cards, allIds(cards));
-    expect(screen.getByRole("checkbox", { name: "Cloak" })).toBeInTheDocument();
-    expect(screen.getByRole("checkbox", { name: "Bless" })).toBeInTheDocument();
+    expect(cardOption("Cloak")).toBeInTheDocument();
+    expect(cardOption("Bless")).toBeInTheDocument();
   });
 
   test("header checkbox clears all visible when all are checked", async () => {
@@ -108,12 +113,12 @@ describe("<PrintSelectionModal>", () => {
     expect(screen.getByRole("button", { name: "Apply (3 cards)" })).toBeInTheDocument();
   });
 
-  test("header checkbox is indeterminate (mixed) when some visible are checked", async () => {
+  test("header checkbox is indeterminate (mixed) when some visible are selected", async () => {
     const cards = itemCardFactory.buildList(3);
     open(cards, allIds(cards));
     const [first] = cards;
     if (!first) throw new Error("expected a card");
-    await userEvent.click(screen.getByRole("checkbox", { name: first.name }));
+    await userEvent.click(cardOption(first.name));
     const header = screen.getByRole("checkbox", { name: /select all shown cards/i });
     expect(header).toBePartiallyChecked();
   });
@@ -123,7 +128,7 @@ describe("<PrintSelectionModal>", () => {
     open(cards, allIds(cards));
     const [first] = cards;
     if (!first) throw new Error("expected a card");
-    await userEvent.click(screen.getByRole("checkbox", { name: first.name })); // now 2 of 3
+    await userEvent.click(cardOption(first.name)); // now 2 of 3
     const header = screen.getByRole("checkbox", { name: /select all shown cards/i });
     await userEvent.click(header);
     expect(screen.getByRole("button", { name: "Apply (0 cards)" })).toBeInTheDocument();
@@ -153,16 +158,16 @@ describe("<PrintSelectionModal>", () => {
     expect(screen.queryByText("Updated")).not.toBeInTheDocument();
   });
 
-  test("Kind filter hides the other kind without unchecking it", async () => {
+  test("Kind filter hides the other kind without deselecting it", async () => {
     const item = itemCardFactory.build({ name: "Cloak" });
     const spell = spellCardFactory.build({ name: "Bless" });
     const cards = [item, spell];
     open(cards, allIds(cards));
     await userEvent.click(screen.getByRole("radio", { name: /items/i }));
-    expect(screen.queryByRole("checkbox", { name: "Bless" })).not.toBeInTheDocument();
-    expect(screen.getByRole("checkbox", { name: "Cloak" })).toBeInTheDocument();
+    expect(within(cardList()).queryByRole("option", { name: "Bless" })).not.toBeInTheDocument();
+    expect(cardOption("Cloak")).toBeInTheDocument();
     await userEvent.click(screen.getByRole("radio", { name: /all/i }));
-    expect(screen.getByRole("checkbox", { name: "Bless" })).toBeChecked();
+    expect(cardOption("Bless")).toHaveAttribute("aria-selected", "true");
   });
 
   test("name search narrows the list case-insensitively", async () => {
@@ -170,8 +175,8 @@ describe("<PrintSelectionModal>", () => {
     const b = itemCardFactory.build({ name: "Bless" });
     open([a, b], allIds([a, b]));
     await userEvent.type(screen.getByRole("searchbox", { name: /search cards/i }), "acid");
-    expect(screen.getByRole("checkbox", { name: "Acid Arrow" })).toBeInTheDocument();
-    expect(screen.queryByRole("checkbox", { name: "Bless" })).not.toBeInTheDocument();
+    expect(cardOption("Acid Arrow")).toBeInTheDocument();
+    expect(within(cardList()).queryByRole("option", { name: "Bless" })).not.toBeInTheDocument();
   });
 
   test("hidden-checked line appears when a filter hides a selected card", async () => {
@@ -192,7 +197,7 @@ describe("<PrintSelectionModal>", () => {
     open(cards, allIds(cards));
     await userEvent.click(screen.getByRole("radio", { name: /items/i }));
     await userEvent.click(screen.getByRole("button", { name: /clear filters/i }));
-    expect(screen.getByRole("checkbox", { name: "Bless" })).toBeInTheDocument();
+    expect(cardOption("Bless")).toBeInTheDocument();
     expect(screen.queryByText(/hidden by filters/i)).not.toBeInTheDocument();
   });
 
@@ -209,10 +214,10 @@ describe("<PrintSelectionModal>", () => {
     const cards = [cloak, bless];
     open(cards, allIds(cards));
     await userEvent.type(screen.getByRole("searchbox", { name: /search cards/i }), "cloak");
-    expect(screen.queryByRole("checkbox", { name: "Bless" })).not.toBeInTheDocument();
+    expect(within(cardList()).queryByRole("option", { name: "Bless" })).not.toBeInTheDocument();
     expect(screen.getByText(/1 selected card is hidden by filters/i)).toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: /clear filters/i }));
-    expect(screen.getByRole("checkbox", { name: "Bless" })).toBeInTheDocument();
+    expect(cardOption("Bless")).toBeInTheDocument();
     expect(screen.getByRole("searchbox", { name: /search cards/i })).toHaveValue("");
   });
 
@@ -222,15 +227,15 @@ describe("<PrintSelectionModal>", () => {
     const alpha = itemCardFactory.build({ name: "Alpha", updatedAt: "2026-05-01T00:00:00Z" });
     const cards = [bravo, alpha];
     open(cards, allIds(cards));
-    // Default recency: Bravo first.
-    let rows = screen.getAllByRole("checkbox", { name: /Alpha|Bravo/ });
+    let rows = cardOptions(/Alpha|Bravo/);
     expect(rows[0]).toHaveAccessibleName("Bravo");
     expect(rows[1]).toHaveAccessibleName("Alpha");
     const sortTrigger = screen.getByRole("button", { name: /sort/i });
     expect(sortTrigger).toHaveTextContent(/recently edited/i);
     await userEvent.click(sortTrigger);
-    await userEvent.click(screen.getByRole("option", { name: /name/i }));
-    rows = screen.getAllByRole("checkbox", { name: /Alpha|Bravo/ });
+    // The Sort dropdown is a separate listbox; its "Name" option is unambiguous here.
+    await userEvent.click(screen.getByRole("option", { name: "Name" }));
+    rows = cardOptions(/Alpha|Bravo/);
     expect(rows[0]).toHaveAccessibleName("Alpha");
     expect(rows[1]).toHaveAccessibleName("Bravo");
   });

--- a/src/views/PrintSelectionModal.test.tsx
+++ b/src/views/PrintSelectionModal.test.tsx
@@ -306,6 +306,37 @@ describe("<PrintSelectionModal> range + keyboard selection", () => {
     expect(cardOption("D")).toHaveAttribute("aria-selected", "false");
   });
 
+  test("Shift-click from a deselected anchor clears the range (Gmail-style)", async () => {
+    const user = userEvent.setup();
+    const cards = [mk("A", "20"), mk("B", "19"), mk("C", "18"), mk("D", "17")];
+    open(cards, allIds(cards)); // all selected
+    await user.click(cardOption("A")); // A becomes the deselected anchor
+    await user.keyboard("{Shift>}");
+    await user.click(cardOption("C")); // range follows anchor A's (deselected) state -> A..C clear
+    await user.keyboard("{/Shift}");
+    expect(cardOption("A")).toHaveAttribute("aria-selected", "false");
+    expect(cardOption("B")).toHaveAttribute("aria-selected", "false");
+    expect(cardOption("C")).toHaveAttribute("aria-selected", "false");
+    expect(cardOption("D")).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("Shift-click from a selected anchor fills the range, incl. cards between (Gmail-style)", async () => {
+    const user = userEvent.setup();
+    const a = mk("A", "20");
+    const b = mk("B", "19");
+    const c = mk("C", "18");
+    const d = mk("D", "17");
+    open([a, b, c, d], new Set([a.id, d.id])); // A & D selected; B, C not
+    await user.click(cardOption("B")); // B becomes the selected anchor
+    await user.keyboard("{Shift>}");
+    await user.click(cardOption("D")); // range follows anchor B's (selected) state -> B..D fill
+    await user.keyboard("{/Shift}");
+    expect(cardOption("B")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("C")).toHaveAttribute("aria-selected", "true"); // was unselected, now filled
+    expect(cardOption("D")).toHaveAttribute("aria-selected", "true");
+    expect(cardOption("A")).toHaveAttribute("aria-selected", "true");
+  });
+
   test("Cmd/Ctrl-click toggles a single card without disturbing others", async () => {
     const user = userEvent.setup();
     const cards = [mk("A", "20"), mk("B", "19"), mk("C", "18")];

--- a/src/views/PrintSelectionModal.tsx
+++ b/src/views/PrintSelectionModal.tsx
@@ -101,9 +101,8 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
       return;
     }
 
-    // We store RAC's Selection object: it carries the range anchor (so rebuilding
-    // a plain Set each render would break keyboard Shift+Arrow) and the
-    // filter-hidden selected keys it rides through, keeping draft whole.
+    // `sel` is RAC's Selection — we keep the object (it carries the range anchor,
+    // so rebuilding a plain Set would break keyboard Shift+Arrow).
     const sel = keys as Set<CardId> & { currentKey?: Key | null };
     const anchor = anchorRef.current;
     const target = sel.currentKey as CardId | null | undefined; // the Shift-clicked card
@@ -112,32 +111,39 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
     // ANCHOR's state (selected → fill, incl. cards in between; deselected → clear),
     // rebuilt from `baseDraftRef` so consecutive Shift-clicks re-base. Extending the
     // range includes the clicked card; shrinking it back inward excludes the clicked
-    // card and drops everything out to the previous extent. RAC's extend is
-    // additive-only, so we overwrite its result, keeping the Selection object so
-    // keyboard Shift+Arrow still works.
-    if (fromShiftClick && anchor != null && target != null && anchor !== target) {
-      const aIdx = visibleIds.indexOf(anchor);
+    // card and drops everything out to the previous extent.
+    if (fromShiftClick && target != null) {
+      // Record the new moving end for the NEXT shrink/extend test, reading the
+      // previous extent first. Done even when the override below bails (e.g. a
+      // Shift-click on the anchor itself) so a stale extent can't misread the next
+      // Shift-click as a shrink.
+      const prevExtentId = extentRef.current;
+      extentRef.current = target;
+
+      const aIdx = anchor != null ? visibleIds.indexOf(anchor) : -1;
       const tIdx = visibleIds.indexOf(target);
-      if (aIdx !== -1 && tIdx !== -1) {
+      if (anchor != null && anchor !== target && aIdx !== -1 && tIdx !== -1) {
         const base = baseDraftRef.current;
         const select = base.has(anchor);
-        const eIdx = extentRef.current != null ? visibleIds.indexOf(extentRef.current) : -1;
+        const eIdx = prevExtentId != null ? visibleIds.indexOf(prevExtentId) : -1;
         const dirT = Math.sign(tIdx - aIdx);
         const shrinking =
           eIdx !== -1 &&
           dirT === Math.sign(eIdx - aIdx) &&
           Math.abs(tIdx - aIdx) < Math.abs(eIdx - aIdx);
         const boundaryIdx = shrinking ? tIdx - dirT : tIdx; // shrink steps one back toward the anchor
-        const lo = Math.min(aIdx, boundaryIdx);
-        const hi = Math.max(aIdx, boundaryIdx);
-        const region = visibleIds.slice(lo, hi + 1);
+        const region = new Set(
+          visibleIds.slice(Math.min(aIdx, boundaryIdx), Math.max(aIdx, boundaryIdx) + 1),
+        );
+        const visibleIdSet = new Set(visibleIds);
         sel.clear();
-        for (const id of base) sel.add(id);
-        for (const id of region) {
-          if (select) sel.add(id);
-          else sel.delete(id);
+        // Preserve currently-hidden selected cards (filters never drop selections) —
+        // including ones a previous Shift-range selected, which aren't in `base`.
+        for (const id of draft) if (!visibleIdSet.has(id)) sel.add(id);
+        // Re-base the visible rows from the snapshot; the region takes the anchor's state.
+        for (const id of visibleIds) {
+          if (region.has(id) ? select : base.has(id)) sel.add(id);
         }
-        extentRef.current = target; // the clicked card becomes the new moving end
         setDraft(sel);
         return;
       }

--- a/src/views/PrintSelectionModal.tsx
+++ b/src/views/PrintSelectionModal.tsx
@@ -142,9 +142,11 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
             )}
           </div>
 
-          <p className={styles.hint} id={hintId}>
-            Shift-click or Shift+↑/↓ to select a range.
-          </p>
+          {visible.length > 0 && (
+            <p className={styles.hint} id={hintId}>
+              Shift-click or Shift+↑/↓ to select a range.
+            </p>
+          )}
 
           <ListBox
             aria-label="Cards to print"

--- a/src/views/PrintSelectionModal.tsx
+++ b/src/views/PrintSelectionModal.tsx
@@ -45,11 +45,6 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
   const allVisibleChecked = visible.length > 0 && visibleCheckedCount === visible.length;
   const headerIndeterminate = !allVisibleChecked && visibleCheckedCount > 0;
 
-  const selectedKeys = useMemo(
-    () => new Set(visibleIds.filter((id) => draft.has(id))),
-    [visibleIds, draft],
-  );
-
   // Intentionally ignores RAC's onChange boolean: RAC passes `true` when clicked
   // from the indeterminate state, but the rule is always "any visible checked → clear".
   const onHeaderToggle = () => {
@@ -155,9 +150,18 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
             selectionMode="multiple"
             selectionBehavior="toggle"
             escapeKeyBehavior="none"
-            selectedKeys={selectedKeys}
+            selectedKeys={draft}
+            // Store RAC's Selection as-is: the range anchor lives on that object, so
+            // rebuilding a plain Set each render would reset it and break Shift /
+            // Shift+Arrow range extension. RAC also carries the filter-hidden selected
+            // keys through toggles, so draft stays whole. Only the "all" (Cmd/Ctrl+A)
+            // sentinel must be expanded to the visible ids.
             onSelectionChange={(keys) =>
-              setDraft((prev) => mergeVisibleSelection(prev, visibleIds, keys))
+              setDraft((prev) =>
+                keys === "all"
+                  ? mergeVisibleSelection(prev, visibleIds, "all")
+                  : (keys as Set<CardId>),
+              )
             }
             items={visible}
             renderEmptyState={() => <span className={styles.emptyState}>No cards match.</span>}

--- a/src/views/PrintSelectionModal.tsx
+++ b/src/views/PrintSelectionModal.tsx
@@ -33,6 +33,8 @@ type Props = {
 // onSelectionChange even when the result is unchanged — needed so a Shift-click
 // that *deselects* an already-selected range still reaches our handler) but
 // doesn't surface it on ListBox's prop types. Widen the type so we can pass it.
+// It reaches react-stately only via RAC's `{...props}` spread, so a RAC upgrade
+// could silently drop it; the "clears the range" test guards that behavior.
 const SelectionListBox = ListBox as unknown as (
   props: ListBoxProps<Card> & { allowDuplicateSelectionEvents?: boolean },
 ) => ReactElement;
@@ -63,56 +65,87 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
   // Intentionally ignores RAC's onChange boolean: RAC passes `true` when clicked
   // from the indeterminate state, but the rule is always "any visible checked → clear".
   const onHeaderToggle = () => {
+    anchorRef.current = null; // bulk action — a later Shift-click starts a fresh range
+    extentRef.current = null;
     const next = visibleCheckedCount > 0 ? new Set<CardId>() : ("all" as const);
     setDraft((prev) => mergeVisibleSelection(prev, visibleIds, next));
   };
 
   // The ListBox is controlled by `draft`. RAC records no anchor when a click
-  // *deselects* an item, and its Shift-extend is additive-only, so we track our
-  // own anchor (the last plain-clicked card, captured on pointerdown below) and
-  // recompute Shift-click ranges ourselves. `shiftClickRef` flags that the change
-  // came from a Shift+pointer (vs. Shift+Arrow, which stays additive via RAC).
+  // *deselects* an item, and its Shift-extend is additive-only, so we manage
+  // Shift-click ranges ourselves, Gmail-style:
+  //   • anchorRef  — the last plain-clicked card (the fixed end of the range).
+  //   • extentRef  — the last Shift-clicked card (the moving end); lets us tell an
+  //                  extend from a shrink.
+  //   • baseDraftRef — the selection snapshot when the anchor was set, so every
+  //                  Shift-click re-bases off it instead of stacking.
+  //   • shiftClickRef — set on a Shift+pointerdown that lands on a row (vs.
+  //                  Shift+Arrow, which RAC handles as an additive extend).
   const anchorRef = useRef<CardId | null>(null);
+  const extentRef = useRef<CardId | null>(null);
+  const baseDraftRef = useRef<Set<CardId>>(new Set(initialSelection));
   const shiftClickRef = useRef(false);
 
   const onSelectionChange = (keys: Selection) => {
     const fromShiftClick = shiftClickRef.current;
     shiftClickRef.current = false;
 
-    // Cmd/Ctrl+A: expand the "all" sentinel to every visible id (∪ hidden).
+    // Cmd/Ctrl+A: expand the "all" sentinel to every visible id (∪ hidden). Bulk
+    // select-all resets the range anchor.
     if (keys === "all") {
-      setDraft((prev) => mergeVisibleSelection(prev, visibleIds, "all"));
+      anchorRef.current = null;
+      extentRef.current = null;
+      const next = mergeVisibleSelection(draft, visibleIds, "all");
+      baseDraftRef.current = new Set(next);
+      setDraft(next);
       return;
     }
 
     // We store RAC's Selection object: it carries the range anchor (so rebuilding
     // a plain Set each render would break keyboard Shift+Arrow) and the
     // filter-hidden selected keys it rides through, keeping draft whole.
-    const sel = keys as Set<CardId> & { anchorKey?: Key | null; currentKey?: Key | null };
-
-    // Gmail-style range on a Shift+CLICK: the whole range from the anchor (the last
-    // plain-clicked card, post-toggle) to the clicked card takes the ANCHOR's
-    // current state — anchor selected → the range fills (incl. unselected cards in
-    // between); anchor unselected → the range clears. RAC's native extend is
-    // additive-only, so we recompute from the pre-click selection and overwrite its
-    // result, keeping sel's anchor/current keys so keyboard Shift+Arrow still works.
+    const sel = keys as Set<CardId> & { currentKey?: Key | null };
     const anchor = anchorRef.current;
     const target = sel.currentKey as CardId | null | undefined; // the Shift-clicked card
+
+    // Gmail-style range on a Shift+CLICK: the range from the anchor takes the
+    // ANCHOR's state (selected → fill, incl. cards in between; deselected → clear),
+    // rebuilt from `baseDraftRef` so consecutive Shift-clicks re-base. Extending the
+    // range includes the clicked card; shrinking it back inward excludes the clicked
+    // card and drops everything out to the previous extent. RAC's extend is
+    // additive-only, so we overwrite its result, keeping the Selection object so
+    // keyboard Shift+Arrow still works.
     if (fromShiftClick && anchor != null && target != null && anchor !== target) {
-      const from = visibleIds.indexOf(anchor);
-      const to = visibleIds.indexOf(target);
-      if (from !== -1 && to !== -1) {
-        const range = visibleIds.slice(Math.min(from, to), Math.max(from, to) + 1);
-        const select = draft.has(anchor);
-        sel.clear(); // drop RAC's additive result; keeps anchorKey/currentKey
-        for (const id of draft) sel.add(id); // restore the pre-click selection (incl. hidden)
-        for (const id of range) {
+      const aIdx = visibleIds.indexOf(anchor);
+      const tIdx = visibleIds.indexOf(target);
+      if (aIdx !== -1 && tIdx !== -1) {
+        const base = baseDraftRef.current;
+        const select = base.has(anchor);
+        const eIdx = extentRef.current != null ? visibleIds.indexOf(extentRef.current) : -1;
+        const dirT = Math.sign(tIdx - aIdx);
+        const shrinking =
+          eIdx !== -1 &&
+          dirT === Math.sign(eIdx - aIdx) &&
+          Math.abs(tIdx - aIdx) < Math.abs(eIdx - aIdx);
+        const boundaryIdx = shrinking ? tIdx - dirT : tIdx; // shrink steps one back toward the anchor
+        const lo = Math.min(aIdx, boundaryIdx);
+        const hi = Math.max(aIdx, boundaryIdx);
+        const region = visibleIds.slice(lo, hi + 1);
+        sel.clear();
+        for (const id of base) sel.add(id);
+        for (const id of region) {
           if (select) sel.add(id);
           else sel.delete(id);
         }
+        extentRef.current = target; // the clicked card becomes the new moving end
+        setDraft(sel);
+        return;
       }
     }
 
+    // Plain/Cmd toggle or keyboard change: store RAC's result as-is, and snapshot
+    // it as the base for any subsequent Shift-click range.
+    if (!fromShiftClick) baseDraftRef.current = new Set(sel);
     setDraft(sel);
   };
 
@@ -211,11 +244,20 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
             allowDuplicateSelectionEvents
             selectedKeys={draft}
             onPointerDownCapture={(e) => {
-              shiftClickRef.current = e.shiftKey;
-              if (!e.shiftKey) {
-                const el = (e.target as HTMLElement).closest("[data-card-id]");
-                const id = el?.getAttribute("data-card-id");
-                if (id) anchorRef.current = id as CardId;
+              // Only treat this as a Shift-click range when an actual option is
+              // hit, so a stray Shift+pointerdown on list chrome can't leave the
+              // flag set for a later (e.g. keyboard) change.
+              const id = (e.target as HTMLElement)
+                .closest("[data-card-id]")
+                ?.getAttribute("data-card-id");
+              if (e.shiftKey) {
+                shiftClickRef.current = id != null;
+              } else {
+                shiftClickRef.current = false;
+                if (id) {
+                  anchorRef.current = id as CardId;
+                  extentRef.current = id as CardId; // a plain click resets the range to itself
+                }
               }
             }}
             onSelectionChange={onSelectionChange}
@@ -255,7 +297,7 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
             <div className={styles.footerActions}>
               {visible.length > 0 && (
                 <p className={styles.hint} id={hintId}>
-                  Shift-click or Shift+↑/↓ to select a range.
+                  Shift-click to fill or clear a range; Shift+↑/↓ to extend.
                 </p>
               )}
               <Button variant="secondary" onPress={onClose}>

--- a/src/views/PrintSelectionModal.tsx
+++ b/src/views/PrintSelectionModal.tsx
@@ -1,6 +1,13 @@
-import { useId, useMemo, useState } from "react";
-import { ListBox, ListBoxItem, TextField } from "react-aria-components";
-import type { CardId, RenderableCard } from "../cards/types";
+import { type ReactElement, useId, useMemo, useRef, useState } from "react";
+import {
+  type Key,
+  ListBox,
+  ListBoxItem,
+  type ListBoxProps,
+  type Selection,
+  TextField,
+} from "react-aria-components";
+import type { Card, CardId, RenderableCard } from "../cards/types";
 import { type DeckKindFilter, type DeckSort, deckListing } from "../decks/deckListing";
 import { pluralize } from "../lib/pluralize";
 import { relativeTime } from "../lib/relativeTime";
@@ -21,6 +28,14 @@ type Props = {
   onApply: (next: Set<CardId>) => void;
   onClose: () => void;
 };
+
+// RAC's ListBox honors react-stately's `allowDuplicateSelectionEvents` (fire
+// onSelectionChange even when the result is unchanged — needed so a Shift-click
+// that *deselects* an already-selected range still reaches our handler) but
+// doesn't surface it on ListBox's prop types. Widen the type so we can pass it.
+const SelectionListBox = ListBox as unknown as (
+  props: ListBoxProps<Card> & { allowDuplicateSelectionEvents?: boolean },
+) => ReactElement;
 
 export function PrintSelectionModal({ cards, initialSelection, onApply, onClose }: Props) {
   const [draft, setDraft] = useState<Set<CardId>>(() => new Set(initialSelection));
@@ -50,6 +65,55 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
   const onHeaderToggle = () => {
     const next = visibleCheckedCount > 0 ? new Set<CardId>() : ("all" as const);
     setDraft((prev) => mergeVisibleSelection(prev, visibleIds, next));
+  };
+
+  // The ListBox is controlled by `draft`. RAC records no anchor when a click
+  // *deselects* an item, and its Shift-extend is additive-only, so we track our
+  // own anchor (the last plain-clicked card, captured on pointerdown below) and
+  // recompute Shift-click ranges ourselves. `shiftClickRef` flags that the change
+  // came from a Shift+pointer (vs. Shift+Arrow, which stays additive via RAC).
+  const anchorRef = useRef<CardId | null>(null);
+  const shiftClickRef = useRef(false);
+
+  const onSelectionChange = (keys: Selection) => {
+    const fromShiftClick = shiftClickRef.current;
+    shiftClickRef.current = false;
+
+    // Cmd/Ctrl+A: expand the "all" sentinel to every visible id (∪ hidden).
+    if (keys === "all") {
+      setDraft((prev) => mergeVisibleSelection(prev, visibleIds, "all"));
+      return;
+    }
+
+    // We store RAC's Selection object: it carries the range anchor (so rebuilding
+    // a plain Set each render would break keyboard Shift+Arrow) and the
+    // filter-hidden selected keys it rides through, keeping draft whole.
+    const sel = keys as Set<CardId> & { anchorKey?: Key | null; currentKey?: Key | null };
+
+    // Gmail-style range on a Shift+CLICK: the whole range from the anchor (the last
+    // plain-clicked card, post-toggle) to the clicked card takes the ANCHOR's
+    // current state — anchor selected → the range fills (incl. unselected cards in
+    // between); anchor unselected → the range clears. RAC's native extend is
+    // additive-only, so we recompute from the pre-click selection and overwrite its
+    // result, keeping sel's anchor/current keys so keyboard Shift+Arrow still works.
+    const anchor = anchorRef.current;
+    const target = sel.currentKey as CardId | null | undefined; // the Shift-clicked card
+    if (fromShiftClick && anchor != null && target != null && anchor !== target) {
+      const from = visibleIds.indexOf(anchor);
+      const to = visibleIds.indexOf(target);
+      if (from !== -1 && to !== -1) {
+        const range = visibleIds.slice(Math.min(from, to), Math.max(from, to) + 1);
+        const select = draft.has(anchor);
+        sel.clear(); // drop RAC's additive result; keeps anchorKey/currentKey
+        for (const id of draft) sel.add(id); // restore the pre-click selection (incl. hidden)
+        for (const id of range) {
+          if (select) sel.add(id);
+          else sel.delete(id);
+        }
+      }
+    }
+
+    setDraft(sel);
   };
 
   const hiddenSelectedCount = useMemo(() => {
@@ -137,37 +201,29 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
             )}
           </div>
 
-          {visible.length > 0 && (
-            <p className={styles.hint} id={hintId}>
-              Shift-click or Shift+↑/↓ to select a range.
-            </p>
-          )}
-
-          <ListBox
+          <SelectionListBox
             aria-label="Cards to print"
             aria-describedby={visible.length > 0 ? hintId : undefined}
             className={styles.list}
             selectionMode="multiple"
             selectionBehavior="toggle"
             escapeKeyBehavior="none"
+            allowDuplicateSelectionEvents
             selectedKeys={draft}
-            // Store RAC's Selection as-is: the range anchor lives on that object, so
-            // rebuilding a plain Set each render would reset it and break Shift /
-            // Shift+Arrow range extension. RAC also carries the filter-hidden selected
-            // keys through toggles, so draft stays whole. Only the "all" (Cmd/Ctrl+A)
-            // sentinel must be expanded to the visible ids.
-            onSelectionChange={(keys) =>
-              setDraft((prev) =>
-                keys === "all"
-                  ? mergeVisibleSelection(prev, visibleIds, "all")
-                  : (keys as Set<CardId>),
-              )
-            }
+            onPointerDownCapture={(e) => {
+              shiftClickRef.current = e.shiftKey;
+              if (!e.shiftKey) {
+                const el = (e.target as HTMLElement).closest("[data-card-id]");
+                const id = el?.getAttribute("data-card-id");
+                if (id) anchorRef.current = id as CardId;
+              }
+            }}
+            onSelectionChange={onSelectionChange}
             items={visible}
             renderEmptyState={() => <span className={styles.emptyState}>No cards match.</span>}
           >
             {(c) => (
-              <ListBoxItem id={c.id} textValue={c.name} className={styles.row}>
+              <ListBoxItem id={c.id} textValue={c.name} className={styles.row} data-card-id={c.id}>
                 <span className={styles.rowMain}>
                   <span className={styles.box} aria-hidden="true" />
                   <span className={styles.rowName}>{c.name}</span>
@@ -180,7 +236,7 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
                 </time>
               </ListBoxItem>
             )}
-          </ListBox>
+          </SelectionListBox>
 
           <div className={styles.footer}>
             {hiddenSelectedCount > 0 && (
@@ -197,6 +253,11 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
               {`${pluralize(total, "card")} selected`}
             </span>
             <div className={styles.footerActions}>
+              {visible.length > 0 && (
+                <p className={styles.hint} id={hintId}>
+                  Shift-click or Shift+↑/↓ to select a range.
+                </p>
+              )}
               <Button variant="secondary" onPress={onClose}>
                 Cancel
               </Button>

--- a/src/views/PrintSelectionModal.tsx
+++ b/src/views/PrintSelectionModal.tsx
@@ -145,7 +145,7 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
 
           <ListBox
             aria-label="Cards to print"
-            aria-describedby={hintId}
+            aria-describedby={visible.length > 0 ? hintId : undefined}
             className={styles.list}
             selectionMode="multiple"
             selectionBehavior="toggle"
@@ -203,7 +203,10 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
               <Button
                 variant="primary"
                 onPress={() => {
-                  onApply(draft);
+                  // Commit a plain Set: `draft` may be RAC's Selection subclass
+                  // (it carries a range anchor), but downstream consumers want a
+                  // bare Set<CardId>.
+                  onApply(new Set(draft));
                   onClose();
                 }}
               >

--- a/src/views/PrintSelectionModal.tsx
+++ b/src/views/PrintSelectionModal.tsx
@@ -1,5 +1,5 @@
 import { useId, useMemo, useState } from "react";
-import { TextField } from "react-aria-components";
+import { ListBox, ListBoxItem, TextField } from "react-aria-components";
 import type { CardId, RenderableCard } from "../cards/types";
 import { type DeckKindFilter, type DeckSort, deckListing } from "../decks/deckListing";
 import { pluralize } from "../lib/pluralize";
@@ -13,6 +13,7 @@ import { Select } from "../lib/ui/Select";
 import { ToggleButton } from "../lib/ui/ToggleButton";
 import { ToggleButtonGroup } from "../lib/ui/ToggleButtonGroup";
 import styles from "./PrintSelectionModal.module.css";
+import { mergeVisibleSelection } from "./printSelectionMerge";
 
 type Props = {
   cards: RenderableCard[];
@@ -44,23 +45,16 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
   const allVisibleChecked = visible.length > 0 && visibleCheckedCount === visible.length;
   const headerIndeterminate = !allVisibleChecked && visibleCheckedCount > 0;
 
+  const selectedKeys = useMemo(
+    () => new Set(visibleIds.filter((id) => draft.has(id))),
+    [visibleIds, draft],
+  );
+
   // Intentionally ignores RAC's onChange boolean: RAC passes `true` when clicked
   // from the indeterminate state, but the rule is always "any visible checked → clear".
   const onHeaderToggle = () => {
-    const next = new Set(draft);
-    if (visibleCheckedCount > 0) {
-      for (const id of visibleIds) next.delete(id);
-    } else {
-      for (const id of visibleIds) next.add(id);
-    }
-    setDraft(next);
-  };
-
-  const toggle = (id: CardId) => {
-    const next = new Set(draft);
-    if (next.has(id)) next.delete(id);
-    else next.add(id);
-    setDraft(next);
+    const next = visibleCheckedCount > 0 ? new Set<CardId>() : ("all" as const);
+    setDraft((prev) => mergeVisibleSelection(prev, visibleIds, next));
   };
 
   const hiddenSelectedCount = useMemo(() => {
@@ -75,6 +69,7 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
 
   const total = draft.size;
   const shownCountId = useId();
+  const hintId = useId();
 
   return (
     <DialogShell
@@ -147,26 +142,39 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
             )}
           </div>
 
-          <ul className={styles.list}>
-            {visible.length === 0 ? (
-              <li className={styles.emptyState}>No cards match.</li>
-            ) : (
-              visible.map((c) => (
-                <li key={c.id} className={styles.row}>
-                  <Checkbox isSelected={draft.has(c.id)} onChange={() => toggle(c.id)}>
-                    {c.name}
-                  </Checkbox>
-                  <span className={styles.rowKind} aria-hidden="true">
-                    {c.kind}
-                  </span>
-                  <time className={styles.rowTime} dateTime={c.updatedAt}>
-                    <span className={styles.srOnly}>{"Updated "}</span>
-                    {relativeTime(c.updatedAt)}
-                  </time>
-                </li>
-              ))
+          <p className={styles.hint} id={hintId}>
+            Shift-click or Shift+↑/↓ to select a range.
+          </p>
+
+          <ListBox
+            aria-label="Cards to print"
+            aria-describedby={hintId}
+            className={styles.list}
+            selectionMode="multiple"
+            selectionBehavior="toggle"
+            escapeKeyBehavior="none"
+            selectedKeys={selectedKeys}
+            onSelectionChange={(keys) =>
+              setDraft((prev) => mergeVisibleSelection(prev, visibleIds, keys))
+            }
+            items={visible}
+            renderEmptyState={() => <span className={styles.emptyState}>No cards match.</span>}
+          >
+            {(c) => (
+              <ListBoxItem id={c.id} textValue={c.name} className={styles.row}>
+                <span className={styles.rowMain}>
+                  <span className={styles.box} aria-hidden="true" />
+                  <span className={styles.rowName}>{c.name}</span>
+                </span>
+                <span className={styles.rowKind} aria-hidden="true">
+                  {c.kind}
+                </span>
+                <time className={styles.rowTime} dateTime={c.updatedAt} aria-hidden="true">
+                  {relativeTime(c.updatedAt)}
+                </time>
+              </ListBoxItem>
             )}
-          </ul>
+          </ListBox>
 
           <div className={styles.footer}>
             {hiddenSelectedCount > 0 && (

--- a/src/views/PrintView.test.tsx
+++ b/src/views/PrintView.test.tsx
@@ -7,7 +7,7 @@ import * as layoutPaginatorModule from "../cards/layoutPaginator";
 import { invariant } from "../lib/invariant";
 import { makeAbilityPayload, makeCardRow, makeItemPayload } from "../test/factories";
 import { SB_URL as SB, server } from "../test/msw";
-import { render, screen, waitFor } from "../test/render";
+import { render, screen, waitFor, within } from "../test/render";
 import { PrintView } from "./PrintView";
 import styles from "./PrintView.module.css";
 
@@ -17,6 +17,9 @@ function wrap(ui: ReactNode) {
 }
 
 describe("<PrintView>", () => {
+  const cardOption = (name: string) =>
+    within(screen.getByRole("listbox", { name: /cards to print/i })).getByRole("option", { name });
+
   test("renders one page at 4-up for up to 4 cards", async () => {
     const cards = makeCardRow.buildList(3);
     server.use(
@@ -328,7 +331,7 @@ describe("<PrintView>", () => {
     await waitFor(() => expect(screen.getByText("All 2 cards")).toBeInTheDocument());
 
     await userEvent.click(screen.getByRole("button", { name: /choose cards/i }));
-    await userEvent.click(screen.getByRole("checkbox", { name: "Drop" }));
+    await userEvent.click(cardOption("Drop"));
     await userEvent.click(screen.getByRole("button", { name: /apply/i }));
 
     expect(screen.getByText("1 of 2 cards")).toBeInTheDocument();
@@ -381,7 +384,7 @@ describe("<PrintView>", () => {
     render(wrap(<PrintView deckId="d1" />));
     await waitFor(() => expect(screen.getByText("All 2 cards")).toBeInTheDocument());
     await userEvent.click(screen.getByRole("button", { name: /choose cards/i }));
-    await userEvent.click(screen.getByRole("checkbox", { name: "Beta" }));
+    await userEvent.click(cardOption("Beta"));
     await userEvent.click(screen.getByRole("button", { name: /apply/i }));
     expect(screen.getByText("1 of 2 cards")).toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: /select all/i }));
@@ -399,8 +402,12 @@ describe("<PrintView>", () => {
     render(wrap(<PrintView deckId="d1" />));
     await waitFor(() => expect(screen.getByText("All 1 card")).toBeInTheDocument());
     await userEvent.click(screen.getByRole("button", { name: /choose cards/i }));
-    expect(screen.getByRole("checkbox", { name: "Cloak" })).toBeInTheDocument();
-    expect(screen.queryByRole("checkbox", { name: "Rage" })).not.toBeInTheDocument();
+    expect(cardOption("Cloak")).toBeInTheDocument();
+    expect(
+      within(screen.getByRole("listbox", { name: /cards to print/i })).queryByRole("option", {
+        name: "Rage",
+      }),
+    ).not.toBeInTheDocument();
   });
 
   test("'Continue content on back' selected state persists across disable/re-enable", async () => {

--- a/src/views/printSelectionMerge.test.ts
+++ b/src/views/printSelectionMerge.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+import type { CardId } from "../cards/types";
+import { mergeVisibleSelection } from "./printSelectionMerge";
+
+const ids = (...xs: string[]) => xs as CardId[];
+
+describe("mergeVisibleSelection", () => {
+  test("keeps selected-but-hidden cards when the visible selection changes", () => {
+    const draft = new Set(ids("a", "b", "hidden"));
+    const visibleIds = ids("a", "b"); // 'hidden' is filtered out of the list
+    const next = mergeVisibleSelection(draft, visibleIds, new Set(ids("a")));
+    expect(next).toEqual(new Set(ids("a", "hidden")));
+  });
+
+  test('the "all" sentinel selects every visible id, plus hidden', () => {
+    const draft = new Set(ids("hidden"));
+    const visibleIds = ids("a", "b");
+    const next = mergeVisibleSelection(draft, visibleIds, "all");
+    expect(next).toEqual(new Set(ids("hidden", "a", "b")));
+  });
+
+  test("drops a key that is not in visibleIds (intersection invariant)", () => {
+    const draft = new Set<CardId>();
+    const visibleIds = ids("a", "b");
+    const next = mergeVisibleSelection(draft, visibleIds, new Set(ids("a", "ghost")));
+    expect(next).toEqual(new Set(ids("a")));
+  });
+
+  test("an empty visible set does not drop hidden-selected cards", () => {
+    const draft = new Set(ids("hidden1", "hidden2"));
+    const visibleIds: CardId[] = [];
+    const next = mergeVisibleSelection(draft, visibleIds, new Set<CardId>());
+    expect(next).toEqual(new Set(ids("hidden1", "hidden2")));
+  });
+
+  test("is idempotent: re-applying the current visible selection is content-equal", () => {
+    const draft = new Set(ids("a", "hidden"));
+    const visibleIds = ids("a", "b");
+    const current = new Set(visibleIds.filter((id) => draft.has(id))); // { a }
+    expect(mergeVisibleSelection(draft, visibleIds, current)).toEqual(draft);
+  });
+});

--- a/src/views/printSelectionMerge.ts
+++ b/src/views/printSelectionMerge.ts
@@ -1,0 +1,26 @@
+import type { Key } from "react-aria-components";
+import type { CardId } from "../cards/types";
+
+/**
+ * Merge the ListBox's visible selection back into the full print draft,
+ * preserving cards that are selected but currently hidden by a filter/search.
+ * RAC's `onSelectionChange` emits "all" (Cmd/Ctrl+A) or a Set of the visible keys.
+ */
+export function mergeVisibleSelection(
+  draft: ReadonlySet<CardId>,
+  visibleIds: readonly CardId[],
+  keys: "all" | ReadonlySet<Key>,
+): Set<CardId> {
+  const visible = new Set<CardId>(visibleIds);
+  const next = new Set<CardId>();
+  // Selected-but-hidden cards (in the draft, not currently visible) survive untouched.
+  for (const id of draft) {
+    if (!visible.has(id)) next.add(id);
+  }
+  // Add back the visible selection — intersection with visibleIds narrows Key -> CardId
+  // and guarantees the result is a subset of (hidden ∪ visibleIds).
+  for (const id of visibleIds) {
+    if (keys === "all" || keys.has(id)) next.add(id);
+  }
+  return next;
+}

--- a/src/views/printSelectionMerge.ts
+++ b/src/views/printSelectionMerge.ts
@@ -2,9 +2,10 @@ import type { Key } from "react-aria-components";
 import type { CardId } from "../cards/types";
 
 /**
- * Merge the ListBox's visible selection back into the full print draft,
- * preserving cards that are selected but currently hidden by a filter/search.
- * RAC's `onSelectionChange` emits "all" (Cmd/Ctrl+A) or a Set of the visible keys.
+ * Merge a visible selection into the full print draft, preserving cards selected
+ * but hidden by a filter/search. Used by the header "select all shown" toggle and
+ * the Cmd/Ctrl+A ("all") path; the per-row Shift-click range recomputes inline in
+ * the modal. `keys` is either "all" or a Set of the keys to keep among the visible.
  */
 export function mergeVisibleSelection(
   draft: ReadonlySet<CardId>,


### PR DESCRIPTION
## Summary
- Replaces the "Choose cards to print" list (`<ul>` of per-row checkboxes) with a `react-aria-components` `ListBox` (multi-select, toggle), adding **Gmail-style Shift-click range selection**: a Shift-click sets the range from the anchor to the anchor's state — selected anchor **fills** (including gaps), deselected anchor **clears**; **extending** includes the clicked row, **shrinking** excludes it and drops out to the previous extent (e.g. `1 → Shift-5 → Shift-3` = `{1,2}`). Cmd/Ctrl-click toggles one row; keyboard gets Space toggle, Shift+↑/↓ extend, Cmd/Ctrl+A select-all, type-ahead.
- `draft: Set<CardId>` stays the source of truth. A pure, unit-tested `mergeVisibleSelection` helper plus an own-anchor/extent override reconcile the controlled selection over the filtered list and **preserve filter-hidden selections** (filters never drop a selected card).
- Search, kind filter, recency/name sort, the header "select all shown" tri-state, the "hidden by filters — still included" footer line, Apply/Cancel, and the `PrintView` sidebar are unchanged. Print output is untouched.
- Adds a one-line range hint in the footer and fixes a focus-ring bug where hovering a row showed the browser-default blue outline.
- Design spec + implementation plan live under `docs/superpowers/`.

Built against the RAC `1.17.0` selection internals (additive-only Shift-extend, no anchor on deselect, no-op event suppression); the workarounds (`allowDuplicateSelectionEvents`, own-anchor tracking, in-place `Selection` rebuild) are documented in code + spec.

## Test plan
- [x] `npx vitest run` (860 passing) and `npm run build` green.
- [ ] Print → Choose cards…: Shift-click fills/clears a range from the anchor; extending includes / shrinking excludes the clicked row; Cmd/Ctrl-click toggles one; keyboard Shift+↑/↓ extends; Cmd/Ctrl+A selects all shown.
- [ ] A card selected via a Shift-range stays selected (and in the Apply count) after a filter hides it.
- [ ] Row focus ring uses the site color on keyboard focus and shows no blue on hover.
- [ ] Existing "print a subset" flow + print output unchanged.

Related: #88 (centralize focus-ring styling site-wide — follow-up).