### PR TITLE
feat(browse): redesign dialog — scope-first layout, radio filter, a11y

### DIFF
--- a/src/api/content-types/all.ts
+++ b/src/api/content-types/all.ts
@@ -16,7 +16,7 @@ type TaggedEntry =
 export const allContentType: ContentType = {
   id: "all",
   label: "All",
-  searchPlaceholder: "Search SRD…",
+  searchPlaceholder: "Search all…",
   emptyMessage: "No results match your search.",
   supportedSources: ["2024", "2014"],
   useResults: (source, query) => {

--- a/src/index.css
+++ b/src/index.css
@@ -116,6 +116,19 @@ h3 {
   outline-offset: 2px;
 }
 
+/* Visually hidden but available to assistive tech (live regions, field hints). */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 @page {
   size: letter portrait;
   margin-top: 0.5in;

--- a/src/lib/ui/README.md
+++ b/src/lib/ui/README.md
@@ -56,6 +56,10 @@ Two scopes for tokens:
 - **Screen tokens** (`--color-*`, `--space-*`, `--radius-*`, `--shadow-*`, `--fs-*`, etc.) — used by everything in `src/lib/ui/` and most of `src/views/`.
 - **Print tokens** (`--print-*`) — used only by `src/cards/Card.tsx` and `src/views/PrintView.tsx` (sheet preview half). Never reference these in screen UI.
 
+## Global utilities
+
+Styling is otherwise CSS-module-scoped, but one global utility lives in `src/index.css`: **`.sr-only`** — visually hides an element while keeping it available to assistive tech (live regions, field hints). Use `className="sr-only"` rather than re-rolling the clip recipe per module.
+
 ## Testing
 
 Tests live next to the primitive (`Foo.tsx` + `Foo.test.tsx`). Conventions:

--- a/src/lib/ui/README.md
+++ b/src/lib/ui/README.md
@@ -17,6 +17,7 @@ Thin wrappers around `react-aria-components` (and a couple of native elements) t
 | `Checkbox` | A checkbox. Supports `isIndeterminate` for tri-state (renders `aria-checked="mixed"`). Children are the label; omit them and pass `aria-label` for a label-less control. |
 | `ToggleButton` | A toggleable button (alone or inside a `ToggleButtonGroup`). |
 | `ToggleButtonGroup` | A segmented selector — wraps `ToggleButton` children. |
+| `RadioGroup` / `Radio` | A single-select control with true `radiogroup`/`radio` semantics. Use for a mutually-exclusive filter/choice where "exactly one selected" should be announced. Styled as a segmented control (no native circles). String `value`/`onChange`. |
 | `DialogShell` | The outer scaffolding (overlay + modal + dialog) for any modal. |
 | `DialogHeader` | The standard header strip for any dialog: title, optional middle slot, close X. |
 | `LoadingState` | A centered "Loading…" indicator (`role="status"`). Use whenever a view is waiting on a query. |

--- a/src/lib/ui/RadioGroup.module.css
+++ b/src/lib/ui/RadioGroup.module.css
@@ -1,0 +1,33 @@
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+/* Segmented-control styling: the radio reads as a selectable pill, with no
+   native circle. Selection state comes through color, matching the app accent. */
+.radio {
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  font: inherit;
+  font-family: var(--font-body);
+  color: var(--color-text);
+  cursor: pointer;
+  outline: none;
+  user-select: none;
+}
+
+.radio[data-hovered]:not([data-selected]) {
+  background: var(--color-border-strong);
+}
+
+.radio[data-selected] {
+  background: var(--color-accent);
+  color: var(--color-accent-fg);
+  font-weight: 600;
+}
+
+.radio[data-focus-visible] {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}

--- a/src/lib/ui/RadioGroup.test.tsx
+++ b/src/lib/ui/RadioGroup.test.tsx
@@ -1,0 +1,48 @@
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { render, screen } from "../../test/render";
+import { Radio, RadioGroup } from "./RadioGroup";
+
+describe("<RadioGroup>", () => {
+  it("renders its options as radios inside a radiogroup", () => {
+    render(
+      <RadioGroup aria-label="Alignment" defaultValue="left">
+        <Radio value="left">Left</Radio>
+        <Radio value="right">Right</Radio>
+      </RadioGroup>,
+    );
+    expect(screen.getByRole("radiogroup", { name: "Alignment" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Left" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "Right" })).not.toBeChecked();
+  });
+
+  it("moves selection to the chosen option", async () => {
+    function Harness() {
+      const [value, setValue] = useState("left");
+      return (
+        <RadioGroup aria-label="Alignment" value={value} onChange={setValue}>
+          <Radio value="left">Left</Radio>
+          <Radio value="right">Right</Radio>
+        </RadioGroup>
+      );
+    }
+    render(<Harness />);
+    await userEvent.click(screen.getByRole("radio", { name: "Right" }));
+    expect(screen.getByRole("radio", { name: "Right" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "Left" })).not.toBeChecked();
+  });
+
+  it("moves selection with the arrow keys", async () => {
+    render(
+      <RadioGroup aria-label="Alignment" defaultValue="left">
+        <Radio value="left">Left</Radio>
+        <Radio value="right">Right</Radio>
+      </RadioGroup>,
+    );
+    await userEvent.tab();
+    expect(screen.getByRole("radio", { name: "Left" })).toHaveFocus();
+    await userEvent.keyboard("{ArrowDown}");
+    expect(screen.getByRole("radio", { name: "Right" })).toBeChecked();
+  });
+});

--- a/src/lib/ui/RadioGroup.tsx
+++ b/src/lib/ui/RadioGroup.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from "react";
 import {
   Radio as RACRadio,
   RadioGroup as RACRadioGroup,
@@ -16,15 +15,10 @@ export function RadioGroup({ className, ...rest }: RadioGroupProps) {
   return <RACRadioGroup {...rest} className={cx(styles.group, className)} />;
 }
 
-export type RadioProps = Omit<RACRadioProps, "className" | "children"> & {
+export type RadioProps = Omit<RACRadioProps, "className"> & {
   className?: string;
-  children?: ReactNode;
 };
 
-export function Radio({ className, children, ...rest }: RadioProps) {
-  return (
-    <RACRadio {...rest} className={cx(styles.radio, className)}>
-      {children}
-    </RACRadio>
-  );
+export function Radio({ className, ...rest }: RadioProps) {
+  return <RACRadio {...rest} className={cx(styles.radio, className)} />;
 }

--- a/src/lib/ui/RadioGroup.tsx
+++ b/src/lib/ui/RadioGroup.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from "react";
+import {
+  Radio as RACRadio,
+  RadioGroup as RACRadioGroup,
+  type RadioGroupProps as RACRadioGroupProps,
+  type RadioProps as RACRadioProps,
+} from "react-aria-components";
+import { cx } from "../cx";
+import styles from "./RadioGroup.module.css";
+
+export type RadioGroupProps = Omit<RACRadioGroupProps, "className"> & {
+  className?: string;
+};
+
+export function RadioGroup({ className, ...rest }: RadioGroupProps) {
+  return <RACRadioGroup {...rest} className={cx(styles.group, className)} />;
+}
+
+export type RadioProps = Omit<RACRadioProps, "className" | "children"> & {
+  className?: string;
+  children?: ReactNode;
+};
+
+export function Radio({ className, children, ...rest }: RadioProps) {
+  return (
+    <RACRadio {...rest} className={cx(styles.radio, className)}>
+      {children}
+    </RACRadio>
+  );
+}

--- a/src/lib/ui/TagInput.module.css
+++ b/src/lib/ui/TagInput.module.css
@@ -198,18 +198,6 @@
   pointer-events: none;
 }
 
-.srOnly {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
 .input:focus-visible {
   outline: 0;
 }

--- a/src/lib/ui/TagInput.tsx
+++ b/src/lib/ui/TagInput.tsx
@@ -313,7 +313,7 @@ export function TagInput({
           return slotChildren;
         })}
       </ul>
-      <span id={hintId} className={styles.srOnly}>
+      <span id={hintId} className="sr-only">
         Use the left arrow key to insert tags between existing tags.
       </span>
       <input

--- a/src/views/BrowseApiModal.module.css
+++ b/src/views/BrowseApiModal.module.css
@@ -6,49 +6,39 @@
   container-type: inline-size;
 }
 
-.layout {
+.body {
   flex: 1;
   display: flex;
   min-height: 0;
 }
 
-.tabs {
-  flex: 1;
-  display: flex;
-  min-height: 0;
-}
-
-.tabList {
+/* Left filter rail: source scope above the type radio group. */
+.rail {
   width: 10rem;
   flex: 0 0 auto;
   display: flex;
   flex-direction: column;
-  padding: var(--space-2) var(--space-2);
-  gap: var(--space-1);
+  gap: var(--space-2);
+  padding: var(--space-2);
   border-right: 1px solid var(--color-border);
   background: var(--color-surface-2);
 }
 
-.tab {
-  padding: var(--space-2) var(--space-3);
-  border-radius: var(--radius-md);
-  font: inherit;
-  font-family: var(--font-body);
-  color: var(--color-text);
-  cursor: pointer;
+.scope {
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--color-border);
 }
 
-.tab[data-hovered]:not([data-selected]) {
-  background: var(--color-border-strong);
+.typeFilter {
+  flex-direction: column;
 }
 
-.tab[data-selected] {
-  background: var(--color-accent);
-  color: var(--color-accent-fg);
-  font-weight: 600;
+.typeFilter > * {
+  width: 100%;
+  text-align: left;
 }
 
-.tabPanel {
+.main {
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -148,27 +138,36 @@
   line-height: 1.4;
 }
 
-.typeMenuTrigger {
-  display: none;
-}
-
+/* Narrow widths: the rail drops below the header as a stacked filter bar, and
+   the type radio group reflows from a vertical list into compact chips that wrap
+   onto further rows as more options are added. */
 @container (max-width: 559px) {
-  .tabList {
-    display: none;
+  .body {
+    flex-direction: column;
   }
-  .typeMenuTrigger {
-    display: inline-block;
+  .rail {
+    width: auto;
+    gap: var(--space-3);
+    border-right: 0;
+    border-bottom: 1px solid var(--color-border);
   }
-}
-
-.tabs:is(:focus-visible, [data-focus-visible]) {
-  outline: none;
-}
-
-.tabList:is(:focus-visible, [data-focus-visible]) {
-  outline: none;
-}
-
-.tabPanel:is(:focus-visible, [data-focus-visible]) {
-  outline: none;
+  .scope {
+    padding-bottom: 0;
+    border-bottom: 0;
+  }
+  .typeFilter {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+  .typeFilter > * {
+    width: auto;
+    padding: var(--space-2) var(--space-3);
+    text-align: center;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border-strong);
+  }
+  .typeFilter > *[data-selected] {
+    border-color: var(--color-accent);
+  }
 }

--- a/src/views/BrowseApiModal.test.tsx
+++ b/src/views/BrowseApiModal.test.tsx
@@ -48,22 +48,25 @@ const openSourceMenu = async () => {
 };
 
 describe("<BrowseApiModal>", () => {
-  test("renders the registered types as a vertical tablist in registry order", async () => {
+  test("renders the registered types as a radio group in registry order", async () => {
     const client = makeClient();
     wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
 
-    const tabs = screen.getAllByRole("tab");
-    expect(tabs.map((t) => t.textContent)).toEqual(["All", "Items", "Spells"]);
+    const options = screen.getAllByRole("radio");
+    expect(options).toHaveLength(3);
+    expect(options[0]).toHaveAccessibleName("All");
+    expect(options[1]).toHaveAccessibleName("Items");
+    expect(options[2]).toHaveAccessibleName("Spells");
   });
 
-  test("All tab is selected by default", async () => {
+  test("All is selected by default", async () => {
     const client = makeClient();
     wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
 
-    expect(screen.getByRole("tab", { name: "All" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("radio", { name: "All" })).toBeChecked();
   });
 
-  test("All tab merges items and spells alphabetically", async () => {
+  test("All merges items and spells alphabetically", async () => {
     const item = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
     const spell = spellIndexEntryFactory.build({ name: "Fireball" });
     const client = makeClient({
@@ -83,7 +86,7 @@ describe("<BrowseApiModal>", () => {
     expect(bagIdx).toBeLessThan(fireIdx);
   });
 
-  test("All tab prefixes item rows with 'Item · '", async () => {
+  test("All prefixes item rows with 'Item · '", async () => {
     const item = magicItemIndexEntryFactory.build({
       name: "Bag of Holding",
       rarity: { name: "Uncommon" },
@@ -96,7 +99,7 @@ describe("<BrowseApiModal>", () => {
     expect(row).toHaveTextContent("Item · Uncommon");
   });
 
-  test("All tab prefixes spell rows with 'Spell · '", async () => {
+  test("All prefixes spell rows with 'Spell · '", async () => {
     const spell = spellIndexEntryFactory.build({
       name: "Fireball",
       level: 3,
@@ -110,7 +113,7 @@ describe("<BrowseApiModal>", () => {
     expect(row).toHaveTextContent("Spell · 3rd-level evocation");
   });
 
-  test("Items tab does not prefix rows with 'Item · '", async () => {
+  test("Items does not prefix rows with 'Item · '", async () => {
     const item = magicItemIndexEntryFactory.build({
       name: "Bag of Holding",
       rarity: { name: "Uncommon" },
@@ -119,13 +122,13 @@ describe("<BrowseApiModal>", () => {
 
     wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
 
-    await userEvent.click(screen.getByRole("tab", { name: "Items" }));
+    await userEvent.click(screen.getByRole("radio", { name: "Items" }));
     const row = await screen.findByRole("button", { name: /Bag of Holding/ });
     expect(row).toHaveTextContent("Uncommon");
     expect(row).not.toHaveTextContent("Item · ");
   });
 
-  test("Spells tab does not prefix rows with 'Spell · '", async () => {
+  test("Spells does not prefix rows with 'Spell · '", async () => {
     const spell = spellIndexEntryFactory.build({
       name: "Fireball",
       level: 3,
@@ -135,13 +138,13 @@ describe("<BrowseApiModal>", () => {
 
     wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
 
-    await userEvent.click(screen.getByRole("tab", { name: "Spells" }));
+    await userEvent.click(screen.getByRole("radio", { name: "Spells" }));
     const row = await screen.findByRole("button", { name: /Fireball/ });
     expect(row).toHaveTextContent("3rd-level evocation");
     expect(row).not.toHaveTextContent("Spell · ");
   });
 
-  test("All tab empty state reads 'No results match your search.'", async () => {
+  test("All empty state reads 'No results match your search.'", async () => {
     const client = makeClient();
     wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
 
@@ -184,7 +187,7 @@ describe("<BrowseApiModal>", () => {
 
     wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
 
-    await userEvent.click(screen.getByRole("tab", { name: "Spells" }));
+    await userEvent.click(screen.getByRole("radio", { name: "Spells" }));
     await screen.findByRole("button", { name: /^Fire Bolt/ });
     await userEvent.type(screen.getByRole("searchbox"), "firebolt");
 
@@ -230,7 +233,7 @@ describe("<BrowseApiModal>", () => {
     expect(screen.queryByRole("button", { name: /Ring A/ })).not.toBeInTheDocument();
   });
 
-  test("switching source on the Items tab updates mundane rows", async () => {
+  test("switching source on the Items type updates mundane rows", async () => {
     const v2024 = mundaneItemIndexEntryFactory.build({ name: "Hempen Rope" });
     const v2014 = mundaneItemIndexEntryFactory.build({ name: "Silken Rope" });
     const client = makeClient({
@@ -252,7 +255,7 @@ describe("<BrowseApiModal>", () => {
     expect(screen.queryByRole("button", { name: /Hempen Rope/ })).not.toBeInTheDocument();
   });
 
-  test("Items tab merges magic and mundane sources alphabetically", async () => {
+  test("Items merges magic and mundane sources alphabetically", async () => {
     const magicItem = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
     const mundaneItem = mundaneItemIndexEntryFactory.build({ name: "Battleaxe" });
     const client = makeClient({
@@ -262,7 +265,7 @@ describe("<BrowseApiModal>", () => {
 
     wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
 
-    await userEvent.click(screen.getByRole("tab", { name: "Items" }));
+    await userEvent.click(screen.getByRole("radio", { name: "Items" }));
     await screen.findByRole("button", { name: /Bag of Holding/ });
     const matched = screen.getAllByRole("button", { name: /Bag of Holding|Battleaxe/ });
     const names = matched.map((b) => b.textContent ?? "");
@@ -273,7 +276,7 @@ describe("<BrowseApiModal>", () => {
     expect(bagIdx).toBeLessThan(battleaxeIdx);
   });
 
-  test("switching to the Spells tab swaps the list source", async () => {
+  test("switching to the Spells type swaps the list source", async () => {
     const item = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
     const spell = spellIndexEntryFactory.build({ name: "Fireball" });
     const client = makeClient({
@@ -284,7 +287,7 @@ describe("<BrowseApiModal>", () => {
     wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
 
     await screen.findByRole("button", { name: /Bag of Holding/ });
-    await userEvent.click(screen.getByRole("tab", { name: "Spells" }));
+    await userEvent.click(screen.getByRole("radio", { name: "Spells" }));
 
     await waitFor(() =>
       expect(screen.getByRole("button", { name: /Fireball/ })).toBeInTheDocument(),
@@ -292,7 +295,7 @@ describe("<BrowseApiModal>", () => {
     expect(screen.queryByRole("button", { name: /Bag of Holding/ })).not.toBeInTheDocument();
   });
 
-  test("switching tabs clears the search query", async () => {
+  test("switching type clears the search query", async () => {
     const item = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
     const spell = spellIndexEntryFactory.build({ name: "Fireball" });
     const client = makeClient({
@@ -305,18 +308,18 @@ describe("<BrowseApiModal>", () => {
     await screen.findByRole("button", { name: /Bag of Holding/ });
     await userEvent.type(screen.getByRole("searchbox"), "bag");
 
-    await userEvent.click(screen.getByRole("tab", { name: "Spells" }));
+    await userEvent.click(screen.getByRole("radio", { name: "Spells" }));
 
     const spellsSearch = await screen.findByRole("searchbox");
     expect(spellsSearch).toHaveValue("");
     expect(spellsSearch).toHaveAttribute("placeholder", "Search spells…");
   });
 
-  test("All tab search placeholder reads 'Search SRD…'", async () => {
+  test("All search placeholder reads 'Search all…'", async () => {
     const client = makeClient();
     wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
 
-    expect(screen.getByRole("searchbox")).toHaveAttribute("placeholder", "Search SRD…");
+    expect(screen.getByRole("searchbox")).toHaveAttribute("placeholder", "Search all…");
   });
 
   test("clicking an item POSTs a card with kind:item", async () => {
@@ -354,7 +357,7 @@ describe("<BrowseApiModal>", () => {
 
     wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={onSelected} />, client);
 
-    await userEvent.click(screen.getByRole("tab", { name: "Spells" }));
+    await userEvent.click(screen.getByRole("radio", { name: "Spells" }));
     await userEvent.click(await screen.findByRole("button", { name: /Fireball/ }));
 
     await waitFor(() => expect(onPost).toHaveBeenCalled());
@@ -362,7 +365,7 @@ describe("<BrowseApiModal>", () => {
     expect(onSelected).toHaveBeenCalledWith(expect.any(String));
   });
 
-  test("clicking a mundane item from the Items tab POSTs a card with kind:item", async () => {
+  test("clicking a mundane item from the Items type POSTs a card with kind:item", async () => {
     const entry = mundaneItemIndexEntryFactory.build({
       name: "Battleaxe",
       category: { name: "Weapon" },
@@ -478,7 +481,7 @@ describe("<BrowseApiModal>", () => {
 
     wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
 
-    await userEvent.click(screen.getByRole("tab", { name: "Spells" }));
+    await userEvent.click(screen.getByRole("radio", { name: "Spells" }));
     const cantripRow = await screen.findByRole("button", { name: /Light/ });
     expect(cantripRow).toHaveTextContent("Evocation cantrip");
     const leveledRow = screen.getByRole("button", { name: /Fireball/ });
@@ -504,7 +507,7 @@ describe("<BrowseApiModal>", () => {
     expect(items.map((el) => el.textContent)).toEqual(["2024", "2014"]);
   });
 
-  test("pick error clears when switching tabs", async () => {
+  test("pick error clears when switching type", async () => {
     const item = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
     const spell = spellIndexEntryFactory.build({ name: "Fireball" });
     const client = makeClient({
@@ -518,7 +521,7 @@ describe("<BrowseApiModal>", () => {
     await userEvent.click(await screen.findByRole("button", { name: /Bag of Holding/ }));
     await screen.findByRole("alert");
 
-    await userEvent.click(screen.getByRole("tab", { name: "Spells" }));
+    await userEvent.click(screen.getByRole("radio", { name: "Spells" }));
 
     await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
   });
@@ -545,5 +548,74 @@ describe("<BrowseApiModal>", () => {
     wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
 
     expect(await screen.findByRole("button", { name: "Retry" })).toBeInTheDocument();
+  });
+
+  test("autofocuses the search box when opened via pointer", async () => {
+    const client = makeClient();
+    wrap(
+      <BrowseApiModal
+        deckId="d1"
+        openPointerType="mouse"
+        onClose={() => {}}
+        onSelected={() => {}}
+      />,
+      client,
+    );
+
+    expect(screen.getByRole("searchbox")).toHaveFocus();
+  });
+
+  test.each([
+    "keyboard",
+    "virtual",
+  ] as const)("does not autofocus the search box when opened via %s", async (openPointerType) => {
+    const client = makeClient();
+    wrap(
+      <BrowseApiModal
+        deckId="d1"
+        openPointerType={openPointerType}
+        onClose={() => {}}
+        onSelected={() => {}}
+      />,
+      client,
+    );
+
+    expect(screen.getByRole("searchbox")).not.toHaveFocus();
+  });
+
+  test("arrowing through the type control does not pull focus into the search box", async () => {
+    // Regression guard: search used to live inside each tab panel, so switching
+    // type remounted an autofocused input that stole focus mid-arrow. The search
+    // is now hoisted and stable, so keyboard navigation of the type stays put.
+    const item = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
+    const spell = spellIndexEntryFactory.build({ name: "Fireball" });
+    const client = makeClient({
+      items: { "2024": { count: 1, results: [item] } },
+      spells: { "2024": { count: 1, results: [spell] } },
+    });
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    screen.getByRole("radio", { name: "All" }).focus();
+    await userEvent.keyboard("{ArrowDown}");
+
+    expect(screen.getByRole("radio", { name: "Items" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "Items" })).toHaveFocus();
+    expect(screen.getByRole("searchbox")).not.toHaveFocus();
+  });
+
+  test("announces the result count in a polite live region, updating as the list filters", async () => {
+    const bag = magicItemIndexEntryFactory.build({ name: "Bag of Holding" });
+    const cloak = magicItemIndexEntryFactory.build({ name: "Cloak of Protection" });
+    const client = makeClient({ items: { "2024": { count: 2, results: [bag, cloak] } } });
+
+    wrap(<BrowseApiModal deckId="d1" onClose={() => {}} onSelected={() => {}} />, client);
+
+    const region = await screen.findByText("2 results");
+    expect(region).toHaveAttribute("aria-live", "polite");
+
+    await userEvent.type(screen.getByRole("searchbox"), "bag");
+
+    expect(await screen.findByText("1 result")).toBeInTheDocument();
   });
 });

--- a/src/views/BrowseApiModal.tsx
+++ b/src/views/BrowseApiModal.tsx
@@ -103,7 +103,7 @@ export function BrowseApiModal({ deckId, onClose, onSelected, openPointerType }:
                 onChange={handleTypeChange}
               >
                 {CONTENT_TYPES.map((t) => (
-                  <Radio key={t.id} value={t.id} className={styles.typeOption}>
+                  <Radio key={t.id} value={t.id}>
                     {t.label}
                   </Radio>
                 ))}

--- a/src/views/BrowseApiModal.tsx
+++ b/src/views/BrowseApiModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Tab, TabList, TabPanel, Tabs, TextField } from "react-aria-components";
+import { type PressEvent, TextField } from "react-aria-components";
 import { CONTENT_TYPES, type ContentType } from "../api/content-types";
 import type { Ruleset } from "../api/endpoints/magicItems";
 import type { Card } from "../cards/types";
@@ -10,16 +10,21 @@ import { DialogShell } from "../lib/ui/DialogShell";
 import { Input } from "../lib/ui/Input";
 import { Link } from "../lib/ui/Link";
 import { LoadingState } from "../lib/ui/LoadingState";
+import { Radio, RadioGroup } from "../lib/ui/RadioGroup";
 import { Select } from "../lib/ui/Select";
 import styles from "./BrowseApiModal.module.css";
+
+/** The trigger's `PressEvent.pointerType` — how the dialog was opened. */
+export type OpenPointerType = PressEvent["pointerType"];
 
 type Props = {
   deckId: string;
   onClose: () => void;
   onSelected: (cardId: string) => void;
+  openPointerType?: OpenPointerType | null;
 };
 
-export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
+export function BrowseApiModal({ deckId, onClose, onSelected, openPointerType }: Props) {
   const [typeId, setTypeId] = useState<string>(CONTENT_TYPES[0].id);
   const activeType = CONTENT_TYPES.find((t) => t.id === typeId) ?? CONTENT_TYPES[0];
 
@@ -33,8 +38,14 @@ export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
   const [query, setQuery] = useState("");
   const [pickingKey, setPickingKey] = useState<string | null>(null);
   const [pickError, setPickError] = useState<string | null>(null);
+  const [resultCount, setResultCount] = useState<number | null>(null);
 
-  const handleTabChange = (next: string) => {
+  // Pointer opens autofocus the search for immediate typing. Keyboard and
+  // assistive-tech opens skip it, leaving focus at the top of the dialog so the
+  // source scope and type filter are encountered before the search box.
+  const autoFocusSearch = openPointerType !== "keyboard" && openPointerType !== "virtual";
+
+  const handleTypeChange = (next: string) => {
     if (next === typeId) return;
     setTypeId(next);
     setQuery("");
@@ -58,56 +69,77 @@ export function BrowseApiModal({ deckId, onClose, onSelected }: Props) {
     }
   };
 
+  const countMessage =
+    resultCount === null ? "" : `${resultCount} ${resultCount === 1 ? "result" : "results"}`;
+
   return (
     <DialogShell
       isOpen
       onOpenChange={(open) => {
         if (!open) onClose();
       }}
-      aria-label="Browse SRD"
+      aria-label="Browse content"
       size="lg"
       height={{ fixed: "min(70vh, 640px)" }}
       bleed
     >
       {() => (
         <div className={styles.modalContainer}>
-          <DialogHeader title="Browse SRD" onClose={onClose}>
-            <TypeMenu activeId={typeId} onChange={handleTabChange} />
-            <SourceMenu
-              source={source}
-              options={activeType.supportedSources}
-              onChange={setSource}
-            />
-          </DialogHeader>
+          <DialogHeader title="Browse content" onClose={onClose} />
 
-          <div className={styles.layout}>
-            <Tabs
-              orientation="vertical"
-              selectedKey={typeId}
-              onSelectionChange={(k) => handleTabChange(String(k))}
-              className={styles.tabs}
-            >
-              <TabList aria-label="Content types" className={styles.tabList}>
+          <div className={styles.body}>
+            <div className={styles.rail}>
+              <div className={styles.scope}>
+                <SourceMenu
+                  source={source}
+                  options={activeType.supportedSources}
+                  onChange={setSource}
+                />
+              </div>
+              <RadioGroup
+                aria-label="Content type"
+                className={styles.typeFilter}
+                value={typeId}
+                onChange={handleTypeChange}
+              >
                 {CONTENT_TYPES.map((t) => (
-                  <Tab key={t.id} id={t.id} className={styles.tab}>
+                  <Radio key={t.id} value={t.id} className={styles.typeOption}>
                     {t.label}
-                  </Tab>
+                  </Radio>
                 ))}
-              </TabList>
-              {CONTENT_TYPES.map((t) => (
-                <TabPanel key={t.id} id={t.id} className={styles.tabPanel}>
-                  <TypePanel
-                    type={t}
-                    source={source}
-                    query={query}
-                    onQueryChange={setQuery}
-                    pickingKey={pickingKey}
-                    pickError={pickError}
-                    onPick={handlePick}
+              </RadioGroup>
+            </div>
+
+            <div className={styles.main}>
+              <div className={styles.searchRow}>
+                <TextField aria-label="Search" className={styles.searchField}>
+                  <Input
+                    type="search"
+                    placeholder={activeType.searchPlaceholder}
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    autoFocus={autoFocusSearch}
                   />
-                </TabPanel>
-              ))}
-            </Tabs>
+                </TextField>
+              </div>
+              {/* Keyed by type so the component remounts on type change: each
+                  ContentType.useResults calls a different number of hooks, so a
+                  single instance switching types would violate the rules of hooks. */}
+              <Results
+                key={activeType.id}
+                type={activeType}
+                source={source}
+                query={query}
+                pickingKey={pickingKey}
+                pickError={pickError}
+                onPick={handlePick}
+                onCount={setResultCount}
+              />
+            </div>
+          </div>
+
+          <div className="sr-only" aria-live="polite" aria-atomic="true">
+            {countMessage}
           </div>
 
           <p className={styles.footer}>
@@ -154,101 +186,71 @@ function SourceMenu({
   );
 }
 
-function TypeMenu({ activeId, onChange }: { activeId: string; onChange: (next: string) => void }) {
-  return (
-    <Select
-      label="Type"
-      selectedKey={activeId}
-      onSelectionChange={onChange}
-      triggerClassName={styles.typeMenuTrigger}
-      items={CONTENT_TYPES.map((t) => ({ id: t.id, label: t.label }))}
-    />
-  );
-}
-
-type TypePanelProps = {
+type ResultsProps = {
   type: ContentType;
   source: Ruleset;
   query: string;
-  onQueryChange: (q: string) => void;
   pickingKey: string | null;
   pickError: string | null;
   onPick: (rowKey: string, card: Card) => void;
+  onCount: (count: number | null) => void;
 };
 
-function TypePanel({
-  type,
-  source,
-  query,
-  onQueryChange,
-  pickingKey,
-  pickError,
-  onPick,
-}: TypePanelProps) {
+function Results({ type, source, query, pickingKey, pickError, onPick, onCount }: ResultsProps) {
   const results = type.useResults(source, query);
-  const emptyMessage = type.emptyMessage;
+  const { isLoading, isError, rows } = results;
+
+  useEffect(() => {
+    onCount(isLoading || isError ? null : rows.length);
+  }, [isLoading, isError, rows.length, onCount]);
 
   return (
-    <>
-      <div className={styles.searchRow}>
-        <TextField aria-label="Search" className={styles.searchField}>
-          <Input
-            type="search"
-            placeholder={type.searchPlaceholder}
-            value={query}
-            onChange={(e) => onQueryChange(e.target.value)}
-            autoFocus
-          />
-        </TextField>
-      </div>
-
-      <div className={styles.results}>
-        {results.isLoading && (
-          <div className={styles.statePane}>
-            <LoadingState />
-          </div>
-        )}
-        {results.isError && (
-          <div className={styles.statePane}>
-            <div className={`${styles.state} ${styles.stateError}`} role="alert">
-              Couldn't load the list.
-              <div className={styles.errorActions}>
-                <Button variant="secondary" size="sm" onPress={() => results.refetch()}>
-                  Retry
-                </Button>
-              </div>
+    <div className={styles.results}>
+      {isLoading && (
+        <div className={styles.statePane}>
+          <LoadingState />
+        </div>
+      )}
+      {isError && (
+        <div className={styles.statePane}>
+          <div className={`${styles.state} ${styles.stateError}`} role="alert">
+            Couldn't load the list.
+            <div className={styles.errorActions}>
+              <Button variant="secondary" size="sm" onPress={() => results.refetch()}>
+                Retry
+              </Button>
             </div>
           </div>
-        )}
-        {!results.isLoading && !results.isError && results.rows.length === 0 && (
-          <div className={styles.statePane}>
-            <div className={styles.state}>{emptyMessage}</div>
-          </div>
-        )}
-        {pickError && (
-          <div className={`${styles.state} ${styles.stateError}`} role="alert">
-            {pickError}
-          </div>
-        )}
-        {results.rows.map((row) => (
-          <button
-            key={row.key}
-            type="button"
-            className={styles.row}
-            onClick={() => onPick(row.key, row.toCard())}
-            disabled={pickingKey !== null}
-          >
-            <span className={styles.rowName}>{row.name}</span>
-            <span className={styles.rowMeta}>
-              {pickingKey === row.key
-                ? "Loading…"
-                : type.id === "all" && row.kindLabel
-                  ? `${row.kindLabel} · ${row.meta}`
-                  : row.meta}
-            </span>
-          </button>
-        ))}
-      </div>
-    </>
+        </div>
+      )}
+      {!isLoading && !isError && rows.length === 0 && (
+        <div className={styles.statePane}>
+          <div className={styles.state}>{type.emptyMessage}</div>
+        </div>
+      )}
+      {pickError && (
+        <div className={`${styles.state} ${styles.stateError}`} role="alert">
+          {pickError}
+        </div>
+      )}
+      {rows.map((row) => (
+        <button
+          key={row.key}
+          type="button"
+          className={styles.row}
+          onClick={() => onPick(row.key, row.toCard())}
+          disabled={pickingKey !== null}
+        >
+          <span className={styles.rowName}>{row.name}</span>
+          <span className={styles.rowMeta}>
+            {pickingKey === row.key
+              ? "Loading…"
+              : type.id === "all" && row.kindLabel
+                ? `${row.kindLabel} · ${row.meta}`
+                : row.meta}
+          </span>
+        </button>
+      ))}
+    </div>
   );
 }

--- a/src/views/DeckView.tsx
+++ b/src/views/DeckView.tsx
@@ -13,7 +13,7 @@ import { LoadingState } from "../lib/ui/LoadingState";
 import { Select } from "../lib/ui/Select";
 import { ToggleButton } from "../lib/ui/ToggleButton";
 import { ToggleButtonGroup } from "../lib/ui/ToggleButtonGroup";
-import { BrowseApiModal } from "./BrowseApiModal";
+import { BrowseApiModal, type OpenPointerType } from "./BrowseApiModal";
 import styles from "./DeckView.module.css";
 
 type Props = { deckId: string };
@@ -28,6 +28,7 @@ export function DeckView({ deckId }: Props) {
   const updateSearch = (patch: Partial<DeckSearch>) =>
     navigate({ from: "/deck/$deckId", search: (prev) => ({ ...prev, ...patch }) });
   const [browseOpen, setBrowseOpen] = useState(false);
+  const [browseModality, setBrowseModality] = useState<OpenPointerType | null>(null);
 
   if (deckQuery.isLoading || cardsQuery.isLoading) return <LoadingState />;
   if (!deckQuery.data) return <p>This deck no longer exists.</p>;
@@ -56,7 +57,13 @@ export function DeckView({ deckId }: Props) {
           </Link>
           {isOwner && (
             <>
-              <Button variant="secondary" onPress={() => setBrowseOpen(true)}>
+              <Button
+                variant="secondary"
+                onPress={(e) => {
+                  setBrowseModality(e.pointerType);
+                  setBrowseOpen(true);
+                }}
+              >
                 Browse Catalog
               </Button>
               <Link
@@ -147,6 +154,7 @@ export function DeckView({ deckId }: Props) {
       {browseOpen && (
         <BrowseApiModal
           deckId={deckId}
+          openPointerType={browseModality}
           onClose={() => setBrowseOpen(false)}
           onSelected={() => setBrowseOpen(false)}
         />

--- a/src/views/EditorView.test.tsx
+++ b/src/views/EditorView.test.tsx
@@ -106,7 +106,7 @@ describe("EditorView", () => {
     render(wrap(<EditorView deckId="d1" cardId="new" />));
     const hint = await screen.findByTestId("import-hint");
     await userEvent.click(within(hint).getByRole("button", { name: /browse catalog/i }));
-    expect(await screen.findByRole("dialog", { name: /browse srd/i })).toBeInTheDocument();
+    expect(await screen.findByRole("dialog", { name: /browse content/i })).toBeInTheDocument();
   });
 
   it("navigates to the imported card's editor after picking from the modal", async () => {

--- a/src/views/EditorView.tsx
+++ b/src/views/EditorView.tsx
@@ -11,7 +11,7 @@ import { invariant } from "../lib/invariant";
 import { nowIso } from "../lib/time";
 import { Button } from "../lib/ui/Button";
 import { LoadingState } from "../lib/ui/LoadingState";
-import { BrowseApiModal } from "./BrowseApiModal";
+import { BrowseApiModal, type OpenPointerType } from "./BrowseApiModal";
 import styles from "./EditorView.module.css";
 
 const isPristineNewCard = (card: ItemCard): boolean =>
@@ -86,6 +86,7 @@ export function EditorView({ deckId, cardId }: Props) {
 
   const [previewPage, setPreviewPage] = useState(0);
   const [browseOpen, setBrowseOpen] = useState(false);
+  const [browseModality, setBrowseModality] = useState<OpenPointerType | null>(null);
   const totalPages4 = Math.max(chunks4Up.length, 1);
   const clampedPage = Math.min(previewPage, totalPages4 - 1);
   const visibleChunk = chunks4Up[clampedPage];
@@ -122,7 +123,13 @@ export function EditorView({ deckId, cardId }: Props) {
         {showImportHint && (
           <div className={styles.importHint} data-testid="import-hint">
             <span>Browse the catalog instead.</span>
-            <Button variant="secondary" onPress={() => setBrowseOpen(true)}>
+            <Button
+              variant="secondary"
+              onPress={(e) => {
+                setBrowseModality(e.pointerType);
+                setBrowseOpen(true);
+              }}
+            >
               Browse Catalog
             </Button>
           </div>
@@ -183,6 +190,7 @@ export function EditorView({ deckId, cardId }: Props) {
       {browseOpen && (
         <BrowseApiModal
           deckId={deckId}
+          openPointerType={browseModality}
           onClose={() => setBrowseOpen(false)}
           onSelected={(importedCardId) => {
             setBrowseOpen(false);

--- a/src/views/PrintSelectionModal.module.css
+++ b/src/views/PrintSelectionModal.module.css
@@ -172,18 +172,6 @@
   cursor: pointer;
 }
 
-.srOnly {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
 .list:is(:focus-visible, [data-focus-visible]) {
   outline: none;
 }

--- a/src/views/PrintSelectionModal.tsx
+++ b/src/views/PrintSelectionModal.tsx
@@ -297,7 +297,7 @@ export function PrintSelectionModal({ cards, initialSelection, onApply, onClose 
                 </button>
               </p>
             )}
-            <span className={styles.srOnly} aria-live="polite">
+            <span className="sr-only" aria-live="polite">
               {`${pluralize(total, "card")} selected`}
             </span>
             <div className={styles.footerActions}>


### PR DESCRIPTION
### What are the relevant tickets?

N/A — no tracked ticket.

### Description (What does it do?)

Redesigns the "Browse content" dialog (formerly "Browse SRD") around the source scope and accessible navigation. Two problems prompted it: (1) "SRD" is jargon we'd removed elsewhere in the UI, and (2) the source dropdown — which scopes everything else in the dialog — sat in the top-right header chrome and landed second-to-last in tab order, so keyboard/screen-reader users hit the most important control last.

Changes:

- **De-jargoned copy** — title "Browse SRD" → "Browse content"; the All-tab placeholder "Search SRD…" → "Search all…". (The SRD attribution stays in the footer.)
- **Scope-first layout** — the source `Select` moves out of the header into a left filter rail, above the type control, so it precedes the content it scopes in both reading and tab order.
- **Type selector is now a `RadioGroup`** (new `src/lib/ui/` primitive with true `radiogroup`/`radio` semantics) instead of `Tabs` — the options are a single-select filter over one catalog, not separate content panels. One control reflows via a container query: a vertical left-aligned list in the rail on desktop, compact wrapping chips on mobile (which scale as more filters are added). This replaces the previous desktop-`TabList` / mobile-`Select` duplication with one control / identical DOM.
- **Search hoisted** to a single stable field above one results region, fixing focus theft when navigating the type control with the keyboard.
- **Modality-aware initial focus** — pointer opens autofocus the search (fast typing for mouse users); keyboard / assistive-tech opens leave focus at the top of the dialog so the source scope and type filter are encountered first. Driven by the trigger's `PressEvent.pointerType`.
- **Result count announced** in a polite live region.
- **`.sr-only` consolidation** — replaced two byte-identical local `.srOnly` module classes (`TagInput`, `PrintSelectionModal`) and a one-off RAC `VisuallyHidden` with a single global `.sr-only` utility in `index.css`.

### Screenshots (if appropriate):
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

Desktop: `Source: 2024` atop the left rail, `All / Items / Spells` as a left-aligned vertical list. Mobile: rail stacks under the header, type options become compact wrapping chips above the search. (Verified at both widths during development; attaching captures.)

### How can this be tested?

Open the dialog via **Browse Catalog** (card editor when starting a new card, or the deck view). Then:

- Confirm the source scope sits at the top of the rail and changing it re-scopes results; type filter switches All/Items/Spells; search filters within the active type.
- **Keyboard**: Tab order is source → type → search → results. Arrow keys move the type selection without focus jumping into the search box. Opening via keyboard (Enter on the trigger) leaves focus at the top of the dialog rather than the search; opening via mouse autofocuses the search.
- **Narrow width**: the type options become wrapping chips above the search; chips are comfortably tappable.

Tests cover: radio-group semantics and selection, the modality-aware autofocus (pointer vs keyboard vs virtual), keyboard-arrow focus retention on the type control, the live-region count updating as results filter, and the new `RadioGroup` primitive (render/selection/arrow keys).

### Additional Context

A few things a reviewer might want flagged:

- **First global utility class.** `.sr-only` in `index.css` is the repo's first non-token/reset global class; previously styling was CSS-module-scoped. It sits next to `:focus-visible` (also a global a11y affordance) and is documented in `src/lib/ui/README.md`. A shared `utils.module.css` was considered and rejected — Vite's default CSS-module type is an index signature, so `styles.x` isn't typo-checked either, so the module buys ceremony without safety.
- **`key={activeType.id}` on the results region is load-bearing**, not a perf key — each `ContentType.useResults` calls a different number of hooks, so the remount-on-type-change is what prevents a rules-of-hooks violation. There's a comment to that effect. A follow-up idea (make each `ContentType` own a `Results` component so the invariant is structural) is noted but intentionally out of scope here — it would touch the shared content-type abstraction this PR doesn't otherwise modify.
- **`openPointerType` is threaded from both triggers** (`EditorView`, `DeckView`) rather than read from a global. `react-aria`'s `useInteractionModality` is only a transitive dep and tracks *global last interaction*, which is the wrong signal; the trigger's own `PressEvent.pointerType` is the correct local source.
- The `aria-orientation` of the radio group stays vertical even where the mobile chips render horizontally. Confirmed all four arrow keys navigate regardless, so this is a cosmetic attribute mismatch, not a functional one.

This branch went through two rounds of multi-lens review (UX, a11y, architecture, code quality, tests, repo conventions).