### PR TITLE
chore: remove vercel.json after CF Workers cutover

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,0 @@
-{
-  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
-}


### PR DESCRIPTION
### What are the relevant tickets?

- https://github.com/ChristopherChudzicki/deckwright/issues/71

Closes #71

### Description (What does it do?)

Final teardown step following the Cloudflare Workers Static Assets cutover (#69). Deletes `vercel.json`, which held the SPA-fallback rewrite for the now-retired Vercel deployment.

`deckwright.org` has been live on CF Workers for two weeks. `wrangler.jsonc` provides SPA routing via `not_found_handling: "single-page-application"`, so the Vercel rewrite config no longer serves any purpose.

### How can this be tested?

This change only affects the (now-deleted) Vercel deployment, not `deckwright.org`. No app code references `vercel.json`, so there's nothing to exercise at runtime — CI build/test covers the rest.

### Additional Context

All out-of-repo teardown from #71 is already complete:
- Vercel project deleted
- Supabase redirect URLs cleaned up (auth confirmed working)
- CF Worker production branch switched to `main`

This PR is the last remaining checklist item, hence `Closes #71`.