### PR TITLE
feat(tooling): type-check CSS module class names via css-modules-kit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // empty' | { read -r f; case \"$f\" in *.module.css) npm run --silent gen:css ;; esac; }",
+            "statusMessage": "Regenerating CSS module types"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
-      - run: npx tsc -b --noEmit
+      - run: npm run typecheck
       - run: npm test
       - run: npm run check:schema
       - run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,12 @@ dist-ssr
 .vite
 coverage
 *.tsbuildinfo
+/generated/
+
+# Claude Code: machine-local scratch
+.claude/settings.local.json
+.claude/worktrees/
+.claude/handoffs/
 
 # Supabase
 supabase/.env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,12 @@ See README's "Design system" section for the full picture. Short version:
 - The card preview shown in the editor renders the same `<Card>` component as `PrintView`, so screen preview matches print output exactly.
 - Card bodies render as Markdown via `src/cards/renderBody.ts` (`marked` → DOMPurify with a strict allowlist). Both `<Card>` and the offscreen `measurer.ts` call this helper. Don't bypass it or expand the allowlist without thinking through pagination + XSS.
 
+## CSS module typing
+
+- `*.module.css` class names are **type-checked**. `@css-modules-kit/codegen` (`cmk`) emits per-file `.d.ts` into the gitignored `generated/` dir (overlaid via `rootDirs` in `tsconfig.app.json`), so `styles.typo` is a real `tsc` error, not `string`.
+- `npm run gen:css` regenerates them; `build` and `typecheck` run it first, and a `PostToolUse` hook in `.claude/settings.json` reruns it whenever you edit a `*.module.css`. So after adding a class you can use `styles.newClass` immediately — no manual step.
+- The regen hook fires only on `*.module.css` edits, not `.tsx`. So when a class is flagged "does not exist on type": if it's already in the `.module.css`, the dts is just stale → run `npm run gen:css`. If it isn't in the `.module.css` yet (or the name is a typo), the error is **real** → add the class or fix the name. Don't reflexively revert the usage.
+
 ## Tests
 
 - Prefer `getByRole(...)` over text/class selectors. React Aria primitives expose accurate ARIA roles.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ UI styling is driven by CSS custom-property tokens defined in [`src/index.css`](
 **Stack**
 
 - [`react-aria-components`](https://react-spectrum.adobe.com/react-aria/) for accessible interactive primitives (Dialog, Menu, ToggleButtonGroup, etc.).
-- CSS modules. No styled-components, emotion, MUI, Tailwind, or shadcn.
+- CSS modules. No styled-components, emotion, MUI, Tailwind, or shadcn. Class names are type-checked in `build`/`typecheck` (and via `npm run gen:css`): `@css-modules-kit/codegen` generates per-module `.d.ts`, so `styles.typo` becomes a compile error.
 - Self-hosted Inter (body) and Cinzel (display headings) via fontsource.
 
 **Token scopes** — `src/index.css` defines two namespaces: screen tokens (`--color-*`, `--space-*`, `--radius-*`, `--shadow-*`, `--fs-*`, etc.) used by all screen UI, and print tokens (`--print-*`) used only by `Card` and `PrintView`. Never reference `--print-*` in screen UI.

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.12",
+        "@css-modules-kit/codegen": "^1.2.0",
         "@faker-js/faker": "^10.4.0",
         "@playwright/test": "^1.59.1",
         "@tanstack/router-devtools": "^1.166.13",
@@ -445,6 +446,45 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@css-modules-kit/codegen": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@css-modules-kit/codegen/-/codegen-1.2.0.tgz",
+      "integrity": "sha512-ci9P4ASxbzqc+0fvf/8o+mO1RltsPx3IOQGLyuSKU3HwbuwGkUHGYcT7t29lAepffbvGKOYDg3jgXy2rYAkP1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@css-modules-kit/core": "^1.2.0",
+        "chokidar": "^4.0.3"
+      },
+      "bin": {
+        "cmk": "bin/cmk.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.7.3"
+      }
+    },
+    "node_modules/@css-modules-kit/core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@css-modules-kit/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-7tHepbNrbb++1MvrjOPh4k5F9a888cZ11fJr+ObgI2ruS2Cr7jgibGPgc8WC3M0wN4OxXrLnGiX/pocOf9InTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^8.5.9",
+        "postcss-safe-parser": "^7.0.1",
+        "postcss-selector-parser": "^7.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.7.3"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -3090,6 +3130,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -3217,6 +3273,19 @@
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -4418,6 +4487,54 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-safe-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
+      "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.31"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/postcss/node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -4575,6 +4692,20 @@
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/redent": {
@@ -5655,6 +5786,13 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.0.10",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "npm run gen:css && tsc -b && vite build",
     "preview": "vite preview",
     "lint": "biome check src scripts e2e",
     "lint:fix": "biome check --write src scripts e2e",
@@ -14,7 +14,8 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "typecheck": "tsc -b --noEmit",
+    "typecheck": "npm run gen:css && tsc -b --noEmit",
+    "gen:css": "cmk --clean -p tsconfig.app.json",
     "gen:schema": "tsx scripts/gen-card-schema.ts",
     "check:schema": "tsx scripts/gen-card-schema.ts --check",
     "gen:db-types": "supabase gen types typescript --local --schema public > src/api/database.types.ts",
@@ -45,6 +46,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.12",
+    "@css-modules-kit/codegen": "^1.2.0",
     "@faker-js/faker": "^10.4.0",
     "@playwright/test": "^1.59.1",
     "@tanstack/router-devtools": "^1.166.13",

--- a/src/cards/measurer.ts
+++ b/src/cards/measurer.ts
@@ -91,7 +91,7 @@ function build(cardsPerPage: CardsPerPage): CardMeasurer {
     el.replaceChildren();
     for (const tag of headerTags) {
       const t = document.createElement("span");
-      t.className = cardStyles.headerTag ?? "";
+      t.className = cardStyles.headerTag;
       t.textContent = tag;
       el.appendChild(t);
     }
@@ -101,10 +101,10 @@ function build(cardsPerPage: CardsPerPage): CardMeasurer {
     el.replaceChildren();
     if (footerTags.length > 0) {
       const left = document.createElement("span");
-      left.className = cardStyles.footerTags ?? "";
+      left.className = cardStyles.footerTags;
       for (const tag of footerTags) {
         const t = document.createElement("span");
-        t.className = cardStyles.footerTag ?? "";
+        t.className = cardStyles.footerTag;
         t.textContent = tag;
         left.appendChild(t);
       }
@@ -112,7 +112,7 @@ function build(cardsPerPage: CardsPerPage): CardMeasurer {
     }
     const right = document.createElement("span");
     right.textContent = pagination;
-    right.className = cardStyles.footerRight ?? "";
+    right.className = cardStyles.footerRight;
     el.appendChild(right);
   };
 

--- a/src/views/PrintView.test.tsx
+++ b/src/views/PrintView.test.tsx
@@ -58,8 +58,8 @@ describe("<PrintView>", () => {
     await waitFor(() => expect(screen.getAllByTestId("page")).toHaveLength(1));
     await userEvent.selectOptions(screen.getByRole("combobox", { name: /cards per page/i }), "2");
     for (const page of screen.getAllByTestId("page")) {
-      expect(page).toHaveClass(styles.perPage2 as string);
-      expect(page).not.toHaveClass(styles.perPage4 as string);
+      expect(page).toHaveClass(styles.perPage2);
+      expect(page).not.toHaveClass(styles.perPage4);
     }
   });
 

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -18,7 +18,11 @@
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals"],
+    "rootDirs": [".", "generated"]
+  },
+  "cmkOptions": {
+    "enabled": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Vite's ambient declaration typed every `*.module.css` import as `{ [key: string]: string }`, so `styles.anyTypo` resolved to `string` and **never errored** — across 42 module files there was zero safety on class names.

This adds [`@css-modules-kit/codegen`](https://github.com/mizdra/css-modules-kit) (`cmk`), which generates a per-file `.d.ts` with a typed default export. The generated files live in a **gitignored `generated/` dir**, overlaid into the program via `rootDirs: [".", "generated"]`, so `styles.typo` becomes a real `tsc` error while `styles.realClass` stays `string`. When `generated/` is absent the import gracefully falls back to Vite's loose ambient type (compiles, unchecked) rather than hard-failing.

The design is tuned for this repo being **LLM-primary**:

- `gen:css` (`cmk --clean …`) runs ahead of `build` and `typecheck`; CI runs both, so the check is enforced there. `--clean` prunes orphaned dts so a renamed/deleted module can't leave a masking stale type.
- A committed `PostToolUse` hook in `.claude/settings.json` regenerates the dts whenever a `*.module.css` is edited, so coding agents get accurate diagnostics with no manual step and no stale-dts phantom errors.
- The editor TypeScript plugin (`typescript-plugin-css-modules` / the cmk ts-plugin) was **intentionally skipped** — it only feeds an interactive tsserver, which an agent never reads, and it can't fail CI.

Also folds in small cleanups the narrower (non-optional) types make redundant: `?? ""` in `measurer.ts` and `as string` in `PrintView.test.tsx`.

### How can this be tested?

- `npm run typecheck` and `npm run build` both regenerate the dts first, then type-check. To see enforcement: add a bogus key like `styles.doesNotExist` anywhere and run `npm run typecheck` — it fails with `TS2339` listing the valid keys. Remove it and it passes.
- Edit any `*.module.css` (add/remove a class) and confirm `generated/` refreshes (the Claude hook does this automatically; otherwise `npm run gen:css`).
- The `measurer.ts` / `PrintView.test.tsx` edits are type-only no-ops; the existing print/pagination tests cover them.

### Additional Context

A reviewer might pause on a few intentional choices:

- **`generated/` is gitignored** (not committed). Trade-off vs. the older `typed-css-modules` approach of committing sibling `.d.ts`: no 42-file merge/review churn, at the cost that a bare `tsc -b` (outside `npm run typecheck`) silently degrades to loose typing. That's documented in `CLAUDE.md`.
- **The hook is committed in `.claude/settings.json`** (not `settings.local.json`) — deliberate, so every agent/clone gets regen-on-edit. This also required loosening the global `.claude/` ignore; the repo `.gitignore` now explicitly covers machine-local `.claude` scratch (`settings.local.json`, `worktrees/`, `handoffs/`).
- **CI `typecheck` step changed** from a bare `npx tsc -b --noEmit` to `npm run typecheck` — the old form skipped `gen:css` and was silently lenient on CSS classes.
- **`@css-modules-kit` is single-maintainer**, dev-only, pinned via lockfile + `npm ci`; CI degrades gracefully if it's ever unavailable.

Reviewed across multiple independent lenses (correctness/CI, supply-chain, agent-DX, conventions) over two rounds before opening.